### PR TITLE
feat(client): add support for selecting fields to count

### DIFF
--- a/src/prisma/generator/templates/actions.py.jinja
+++ b/src/prisma/generator/templates/actions.py.jinja
@@ -209,6 +209,7 @@ class {{ model.name }}Actions(Generic[BaseModelT]):
         )
         return int(resp['data']['result']['count'])
 
+    @overload
     {{ maybe_async_def }}count(
         self,
         take: Optional[int] = None,
@@ -216,8 +217,41 @@ class {{ model.name }}Actions(Generic[BaseModelT]):
         where: Optional[types.{{ model.name }}WhereInput] = None,
         cursor: Optional[types.{{ model.name }}WhereUniqueInput] = None,
         order: Optional[Union[types.{{ model.name }}OrderByInput, List[types.{{ model.name }}OrderByInput]]] = None,
+        select: None = None,
     ) -> int:
-        # TODO: support select
+        ...
+
+    @overload
+    {{ maybe_async_def }}count(
+        self,
+        take: Optional[int] = None,
+        skip: Optional[int] = None,
+        where: Optional[types.{{ model.name }}WhereInput] = None,
+        cursor: Optional[types.{{ model.name }}WhereUniqueInput] = None,
+        order: Optional[Union[types.{{ model.name }}OrderByInput, List[types.{{ model.name }}OrderByInput]]] = None,
+        select: types.{{ model.name }}CountAggregateInput = ...,
+    ) -> types.{{ model.name }}CountAggregateOutput:
+        ...
+
+    {{ maybe_async_def }}count(
+        self,
+        take: Optional[int] = None,
+        skip: Optional[int] = None,
+        where: Optional[types.{{ model.name }}WhereInput] = None,
+        cursor: Optional[types.{{ model.name }}WhereUniqueInput] = None,
+        order: Optional[Union[types.{{ model.name }}OrderByInput, List[types.{{ model.name }}OrderByInput]]] = None,
+        select: Optional[types.{{ model.name }}CountAggregateInput] = None,
+    ) -> Union[int, types.{{ model.name }}CountAggregateOutput]:
+        # TODO: this selection building should be moved to the QueryBuilder
+        if select is None:
+            root_selection = ['_count { _all }']
+        else:
+            {% raw %}
+            root_selection = [
+                '_count {{ {0} }}'.format(' '.join(k for k, v in select.items() if v is True))
+            ]
+            {% endraw %}
+
         resp = {{ maybe_await }}self._client._execute(
             operation='{{ operations.count }}',
             method='{{ methods.count }}',
@@ -229,9 +263,13 @@ class {{ model.name }}Actions(Generic[BaseModelT]):
                 'order_by': order,
                 'cursor': cursor,
             },
-            root_selection=['_count { _all }'],
+            root_selection=root_selection,
         )
-        return cast(int, resp['data']['result']['_count']['_all'])
+
+        if select is None:
+            return cast(int, resp['data']['result']['_count']['_all'])
+        else:
+            return resp['data']['result']['_count']
 
     {{ maybe_async_def }}delete_many(
         self,

--- a/src/prisma/generator/templates/actions.py.jinja
+++ b/src/prisma/generator/templates/actions.py.jinja
@@ -212,38 +212,42 @@ class {{ model.name }}Actions(Generic[BaseModelT]):
     @overload
     {{ maybe_async_def }}count(
         self,
+        select: None = None,
         take: Optional[int] = None,
         skip: Optional[int] = None,
         where: Optional[types.{{ model.name }}WhereInput] = None,
         cursor: Optional[types.{{ model.name }}WhereUniqueInput] = None,
         order: Optional[Union[types.{{ model.name }}OrderByInput, List[types.{{ model.name }}OrderByInput]]] = None,
-        select: None = None,
     ) -> int:
         ...
 
     @overload
     {{ maybe_async_def }}count(
         self,
+        select: types.{{ model.name }}CountAggregateInput,
         take: Optional[int] = None,
         skip: Optional[int] = None,
         where: Optional[types.{{ model.name }}WhereInput] = None,
         cursor: Optional[types.{{ model.name }}WhereUniqueInput] = None,
         order: Optional[Union[types.{{ model.name }}OrderByInput, List[types.{{ model.name }}OrderByInput]]] = None,
-        select: types.{{ model.name }}CountAggregateInput = ...,
     ) -> types.{{ model.name }}CountAggregateOutput:
         ...
 
     {{ maybe_async_def }}count(
         self,
+        select: Optional[types.{{ model.name }}CountAggregateInput] = None,
         take: Optional[int] = None,
         skip: Optional[int] = None,
         where: Optional[types.{{ model.name }}WhereInput] = None,
         cursor: Optional[types.{{ model.name }}WhereUniqueInput] = None,
         order: Optional[Union[types.{{ model.name }}OrderByInput, List[types.{{ model.name }}OrderByInput]]] = None,
-        select: Optional[types.{{ model.name }}CountAggregateInput] = None,
     ) -> Union[int, types.{{ model.name }}CountAggregateOutput]:
         # TODO: this selection building should be moved to the QueryBuilder
-        if select is None:
+        #
+        # note the distinction between checking for `not select` here `select is None`
+        # later is to handle the case that the given select dictionary is empty, this
+        # is a limitation of our types.
+        if not select:
             root_selection = ['_count { _all }']
         else:
             {% raw %}
@@ -269,7 +273,7 @@ class {{ model.name }}Actions(Generic[BaseModelT]):
         if select is None:
             return cast(int, resp['data']['result']['_count']['_all'])
         else:
-            return resp['data']['result']['_count']
+            return cast(types.{{ model.name }}CountAggregateOutput, resp['data']['result']['_count'])
 
     {{ maybe_async_def }}delete_many(
         self,

--- a/src/prisma/generator/templates/types.py.jinja
+++ b/src/prisma/generator/templates/types.py.jinja
@@ -459,6 +459,29 @@ class {{ current }}(TypedDict, total=False):
 {% endcall %}
 
 
+{{ model.name }}CountAggregateInput = TypedDict(
+    '{{ model.name }}CountAggregateInput',
+    {
+        {% for field in model.scalar_fields %}
+        '{{ field.name }}': bool,
+        {% endfor %}
+        '_all': bool,
+    },
+    total=False,
+)
+
+{{ model.name }}CountAggregateOutput = TypedDict(
+    '{{ model.name }}CountAggregateOutput',
+    {
+        {% for field in model.scalar_fields %}
+        '{{ field.name }}': int,
+        {% endfor %}
+        '_all': int,
+    },
+    total=False,
+)
+
+
 {{ model.name }}Keys = Literal[
     {% for field in model.all_fields %}
     '{{ field.name }}',

--- a/tests/test_count.py
+++ b/tests/test_count.py
@@ -27,6 +27,11 @@ async def test_select(client: Client) -> None:
         batcher.post.create({'title': 'Foo 2', 'published': False, 'desc': 'A'})
 
     count = await client.post.count(
+        select={},
+    )
+    assert count == {'_all': 2}
+
+    count = await client.post.count(
         select={
             'desc': True,
         },

--- a/tests/test_count.py
+++ b/tests/test_count.py
@@ -17,3 +17,26 @@ async def test_count_no_results(client: Client) -> None:
     """No results returns 0"""
     total = await client.post.count(where={'title': 'kdbsajdh'})
     assert total == 0
+
+
+@pytest.mark.asyncio
+async def test_select(client: Client) -> None:
+    """Selecting a field counts non-null values"""
+    async with client.batch_() as batcher:
+        batcher.post.create({'title': 'Foo', 'published': False})
+        batcher.post.create({'title': 'Foo 2', 'published': False, 'desc': 'A'})
+
+    count = await client.post.count(
+        select={
+            'desc': True,
+        },
+    )
+    assert count == {'desc': 1}
+
+    count = await client.post.count(
+        select={
+            '_all': True,
+            'desc': True,
+        },
+    )
+    assert count == {'_all': 2, 'desc': 1}

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive.ambr
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive.ambr
@@ -241,6 +241,7 @@
           )
           return int(resp['data']['result']['count'])
   
+      @overload
       async def count(
           self,
           take: Optional[int] = None,
@@ -248,8 +249,40 @@
           where: Optional[types.PostWhereInput] = None,
           cursor: Optional[types.PostWhereUniqueInput] = None,
           order: Optional[Union[types.PostOrderByInput, List[types.PostOrderByInput]]] = None,
+          select: None = None,
       ) -> int:
-          # TODO: support select
+          ...
+  
+      @overload
+      async def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.PostWhereInput] = None,
+          cursor: Optional[types.PostWhereUniqueInput] = None,
+          order: Optional[Union[types.PostOrderByInput, List[types.PostOrderByInput]]] = None,
+          select: types.PostCountAggregateInput = ...,
+      ) -> types.PostCountAggregateOutput:
+          ...
+  
+      async def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.PostWhereInput] = None,
+          cursor: Optional[types.PostWhereUniqueInput] = None,
+          order: Optional[Union[types.PostOrderByInput, List[types.PostOrderByInput]]] = None,
+          select: Optional[types.PostCountAggregateInput] = None,
+      ) -> Union[int, types.PostCountAggregateOutput]:
+          # TODO: this selection building should be moved to the QueryBuilder
+          if select is None:
+              root_selection = ['_count { _all }']
+          else:
+  
+              root_selection = [
+                  '_count {{ {0} }}'.format(' '.join(k for k, v in select.items() if v is True))
+              ]
+  
           resp = await self._client._execute(
               operation='query',
               method='aggregate',
@@ -261,9 +294,13 @@
                   'order_by': order,
                   'cursor': cursor,
               },
-              root_selection=['_count { _all }'],
+              root_selection=root_selection,
           )
-          return cast(int, resp['data']['result']['_count']['_all'])
+  
+          if select is None:
+              return cast(int, resp['data']['result']['_count']['_all'])
+          else:
+              return resp['data']['result']['_count']
   
       async def delete_many(
           self,
@@ -478,6 +515,7 @@
           )
           return int(resp['data']['result']['count'])
   
+      @overload
       async def count(
           self,
           take: Optional[int] = None,
@@ -485,8 +523,40 @@
           where: Optional[types.UserWhereInput] = None,
           cursor: Optional[types.UserWhereUniqueInput] = None,
           order: Optional[Union[types.UserOrderByInput, List[types.UserOrderByInput]]] = None,
+          select: None = None,
       ) -> int:
-          # TODO: support select
+          ...
+  
+      @overload
+      async def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.UserWhereInput] = None,
+          cursor: Optional[types.UserWhereUniqueInput] = None,
+          order: Optional[Union[types.UserOrderByInput, List[types.UserOrderByInput]]] = None,
+          select: types.UserCountAggregateInput = ...,
+      ) -> types.UserCountAggregateOutput:
+          ...
+  
+      async def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.UserWhereInput] = None,
+          cursor: Optional[types.UserWhereUniqueInput] = None,
+          order: Optional[Union[types.UserOrderByInput, List[types.UserOrderByInput]]] = None,
+          select: Optional[types.UserCountAggregateInput] = None,
+      ) -> Union[int, types.UserCountAggregateOutput]:
+          # TODO: this selection building should be moved to the QueryBuilder
+          if select is None:
+              root_selection = ['_count { _all }']
+          else:
+  
+              root_selection = [
+                  '_count {{ {0} }}'.format(' '.join(k for k, v in select.items() if v is True))
+              ]
+  
           resp = await self._client._execute(
               operation='query',
               method='aggregate',
@@ -498,9 +568,13 @@
                   'order_by': order,
                   'cursor': cursor,
               },
-              root_selection=['_count { _all }'],
+              root_selection=root_selection,
           )
-          return cast(int, resp['data']['result']['_count']['_all'])
+  
+          if select is None:
+              return cast(int, resp['data']['result']['_count']['_all'])
+          else:
+              return resp['data']['result']['_count']
   
       async def delete_many(
           self,
@@ -715,6 +789,7 @@
           )
           return int(resp['data']['result']['count'])
   
+      @overload
       async def count(
           self,
           take: Optional[int] = None,
@@ -722,8 +797,40 @@
           where: Optional[types.MWhereInput] = None,
           cursor: Optional[types.MWhereUniqueInput] = None,
           order: Optional[Union[types.MOrderByInput, List[types.MOrderByInput]]] = None,
+          select: None = None,
       ) -> int:
-          # TODO: support select
+          ...
+  
+      @overload
+      async def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.MWhereInput] = None,
+          cursor: Optional[types.MWhereUniqueInput] = None,
+          order: Optional[Union[types.MOrderByInput, List[types.MOrderByInput]]] = None,
+          select: types.MCountAggregateInput = ...,
+      ) -> types.MCountAggregateOutput:
+          ...
+  
+      async def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.MWhereInput] = None,
+          cursor: Optional[types.MWhereUniqueInput] = None,
+          order: Optional[Union[types.MOrderByInput, List[types.MOrderByInput]]] = None,
+          select: Optional[types.MCountAggregateInput] = None,
+      ) -> Union[int, types.MCountAggregateOutput]:
+          # TODO: this selection building should be moved to the QueryBuilder
+          if select is None:
+              root_selection = ['_count { _all }']
+          else:
+  
+              root_selection = [
+                  '_count {{ {0} }}'.format(' '.join(k for k, v in select.items() if v is True))
+              ]
+  
           resp = await self._client._execute(
               operation='query',
               method='aggregate',
@@ -735,9 +842,13 @@
                   'order_by': order,
                   'cursor': cursor,
               },
-              root_selection=['_count { _all }'],
+              root_selection=root_selection,
           )
-          return cast(int, resp['data']['result']['_count']['_all'])
+  
+          if select is None:
+              return cast(int, resp['data']['result']['_count']['_all'])
+          else:
+              return resp['data']['result']['_count']
   
       async def delete_many(
           self,
@@ -952,6 +1063,7 @@
           )
           return int(resp['data']['result']['count'])
   
+      @overload
       async def count(
           self,
           take: Optional[int] = None,
@@ -959,8 +1071,40 @@
           where: Optional[types.NWhereInput] = None,
           cursor: Optional[types.NWhereUniqueInput] = None,
           order: Optional[Union[types.NOrderByInput, List[types.NOrderByInput]]] = None,
+          select: None = None,
       ) -> int:
-          # TODO: support select
+          ...
+  
+      @overload
+      async def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.NWhereInput] = None,
+          cursor: Optional[types.NWhereUniqueInput] = None,
+          order: Optional[Union[types.NOrderByInput, List[types.NOrderByInput]]] = None,
+          select: types.NCountAggregateInput = ...,
+      ) -> types.NCountAggregateOutput:
+          ...
+  
+      async def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.NWhereInput] = None,
+          cursor: Optional[types.NWhereUniqueInput] = None,
+          order: Optional[Union[types.NOrderByInput, List[types.NOrderByInput]]] = None,
+          select: Optional[types.NCountAggregateInput] = None,
+      ) -> Union[int, types.NCountAggregateOutput]:
+          # TODO: this selection building should be moved to the QueryBuilder
+          if select is None:
+              root_selection = ['_count { _all }']
+          else:
+  
+              root_selection = [
+                  '_count {{ {0} }}'.format(' '.join(k for k, v in select.items() if v is True))
+              ]
+  
           resp = await self._client._execute(
               operation='query',
               method='aggregate',
@@ -972,9 +1116,13 @@
                   'order_by': order,
                   'cursor': cursor,
               },
-              root_selection=['_count { _all }'],
+              root_selection=root_selection,
           )
-          return cast(int, resp['data']['result']['_count']['_all'])
+  
+          if select is None:
+              return cast(int, resp['data']['result']['_count']['_all'])
+          else:
+              return resp['data']['result']['_count']
   
       async def delete_many(
           self,
@@ -1189,6 +1337,7 @@
           )
           return int(resp['data']['result']['count'])
   
+      @overload
       async def count(
           self,
           take: Optional[int] = None,
@@ -1196,8 +1345,40 @@
           where: Optional[types.OneOptionalWhereInput] = None,
           cursor: Optional[types.OneOptionalWhereUniqueInput] = None,
           order: Optional[Union[types.OneOptionalOrderByInput, List[types.OneOptionalOrderByInput]]] = None,
+          select: None = None,
       ) -> int:
-          # TODO: support select
+          ...
+  
+      @overload
+      async def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.OneOptionalWhereInput] = None,
+          cursor: Optional[types.OneOptionalWhereUniqueInput] = None,
+          order: Optional[Union[types.OneOptionalOrderByInput, List[types.OneOptionalOrderByInput]]] = None,
+          select: types.OneOptionalCountAggregateInput = ...,
+      ) -> types.OneOptionalCountAggregateOutput:
+          ...
+  
+      async def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.OneOptionalWhereInput] = None,
+          cursor: Optional[types.OneOptionalWhereUniqueInput] = None,
+          order: Optional[Union[types.OneOptionalOrderByInput, List[types.OneOptionalOrderByInput]]] = None,
+          select: Optional[types.OneOptionalCountAggregateInput] = None,
+      ) -> Union[int, types.OneOptionalCountAggregateOutput]:
+          # TODO: this selection building should be moved to the QueryBuilder
+          if select is None:
+              root_selection = ['_count { _all }']
+          else:
+  
+              root_selection = [
+                  '_count {{ {0} }}'.format(' '.join(k for k, v in select.items() if v is True))
+              ]
+  
           resp = await self._client._execute(
               operation='query',
               method='aggregate',
@@ -1209,9 +1390,13 @@
                   'order_by': order,
                   'cursor': cursor,
               },
-              root_selection=['_count { _all }'],
+              root_selection=root_selection,
           )
-          return cast(int, resp['data']['result']['_count']['_all'])
+  
+          if select is None:
+              return cast(int, resp['data']['result']['_count']['_all'])
+          else:
+              return resp['data']['result']['_count']
   
       async def delete_many(
           self,
@@ -1426,6 +1611,7 @@
           )
           return int(resp['data']['result']['count'])
   
+      @overload
       async def count(
           self,
           take: Optional[int] = None,
@@ -1433,8 +1619,40 @@
           where: Optional[types.ManyRequiredWhereInput] = None,
           cursor: Optional[types.ManyRequiredWhereUniqueInput] = None,
           order: Optional[Union[types.ManyRequiredOrderByInput, List[types.ManyRequiredOrderByInput]]] = None,
+          select: None = None,
       ) -> int:
-          # TODO: support select
+          ...
+  
+      @overload
+      async def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.ManyRequiredWhereInput] = None,
+          cursor: Optional[types.ManyRequiredWhereUniqueInput] = None,
+          order: Optional[Union[types.ManyRequiredOrderByInput, List[types.ManyRequiredOrderByInput]]] = None,
+          select: types.ManyRequiredCountAggregateInput = ...,
+      ) -> types.ManyRequiredCountAggregateOutput:
+          ...
+  
+      async def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.ManyRequiredWhereInput] = None,
+          cursor: Optional[types.ManyRequiredWhereUniqueInput] = None,
+          order: Optional[Union[types.ManyRequiredOrderByInput, List[types.ManyRequiredOrderByInput]]] = None,
+          select: Optional[types.ManyRequiredCountAggregateInput] = None,
+      ) -> Union[int, types.ManyRequiredCountAggregateOutput]:
+          # TODO: this selection building should be moved to the QueryBuilder
+          if select is None:
+              root_selection = ['_count { _all }']
+          else:
+  
+              root_selection = [
+                  '_count {{ {0} }}'.format(' '.join(k for k, v in select.items() if v is True))
+              ]
+  
           resp = await self._client._execute(
               operation='query',
               method='aggregate',
@@ -1446,9 +1664,13 @@
                   'order_by': order,
                   'cursor': cursor,
               },
-              root_selection=['_count { _all }'],
+              root_selection=root_selection,
           )
-          return cast(int, resp['data']['result']['_count']['_all'])
+  
+          if select is None:
+              return cast(int, resp['data']['result']['_count']['_all'])
+          else:
+              return resp['data']['result']['_count']
   
       async def delete_many(
           self,
@@ -1663,6 +1885,7 @@
           )
           return int(resp['data']['result']['count'])
   
+      @overload
       async def count(
           self,
           take: Optional[int] = None,
@@ -1670,8 +1893,40 @@
           where: Optional[types.AWhereInput] = None,
           cursor: Optional[types.AWhereUniqueInput] = None,
           order: Optional[Union[types.AOrderByInput, List[types.AOrderByInput]]] = None,
+          select: None = None,
       ) -> int:
-          # TODO: support select
+          ...
+  
+      @overload
+      async def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.AWhereInput] = None,
+          cursor: Optional[types.AWhereUniqueInput] = None,
+          order: Optional[Union[types.AOrderByInput, List[types.AOrderByInput]]] = None,
+          select: types.ACountAggregateInput = ...,
+      ) -> types.ACountAggregateOutput:
+          ...
+  
+      async def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.AWhereInput] = None,
+          cursor: Optional[types.AWhereUniqueInput] = None,
+          order: Optional[Union[types.AOrderByInput, List[types.AOrderByInput]]] = None,
+          select: Optional[types.ACountAggregateInput] = None,
+      ) -> Union[int, types.ACountAggregateOutput]:
+          # TODO: this selection building should be moved to the QueryBuilder
+          if select is None:
+              root_selection = ['_count { _all }']
+          else:
+  
+              root_selection = [
+                  '_count {{ {0} }}'.format(' '.join(k for k, v in select.items() if v is True))
+              ]
+  
           resp = await self._client._execute(
               operation='query',
               method='aggregate',
@@ -1683,9 +1938,13 @@
                   'order_by': order,
                   'cursor': cursor,
               },
-              root_selection=['_count { _all }'],
+              root_selection=root_selection,
           )
-          return cast(int, resp['data']['result']['_count']['_all'])
+  
+          if select is None:
+              return cast(int, resp['data']['result']['_count']['_all'])
+          else:
+              return resp['data']['result']['_count']
   
       async def delete_many(
           self,
@@ -1900,6 +2159,7 @@
           )
           return int(resp['data']['result']['count'])
   
+      @overload
       async def count(
           self,
           take: Optional[int] = None,
@@ -1907,8 +2167,40 @@
           where: Optional[types.BWhereInput] = None,
           cursor: Optional[types.BWhereUniqueInput] = None,
           order: Optional[Union[types.BOrderByInput, List[types.BOrderByInput]]] = None,
+          select: None = None,
       ) -> int:
-          # TODO: support select
+          ...
+  
+      @overload
+      async def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.BWhereInput] = None,
+          cursor: Optional[types.BWhereUniqueInput] = None,
+          order: Optional[Union[types.BOrderByInput, List[types.BOrderByInput]]] = None,
+          select: types.BCountAggregateInput = ...,
+      ) -> types.BCountAggregateOutput:
+          ...
+  
+      async def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.BWhereInput] = None,
+          cursor: Optional[types.BWhereUniqueInput] = None,
+          order: Optional[Union[types.BOrderByInput, List[types.BOrderByInput]]] = None,
+          select: Optional[types.BCountAggregateInput] = None,
+      ) -> Union[int, types.BCountAggregateOutput]:
+          # TODO: this selection building should be moved to the QueryBuilder
+          if select is None:
+              root_selection = ['_count { _all }']
+          else:
+  
+              root_selection = [
+                  '_count {{ {0} }}'.format(' '.join(k for k, v in select.items() if v is True))
+              ]
+  
           resp = await self._client._execute(
               operation='query',
               method='aggregate',
@@ -1920,9 +2212,13 @@
                   'order_by': order,
                   'cursor': cursor,
               },
-              root_selection=['_count { _all }'],
+              root_selection=root_selection,
           )
-          return cast(int, resp['data']['result']['_count']['_all'])
+  
+          if select is None:
+              return cast(int, resp['data']['result']['_count']['_all'])
+          else:
+              return resp['data']['result']['_count']
   
       async def delete_many(
           self,
@@ -2137,6 +2433,7 @@
           )
           return int(resp['data']['result']['count'])
   
+      @overload
       async def count(
           self,
           take: Optional[int] = None,
@@ -2144,8 +2441,40 @@
           where: Optional[types.CWhereInput] = None,
           cursor: Optional[types.CWhereUniqueInput] = None,
           order: Optional[Union[types.COrderByInput, List[types.COrderByInput]]] = None,
+          select: None = None,
       ) -> int:
-          # TODO: support select
+          ...
+  
+      @overload
+      async def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.CWhereInput] = None,
+          cursor: Optional[types.CWhereUniqueInput] = None,
+          order: Optional[Union[types.COrderByInput, List[types.COrderByInput]]] = None,
+          select: types.CCountAggregateInput = ...,
+      ) -> types.CCountAggregateOutput:
+          ...
+  
+      async def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.CWhereInput] = None,
+          cursor: Optional[types.CWhereUniqueInput] = None,
+          order: Optional[Union[types.COrderByInput, List[types.COrderByInput]]] = None,
+          select: Optional[types.CCountAggregateInput] = None,
+      ) -> Union[int, types.CCountAggregateOutput]:
+          # TODO: this selection building should be moved to the QueryBuilder
+          if select is None:
+              root_selection = ['_count { _all }']
+          else:
+  
+              root_selection = [
+                  '_count {{ {0} }}'.format(' '.join(k for k, v in select.items() if v is True))
+              ]
+  
           resp = await self._client._execute(
               operation='query',
               method='aggregate',
@@ -2157,9 +2486,13 @@
                   'order_by': order,
                   'cursor': cursor,
               },
-              root_selection=['_count { _all }'],
+              root_selection=root_selection,
           )
-          return cast(int, resp['data']['result']['_count']['_all'])
+  
+          if select is None:
+              return cast(int, resp['data']['result']['_count']['_all'])
+          else:
+              return resp['data']['result']['_count']
   
       async def delete_many(
           self,
@@ -2374,6 +2707,7 @@
           )
           return int(resp['data']['result']['count'])
   
+      @overload
       async def count(
           self,
           take: Optional[int] = None,
@@ -2381,8 +2715,40 @@
           where: Optional[types.DWhereInput] = None,
           cursor: Optional[types.DWhereUniqueInput] = None,
           order: Optional[Union[types.DOrderByInput, List[types.DOrderByInput]]] = None,
+          select: None = None,
       ) -> int:
-          # TODO: support select
+          ...
+  
+      @overload
+      async def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.DWhereInput] = None,
+          cursor: Optional[types.DWhereUniqueInput] = None,
+          order: Optional[Union[types.DOrderByInput, List[types.DOrderByInput]]] = None,
+          select: types.DCountAggregateInput = ...,
+      ) -> types.DCountAggregateOutput:
+          ...
+  
+      async def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.DWhereInput] = None,
+          cursor: Optional[types.DWhereUniqueInput] = None,
+          order: Optional[Union[types.DOrderByInput, List[types.DOrderByInput]]] = None,
+          select: Optional[types.DCountAggregateInput] = None,
+      ) -> Union[int, types.DCountAggregateOutput]:
+          # TODO: this selection building should be moved to the QueryBuilder
+          if select is None:
+              root_selection = ['_count { _all }']
+          else:
+  
+              root_selection = [
+                  '_count {{ {0} }}'.format(' '.join(k for k, v in select.items() if v is True))
+              ]
+  
           resp = await self._client._execute(
               operation='query',
               method='aggregate',
@@ -2394,9 +2760,13 @@
                   'order_by': order,
                   'cursor': cursor,
               },
-              root_selection=['_count { _all }'],
+              root_selection=root_selection,
           )
-          return cast(int, resp['data']['result']['_count']['_all'])
+  
+          if select is None:
+              return cast(int, resp['data']['result']['_count']['_all'])
+          else:
+              return resp['data']['result']['_count']
   
       async def delete_many(
           self,
@@ -2611,6 +2981,7 @@
           )
           return int(resp['data']['result']['count'])
   
+      @overload
       async def count(
           self,
           take: Optional[int] = None,
@@ -2618,8 +2989,40 @@
           where: Optional[types.EWhereInput] = None,
           cursor: Optional[types.EWhereUniqueInput] = None,
           order: Optional[Union[types.EOrderByInput, List[types.EOrderByInput]]] = None,
+          select: None = None,
       ) -> int:
-          # TODO: support select
+          ...
+  
+      @overload
+      async def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.EWhereInput] = None,
+          cursor: Optional[types.EWhereUniqueInput] = None,
+          order: Optional[Union[types.EOrderByInput, List[types.EOrderByInput]]] = None,
+          select: types.ECountAggregateInput = ...,
+      ) -> types.ECountAggregateOutput:
+          ...
+  
+      async def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.EWhereInput] = None,
+          cursor: Optional[types.EWhereUniqueInput] = None,
+          order: Optional[Union[types.EOrderByInput, List[types.EOrderByInput]]] = None,
+          select: Optional[types.ECountAggregateInput] = None,
+      ) -> Union[int, types.ECountAggregateOutput]:
+          # TODO: this selection building should be moved to the QueryBuilder
+          if select is None:
+              root_selection = ['_count { _all }']
+          else:
+  
+              root_selection = [
+                  '_count {{ {0} }}'.format(' '.join(k for k, v in select.items() if v is True))
+              ]
+  
           resp = await self._client._execute(
               operation='query',
               method='aggregate',
@@ -2631,9 +3034,13 @@
                   'order_by': order,
                   'cursor': cursor,
               },
-              root_selection=['_count { _all }'],
+              root_selection=root_selection,
           )
-          return cast(int, resp['data']['result']['_count']['_all'])
+  
+          if select is None:
+              return cast(int, resp['data']['result']['_count']['_all'])
+          else:
+              return resp['data']['result']['_count']
   
       async def delete_many(
           self,
@@ -8814,6 +9221,35 @@
   
   
   
+  PostCountAggregateInput = TypedDict(
+      'PostCountAggregateInput',
+      {
+          'id': bool,
+          'created_at': bool,
+          'title': bool,
+          'content': bool,
+          'published': bool,
+          'author_id': bool,
+          '_all': bool,
+      },
+      total=False,
+  )
+  
+  PostCountAggregateOutput = TypedDict(
+      'PostCountAggregateOutput',
+      {
+          'id': int,
+          'created_at': int,
+          'title': int,
+          'content': int,
+          'published': int,
+          'author_id': int,
+          '_all': int,
+      },
+      total=False,
+  )
+  
+  
   PostKeys = Literal[
       'id',
       'created_at',
@@ -9720,6 +10156,47 @@
   
   
   
+  UserCountAggregateInput = TypedDict(
+      'UserCountAggregateInput',
+      {
+          'id': bool,
+          'email': bool,
+          'int': bool,
+          'optional_int': bool,
+          'float': bool,
+          'optional_float': bool,
+          'string': bool,
+          'optional_string': bool,
+          'enum': bool,
+          'optional_enum': bool,
+          'boolean': bool,
+          'optional_boolean': bool,
+          '_all': bool,
+      },
+      total=False,
+  )
+  
+  UserCountAggregateOutput = TypedDict(
+      'UserCountAggregateOutput',
+      {
+          'id': int,
+          'email': int,
+          'int': int,
+          'optional_int': int,
+          'float': int,
+          'optional_float': int,
+          'string': int,
+          'optional_string': int,
+          'enum': int,
+          'optional_enum': int,
+          'boolean': int,
+          'optional_boolean': int,
+          '_all': int,
+      },
+      total=False,
+  )
+  
+  
   UserKeys = Literal[
       'id',
       'email',
@@ -10622,6 +11099,45 @@
       boolean: Union[bool, 'types.BooleanFilter']
       optional_boolean: Union[bool, 'types.BooleanFilter']
   
+  
+  
+  MCountAggregateInput = TypedDict(
+      'MCountAggregateInput',
+      {
+          'id': bool,
+          'int': bool,
+          'optional_int': bool,
+          'float': bool,
+          'optional_float': bool,
+          'string': bool,
+          'optional_string': bool,
+          'enum': bool,
+          'optional_enum': bool,
+          'boolean': bool,
+          'optional_boolean': bool,
+          '_all': bool,
+      },
+      total=False,
+  )
+  
+  MCountAggregateOutput = TypedDict(
+      'MCountAggregateOutput',
+      {
+          'id': int,
+          'int': int,
+          'optional_int': int,
+          'float': int,
+          'optional_float': int,
+          'string': int,
+          'optional_string': int,
+          'enum': int,
+          'optional_enum': int,
+          'boolean': int,
+          'optional_boolean': int,
+          '_all': int,
+      },
+      total=False,
+  )
   
   
   MKeys = Literal[
@@ -11543,6 +12059,49 @@
   
   
   
+  NCountAggregateInput = TypedDict(
+      'NCountAggregateInput',
+      {
+          'id': bool,
+          'int': bool,
+          'optional_int': bool,
+          'float': bool,
+          'optional_float': bool,
+          'string': bool,
+          'optional_string': bool,
+          'json_': bool,
+          'optional_json': bool,
+          'enum': bool,
+          'optional_enum': bool,
+          'boolean': bool,
+          'optional_boolean': bool,
+          '_all': bool,
+      },
+      total=False,
+  )
+  
+  NCountAggregateOutput = TypedDict(
+      'NCountAggregateOutput',
+      {
+          'id': int,
+          'int': int,
+          'optional_int': int,
+          'float': int,
+          'optional_float': int,
+          'string': int,
+          'optional_string': int,
+          'json_': int,
+          'optional_json': int,
+          'enum': int,
+          'optional_enum': int,
+          'boolean': int,
+          'optional_boolean': int,
+          '_all': int,
+      },
+      total=False,
+  )
+  
+  
   NKeys = Literal[
       'id',
       'm',
@@ -12446,6 +13005,45 @@
       boolean: Union[bool, 'types.BooleanFilter']
       optional_boolean: Union[bool, 'types.BooleanFilter']
   
+  
+  
+  OneOptionalCountAggregateInput = TypedDict(
+      'OneOptionalCountAggregateInput',
+      {
+          'id': bool,
+          'int': bool,
+          'optional_int': bool,
+          'float': bool,
+          'optional_float': bool,
+          'string': bool,
+          'optional_string': bool,
+          'enum': bool,
+          'optional_enum': bool,
+          'boolean': bool,
+          'optional_boolean': bool,
+          '_all': bool,
+      },
+      total=False,
+  )
+  
+  OneOptionalCountAggregateOutput = TypedDict(
+      'OneOptionalCountAggregateOutput',
+      {
+          'id': int,
+          'int': int,
+          'optional_int': int,
+          'float': int,
+          'optional_float': int,
+          'string': int,
+          'optional_string': int,
+          'enum': int,
+          'optional_enum': int,
+          'boolean': int,
+          'optional_boolean': int,
+          '_all': int,
+      },
+      total=False,
+  )
   
   
   OneOptionalKeys = Literal[
@@ -13355,6 +13953,47 @@
   
   
   
+  ManyRequiredCountAggregateInput = TypedDict(
+      'ManyRequiredCountAggregateInput',
+      {
+          'id': bool,
+          'one_optional_id': bool,
+          'int': bool,
+          'optional_int': bool,
+          'float': bool,
+          'optional_float': bool,
+          'string': bool,
+          'optional_string': bool,
+          'enum': bool,
+          'optional_enum': bool,
+          'boolean': bool,
+          'optional_boolean': bool,
+          '_all': bool,
+      },
+      total=False,
+  )
+  
+  ManyRequiredCountAggregateOutput = TypedDict(
+      'ManyRequiredCountAggregateOutput',
+      {
+          'id': int,
+          'one_optional_id': int,
+          'int': int,
+          'optional_int': int,
+          'float': int,
+          'optional_float': int,
+          'string': int,
+          'optional_string': int,
+          'enum': int,
+          'optional_enum': int,
+          'boolean': int,
+          'optional_boolean': int,
+          '_all': int,
+      },
+      total=False,
+  )
+  
+  
   ManyRequiredKeys = Literal[
       'id',
       'one',
@@ -14236,6 +14875,41 @@
   
   
   
+  ACountAggregateInput = TypedDict(
+      'ACountAggregateInput',
+      {
+          'id': bool,
+          'email': bool,
+          'name': bool,
+          'int': bool,
+          'sInt': bool,
+          'inc_int': bool,
+          'inc_sInt': bool,
+          'bInt': bool,
+          'inc_bInt': bool,
+          '_all': bool,
+      },
+      total=False,
+  )
+  
+  ACountAggregateOutput = TypedDict(
+      'ACountAggregateOutput',
+      {
+          'id': int,
+          'email': int,
+          'name': int,
+          'int': int,
+          'sInt': int,
+          'inc_int': int,
+          'inc_sInt': int,
+          'bInt': int,
+          'inc_bInt': int,
+          '_all': int,
+      },
+      total=False,
+  )
+  
+  
   AKeys = Literal[
       'id',
       'email',
@@ -15061,6 +15735,29 @@
       float: Union[float, 'types.FloatFilter']
       d_float: Union[float, 'types.FloatFilter']
   
+  
+  
+  BCountAggregateInput = TypedDict(
+      'BCountAggregateInput',
+      {
+          'id': bool,
+          'float': bool,
+          'd_float': bool,
+          '_all': bool,
+      },
+      total=False,
+  )
+  
+  BCountAggregateOutput = TypedDict(
+      'BCountAggregateOutput',
+      {
+          'id': int,
+          'float': int,
+          'd_float': int,
+          '_all': int,
+      },
+      total=False,
+  )
   
   
   BKeys = Literal[
@@ -15916,6 +16613,37 @@
   
   
   
+  CCountAggregateInput = TypedDict(
+      'CCountAggregateInput',
+      {
+          'id': bool,
+          'char': bool,
+          'v_char': bool,
+          'text': bool,
+          'bit': bool,
+          'v_bit': bool,
+          'uuid': bool,
+          '_all': bool,
+      },
+      total=False,
+  )
+  
+  CCountAggregateOutput = TypedDict(
+      'CCountAggregateOutput',
+      {
+          'id': int,
+          'char': int,
+          'v_char': int,
+          'text': int,
+          'bit': int,
+          'v_bit': int,
+          'uuid': int,
+          '_all': int,
+      },
+      total=False,
+  )
+  
+  
   CKeys = Literal[
       'id',
       'char',
@@ -16757,6 +17485,33 @@
   
   
   
+  DCountAggregateInput = TypedDict(
+      'DCountAggregateInput',
+      {
+          'id': bool,
+          'bool': bool,
+          'xml': bool,
+          'json_': bool,
+          'jsonb': bool,
+          '_all': bool,
+      },
+      total=False,
+  )
+  
+  DCountAggregateOutput = TypedDict(
+      'DCountAggregateOutput',
+      {
+          'id': int,
+          'bool': int,
+          'xml': int,
+          'json_': int,
+          'jsonb': int,
+          '_all': int,
+      },
+      total=False,
+  )
+  
+  
   DKeys = Literal[
       'id',
       'bool',
@@ -17588,6 +18343,31 @@
   
   
   
+  ECountAggregateInput = TypedDict(
+      'ECountAggregateInput',
+      {
+          'id': bool,
+          'date': bool,
+          'time': bool,
+          'ts': bool,
+          '_all': bool,
+      },
+      total=False,
+  )
+  
+  ECountAggregateOutput = TypedDict(
+      'ECountAggregateOutput',
+      {
+          'id': int,
+          'date': int,
+          'time': int,
+          'ts': int,
+          '_all': int,
+      },
+      total=False,
+  )
+  
+  
   EKeys = Literal[
       'id',
       'date',
@@ -17846,6 +18626,7 @@
           )
           return int(resp['data']['result']['count'])
   
+      @overload
       def count(
           self,
           take: Optional[int] = None,
@@ -17853,8 +18634,40 @@
           where: Optional[types.PostWhereInput] = None,
           cursor: Optional[types.PostWhereUniqueInput] = None,
           order: Optional[Union[types.PostOrderByInput, List[types.PostOrderByInput]]] = None,
+          select: None = None,
       ) -> int:
-          # TODO: support select
+          ...
+  
+      @overload
+      def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.PostWhereInput] = None,
+          cursor: Optional[types.PostWhereUniqueInput] = None,
+          order: Optional[Union[types.PostOrderByInput, List[types.PostOrderByInput]]] = None,
+          select: types.PostCountAggregateInput = ...,
+      ) -> types.PostCountAggregateOutput:
+          ...
+  
+      def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.PostWhereInput] = None,
+          cursor: Optional[types.PostWhereUniqueInput] = None,
+          order: Optional[Union[types.PostOrderByInput, List[types.PostOrderByInput]]] = None,
+          select: Optional[types.PostCountAggregateInput] = None,
+      ) -> Union[int, types.PostCountAggregateOutput]:
+          # TODO: this selection building should be moved to the QueryBuilder
+          if select is None:
+              root_selection = ['_count { _all }']
+          else:
+  
+              root_selection = [
+                  '_count {{ {0} }}'.format(' '.join(k for k, v in select.items() if v is True))
+              ]
+  
           resp = self._client._execute(
               operation='query',
               method='aggregate',
@@ -17866,9 +18679,13 @@
                   'order_by': order,
                   'cursor': cursor,
               },
-              root_selection=['_count { _all }'],
+              root_selection=root_selection,
           )
-          return cast(int, resp['data']['result']['_count']['_all'])
+  
+          if select is None:
+              return cast(int, resp['data']['result']['_count']['_all'])
+          else:
+              return resp['data']['result']['_count']
   
       def delete_many(
           self,
@@ -18083,6 +18900,7 @@
           )
           return int(resp['data']['result']['count'])
   
+      @overload
       def count(
           self,
           take: Optional[int] = None,
@@ -18090,8 +18908,40 @@
           where: Optional[types.UserWhereInput] = None,
           cursor: Optional[types.UserWhereUniqueInput] = None,
           order: Optional[Union[types.UserOrderByInput, List[types.UserOrderByInput]]] = None,
+          select: None = None,
       ) -> int:
-          # TODO: support select
+          ...
+  
+      @overload
+      def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.UserWhereInput] = None,
+          cursor: Optional[types.UserWhereUniqueInput] = None,
+          order: Optional[Union[types.UserOrderByInput, List[types.UserOrderByInput]]] = None,
+          select: types.UserCountAggregateInput = ...,
+      ) -> types.UserCountAggregateOutput:
+          ...
+  
+      def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.UserWhereInput] = None,
+          cursor: Optional[types.UserWhereUniqueInput] = None,
+          order: Optional[Union[types.UserOrderByInput, List[types.UserOrderByInput]]] = None,
+          select: Optional[types.UserCountAggregateInput] = None,
+      ) -> Union[int, types.UserCountAggregateOutput]:
+          # TODO: this selection building should be moved to the QueryBuilder
+          if select is None:
+              root_selection = ['_count { _all }']
+          else:
+  
+              root_selection = [
+                  '_count {{ {0} }}'.format(' '.join(k for k, v in select.items() if v is True))
+              ]
+  
           resp = self._client._execute(
               operation='query',
               method='aggregate',
@@ -18103,9 +18953,13 @@
                   'order_by': order,
                   'cursor': cursor,
               },
-              root_selection=['_count { _all }'],
+              root_selection=root_selection,
           )
-          return cast(int, resp['data']['result']['_count']['_all'])
+  
+          if select is None:
+              return cast(int, resp['data']['result']['_count']['_all'])
+          else:
+              return resp['data']['result']['_count']
   
       def delete_many(
           self,
@@ -18320,6 +19174,7 @@
           )
           return int(resp['data']['result']['count'])
   
+      @overload
       def count(
           self,
           take: Optional[int] = None,
@@ -18327,8 +19182,40 @@
           where: Optional[types.MWhereInput] = None,
           cursor: Optional[types.MWhereUniqueInput] = None,
           order: Optional[Union[types.MOrderByInput, List[types.MOrderByInput]]] = None,
+          select: None = None,
       ) -> int:
-          # TODO: support select
+          ...
+  
+      @overload
+      def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.MWhereInput] = None,
+          cursor: Optional[types.MWhereUniqueInput] = None,
+          order: Optional[Union[types.MOrderByInput, List[types.MOrderByInput]]] = None,
+          select: types.MCountAggregateInput = ...,
+      ) -> types.MCountAggregateOutput:
+          ...
+  
+      def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.MWhereInput] = None,
+          cursor: Optional[types.MWhereUniqueInput] = None,
+          order: Optional[Union[types.MOrderByInput, List[types.MOrderByInput]]] = None,
+          select: Optional[types.MCountAggregateInput] = None,
+      ) -> Union[int, types.MCountAggregateOutput]:
+          # TODO: this selection building should be moved to the QueryBuilder
+          if select is None:
+              root_selection = ['_count { _all }']
+          else:
+  
+              root_selection = [
+                  '_count {{ {0} }}'.format(' '.join(k for k, v in select.items() if v is True))
+              ]
+  
           resp = self._client._execute(
               operation='query',
               method='aggregate',
@@ -18340,9 +19227,13 @@
                   'order_by': order,
                   'cursor': cursor,
               },
-              root_selection=['_count { _all }'],
+              root_selection=root_selection,
           )
-          return cast(int, resp['data']['result']['_count']['_all'])
+  
+          if select is None:
+              return cast(int, resp['data']['result']['_count']['_all'])
+          else:
+              return resp['data']['result']['_count']
   
       def delete_many(
           self,
@@ -18557,6 +19448,7 @@
           )
           return int(resp['data']['result']['count'])
   
+      @overload
       def count(
           self,
           take: Optional[int] = None,
@@ -18564,8 +19456,40 @@
           where: Optional[types.NWhereInput] = None,
           cursor: Optional[types.NWhereUniqueInput] = None,
           order: Optional[Union[types.NOrderByInput, List[types.NOrderByInput]]] = None,
+          select: None = None,
       ) -> int:
-          # TODO: support select
+          ...
+  
+      @overload
+      def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.NWhereInput] = None,
+          cursor: Optional[types.NWhereUniqueInput] = None,
+          order: Optional[Union[types.NOrderByInput, List[types.NOrderByInput]]] = None,
+          select: types.NCountAggregateInput = ...,
+      ) -> types.NCountAggregateOutput:
+          ...
+  
+      def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.NWhereInput] = None,
+          cursor: Optional[types.NWhereUniqueInput] = None,
+          order: Optional[Union[types.NOrderByInput, List[types.NOrderByInput]]] = None,
+          select: Optional[types.NCountAggregateInput] = None,
+      ) -> Union[int, types.NCountAggregateOutput]:
+          # TODO: this selection building should be moved to the QueryBuilder
+          if select is None:
+              root_selection = ['_count { _all }']
+          else:
+  
+              root_selection = [
+                  '_count {{ {0} }}'.format(' '.join(k for k, v in select.items() if v is True))
+              ]
+  
           resp = self._client._execute(
               operation='query',
               method='aggregate',
@@ -18577,9 +19501,13 @@
                   'order_by': order,
                   'cursor': cursor,
               },
-              root_selection=['_count { _all }'],
+              root_selection=root_selection,
           )
-          return cast(int, resp['data']['result']['_count']['_all'])
+  
+          if select is None:
+              return cast(int, resp['data']['result']['_count']['_all'])
+          else:
+              return resp['data']['result']['_count']
   
       def delete_many(
           self,
@@ -18794,6 +19722,7 @@
           )
           return int(resp['data']['result']['count'])
   
+      @overload
       def count(
           self,
           take: Optional[int] = None,
@@ -18801,8 +19730,40 @@
           where: Optional[types.OneOptionalWhereInput] = None,
           cursor: Optional[types.OneOptionalWhereUniqueInput] = None,
           order: Optional[Union[types.OneOptionalOrderByInput, List[types.OneOptionalOrderByInput]]] = None,
+          select: None = None,
       ) -> int:
-          # TODO: support select
+          ...
+  
+      @overload
+      def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.OneOptionalWhereInput] = None,
+          cursor: Optional[types.OneOptionalWhereUniqueInput] = None,
+          order: Optional[Union[types.OneOptionalOrderByInput, List[types.OneOptionalOrderByInput]]] = None,
+          select: types.OneOptionalCountAggregateInput = ...,
+      ) -> types.OneOptionalCountAggregateOutput:
+          ...
+  
+      def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.OneOptionalWhereInput] = None,
+          cursor: Optional[types.OneOptionalWhereUniqueInput] = None,
+          order: Optional[Union[types.OneOptionalOrderByInput, List[types.OneOptionalOrderByInput]]] = None,
+          select: Optional[types.OneOptionalCountAggregateInput] = None,
+      ) -> Union[int, types.OneOptionalCountAggregateOutput]:
+          # TODO: this selection building should be moved to the QueryBuilder
+          if select is None:
+              root_selection = ['_count { _all }']
+          else:
+  
+              root_selection = [
+                  '_count {{ {0} }}'.format(' '.join(k for k, v in select.items() if v is True))
+              ]
+  
           resp = self._client._execute(
               operation='query',
               method='aggregate',
@@ -18814,9 +19775,13 @@
                   'order_by': order,
                   'cursor': cursor,
               },
-              root_selection=['_count { _all }'],
+              root_selection=root_selection,
           )
-          return cast(int, resp['data']['result']['_count']['_all'])
+  
+          if select is None:
+              return cast(int, resp['data']['result']['_count']['_all'])
+          else:
+              return resp['data']['result']['_count']
   
       def delete_many(
           self,
@@ -19031,6 +19996,7 @@
           )
           return int(resp['data']['result']['count'])
   
+      @overload
       def count(
           self,
           take: Optional[int] = None,
@@ -19038,8 +20004,40 @@
           where: Optional[types.ManyRequiredWhereInput] = None,
           cursor: Optional[types.ManyRequiredWhereUniqueInput] = None,
           order: Optional[Union[types.ManyRequiredOrderByInput, List[types.ManyRequiredOrderByInput]]] = None,
+          select: None = None,
       ) -> int:
-          # TODO: support select
+          ...
+  
+      @overload
+      def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.ManyRequiredWhereInput] = None,
+          cursor: Optional[types.ManyRequiredWhereUniqueInput] = None,
+          order: Optional[Union[types.ManyRequiredOrderByInput, List[types.ManyRequiredOrderByInput]]] = None,
+          select: types.ManyRequiredCountAggregateInput = ...,
+      ) -> types.ManyRequiredCountAggregateOutput:
+          ...
+  
+      def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.ManyRequiredWhereInput] = None,
+          cursor: Optional[types.ManyRequiredWhereUniqueInput] = None,
+          order: Optional[Union[types.ManyRequiredOrderByInput, List[types.ManyRequiredOrderByInput]]] = None,
+          select: Optional[types.ManyRequiredCountAggregateInput] = None,
+      ) -> Union[int, types.ManyRequiredCountAggregateOutput]:
+          # TODO: this selection building should be moved to the QueryBuilder
+          if select is None:
+              root_selection = ['_count { _all }']
+          else:
+  
+              root_selection = [
+                  '_count {{ {0} }}'.format(' '.join(k for k, v in select.items() if v is True))
+              ]
+  
           resp = self._client._execute(
               operation='query',
               method='aggregate',
@@ -19051,9 +20049,13 @@
                   'order_by': order,
                   'cursor': cursor,
               },
-              root_selection=['_count { _all }'],
+              root_selection=root_selection,
           )
-          return cast(int, resp['data']['result']['_count']['_all'])
+  
+          if select is None:
+              return cast(int, resp['data']['result']['_count']['_all'])
+          else:
+              return resp['data']['result']['_count']
   
       def delete_many(
           self,
@@ -19268,6 +20270,7 @@
           )
           return int(resp['data']['result']['count'])
   
+      @overload
       def count(
           self,
           take: Optional[int] = None,
@@ -19275,8 +20278,40 @@
           where: Optional[types.AWhereInput] = None,
           cursor: Optional[types.AWhereUniqueInput] = None,
           order: Optional[Union[types.AOrderByInput, List[types.AOrderByInput]]] = None,
+          select: None = None,
       ) -> int:
-          # TODO: support select
+          ...
+  
+      @overload
+      def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.AWhereInput] = None,
+          cursor: Optional[types.AWhereUniqueInput] = None,
+          order: Optional[Union[types.AOrderByInput, List[types.AOrderByInput]]] = None,
+          select: types.ACountAggregateInput = ...,
+      ) -> types.ACountAggregateOutput:
+          ...
+  
+      def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.AWhereInput] = None,
+          cursor: Optional[types.AWhereUniqueInput] = None,
+          order: Optional[Union[types.AOrderByInput, List[types.AOrderByInput]]] = None,
+          select: Optional[types.ACountAggregateInput] = None,
+      ) -> Union[int, types.ACountAggregateOutput]:
+          # TODO: this selection building should be moved to the QueryBuilder
+          if select is None:
+              root_selection = ['_count { _all }']
+          else:
+  
+              root_selection = [
+                  '_count {{ {0} }}'.format(' '.join(k for k, v in select.items() if v is True))
+              ]
+  
           resp = self._client._execute(
               operation='query',
               method='aggregate',
@@ -19288,9 +20323,13 @@
                   'order_by': order,
                   'cursor': cursor,
               },
-              root_selection=['_count { _all }'],
+              root_selection=root_selection,
           )
-          return cast(int, resp['data']['result']['_count']['_all'])
+  
+          if select is None:
+              return cast(int, resp['data']['result']['_count']['_all'])
+          else:
+              return resp['data']['result']['_count']
   
       def delete_many(
           self,
@@ -19505,6 +20544,7 @@
           )
           return int(resp['data']['result']['count'])
   
+      @overload
       def count(
           self,
           take: Optional[int] = None,
@@ -19512,8 +20552,40 @@
           where: Optional[types.BWhereInput] = None,
           cursor: Optional[types.BWhereUniqueInput] = None,
           order: Optional[Union[types.BOrderByInput, List[types.BOrderByInput]]] = None,
+          select: None = None,
       ) -> int:
-          # TODO: support select
+          ...
+  
+      @overload
+      def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.BWhereInput] = None,
+          cursor: Optional[types.BWhereUniqueInput] = None,
+          order: Optional[Union[types.BOrderByInput, List[types.BOrderByInput]]] = None,
+          select: types.BCountAggregateInput = ...,
+      ) -> types.BCountAggregateOutput:
+          ...
+  
+      def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.BWhereInput] = None,
+          cursor: Optional[types.BWhereUniqueInput] = None,
+          order: Optional[Union[types.BOrderByInput, List[types.BOrderByInput]]] = None,
+          select: Optional[types.BCountAggregateInput] = None,
+      ) -> Union[int, types.BCountAggregateOutput]:
+          # TODO: this selection building should be moved to the QueryBuilder
+          if select is None:
+              root_selection = ['_count { _all }']
+          else:
+  
+              root_selection = [
+                  '_count {{ {0} }}'.format(' '.join(k for k, v in select.items() if v is True))
+              ]
+  
           resp = self._client._execute(
               operation='query',
               method='aggregate',
@@ -19525,9 +20597,13 @@
                   'order_by': order,
                   'cursor': cursor,
               },
-              root_selection=['_count { _all }'],
+              root_selection=root_selection,
           )
-          return cast(int, resp['data']['result']['_count']['_all'])
+  
+          if select is None:
+              return cast(int, resp['data']['result']['_count']['_all'])
+          else:
+              return resp['data']['result']['_count']
   
       def delete_many(
           self,
@@ -19742,6 +20818,7 @@
           )
           return int(resp['data']['result']['count'])
   
+      @overload
       def count(
           self,
           take: Optional[int] = None,
@@ -19749,8 +20826,40 @@
           where: Optional[types.CWhereInput] = None,
           cursor: Optional[types.CWhereUniqueInput] = None,
           order: Optional[Union[types.COrderByInput, List[types.COrderByInput]]] = None,
+          select: None = None,
       ) -> int:
-          # TODO: support select
+          ...
+  
+      @overload
+      def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.CWhereInput] = None,
+          cursor: Optional[types.CWhereUniqueInput] = None,
+          order: Optional[Union[types.COrderByInput, List[types.COrderByInput]]] = None,
+          select: types.CCountAggregateInput = ...,
+      ) -> types.CCountAggregateOutput:
+          ...
+  
+      def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.CWhereInput] = None,
+          cursor: Optional[types.CWhereUniqueInput] = None,
+          order: Optional[Union[types.COrderByInput, List[types.COrderByInput]]] = None,
+          select: Optional[types.CCountAggregateInput] = None,
+      ) -> Union[int, types.CCountAggregateOutput]:
+          # TODO: this selection building should be moved to the QueryBuilder
+          if select is None:
+              root_selection = ['_count { _all }']
+          else:
+  
+              root_selection = [
+                  '_count {{ {0} }}'.format(' '.join(k for k, v in select.items() if v is True))
+              ]
+  
           resp = self._client._execute(
               operation='query',
               method='aggregate',
@@ -19762,9 +20871,13 @@
                   'order_by': order,
                   'cursor': cursor,
               },
-              root_selection=['_count { _all }'],
+              root_selection=root_selection,
           )
-          return cast(int, resp['data']['result']['_count']['_all'])
+  
+          if select is None:
+              return cast(int, resp['data']['result']['_count']['_all'])
+          else:
+              return resp['data']['result']['_count']
   
       def delete_many(
           self,
@@ -19979,6 +21092,7 @@
           )
           return int(resp['data']['result']['count'])
   
+      @overload
       def count(
           self,
           take: Optional[int] = None,
@@ -19986,8 +21100,40 @@
           where: Optional[types.DWhereInput] = None,
           cursor: Optional[types.DWhereUniqueInput] = None,
           order: Optional[Union[types.DOrderByInput, List[types.DOrderByInput]]] = None,
+          select: None = None,
       ) -> int:
-          # TODO: support select
+          ...
+  
+      @overload
+      def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.DWhereInput] = None,
+          cursor: Optional[types.DWhereUniqueInput] = None,
+          order: Optional[Union[types.DOrderByInput, List[types.DOrderByInput]]] = None,
+          select: types.DCountAggregateInput = ...,
+      ) -> types.DCountAggregateOutput:
+          ...
+  
+      def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.DWhereInput] = None,
+          cursor: Optional[types.DWhereUniqueInput] = None,
+          order: Optional[Union[types.DOrderByInput, List[types.DOrderByInput]]] = None,
+          select: Optional[types.DCountAggregateInput] = None,
+      ) -> Union[int, types.DCountAggregateOutput]:
+          # TODO: this selection building should be moved to the QueryBuilder
+          if select is None:
+              root_selection = ['_count { _all }']
+          else:
+  
+              root_selection = [
+                  '_count {{ {0} }}'.format(' '.join(k for k, v in select.items() if v is True))
+              ]
+  
           resp = self._client._execute(
               operation='query',
               method='aggregate',
@@ -19999,9 +21145,13 @@
                   'order_by': order,
                   'cursor': cursor,
               },
-              root_selection=['_count { _all }'],
+              root_selection=root_selection,
           )
-          return cast(int, resp['data']['result']['_count']['_all'])
+  
+          if select is None:
+              return cast(int, resp['data']['result']['_count']['_all'])
+          else:
+              return resp['data']['result']['_count']
   
       def delete_many(
           self,
@@ -20216,6 +21366,7 @@
           )
           return int(resp['data']['result']['count'])
   
+      @overload
       def count(
           self,
           take: Optional[int] = None,
@@ -20223,8 +21374,40 @@
           where: Optional[types.EWhereInput] = None,
           cursor: Optional[types.EWhereUniqueInput] = None,
           order: Optional[Union[types.EOrderByInput, List[types.EOrderByInput]]] = None,
+          select: None = None,
       ) -> int:
-          # TODO: support select
+          ...
+  
+      @overload
+      def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.EWhereInput] = None,
+          cursor: Optional[types.EWhereUniqueInput] = None,
+          order: Optional[Union[types.EOrderByInput, List[types.EOrderByInput]]] = None,
+          select: types.ECountAggregateInput = ...,
+      ) -> types.ECountAggregateOutput:
+          ...
+  
+      def count(
+          self,
+          take: Optional[int] = None,
+          skip: Optional[int] = None,
+          where: Optional[types.EWhereInput] = None,
+          cursor: Optional[types.EWhereUniqueInput] = None,
+          order: Optional[Union[types.EOrderByInput, List[types.EOrderByInput]]] = None,
+          select: Optional[types.ECountAggregateInput] = None,
+      ) -> Union[int, types.ECountAggregateOutput]:
+          # TODO: this selection building should be moved to the QueryBuilder
+          if select is None:
+              root_selection = ['_count { _all }']
+          else:
+  
+              root_selection = [
+                  '_count {{ {0} }}'.format(' '.join(k for k, v in select.items() if v is True))
+              ]
+  
           resp = self._client._execute(
               operation='query',
               method='aggregate',
@@ -20236,9 +21419,13 @@
                   'order_by': order,
                   'cursor': cursor,
               },
-              root_selection=['_count { _all }'],
+              root_selection=root_selection,
           )
-          return cast(int, resp['data']['result']['_count']['_all'])
+  
+          if select is None:
+              return cast(int, resp['data']['result']['_count']['_all'])
+          else:
+              return resp['data']['result']['_count']
   
       def delete_many(
           self,
@@ -26412,6 +27599,35 @@
   
   
   
+  PostCountAggregateInput = TypedDict(
+      'PostCountAggregateInput',
+      {
+          'id': bool,
+          'created_at': bool,
+          'title': bool,
+          'content': bool,
+          'published': bool,
+          'author_id': bool,
+          '_all': bool,
+      },
+      total=False,
+  )
+  
+  PostCountAggregateOutput = TypedDict(
+      'PostCountAggregateOutput',
+      {
+          'id': int,
+          'created_at': int,
+          'title': int,
+          'content': int,
+          'published': int,
+          'author_id': int,
+          '_all': int,
+      },
+      total=False,
+  )
+  
+  
   PostKeys = Literal[
       'id',
       'created_at',
@@ -27318,6 +28534,47 @@
   
   
   
+  UserCountAggregateInput = TypedDict(
+      'UserCountAggregateInput',
+      {
+          'id': bool,
+          'email': bool,
+          'int': bool,
+          'optional_int': bool,
+          'float': bool,
+          'optional_float': bool,
+          'string': bool,
+          'optional_string': bool,
+          'enum': bool,
+          'optional_enum': bool,
+          'boolean': bool,
+          'optional_boolean': bool,
+          '_all': bool,
+      },
+      total=False,
+  )
+  
+  UserCountAggregateOutput = TypedDict(
+      'UserCountAggregateOutput',
+      {
+          'id': int,
+          'email': int,
+          'int': int,
+          'optional_int': int,
+          'float': int,
+          'optional_float': int,
+          'string': int,
+          'optional_string': int,
+          'enum': int,
+          'optional_enum': int,
+          'boolean': int,
+          'optional_boolean': int,
+          '_all': int,
+      },
+      total=False,
+  )
+  
+  
   UserKeys = Literal[
       'id',
       'email',
@@ -28220,6 +29477,45 @@
       boolean: Union[bool, 'types.BooleanFilter']
       optional_boolean: Union[bool, 'types.BooleanFilter']
   
+  
+  
+  MCountAggregateInput = TypedDict(
+      'MCountAggregateInput',
+      {
+          'id': bool,
+          'int': bool,
+          'optional_int': bool,
+          'float': bool,
+          'optional_float': bool,
+          'string': bool,
+          'optional_string': bool,
+          'enum': bool,
+          'optional_enum': bool,
+          'boolean': bool,
+          'optional_boolean': bool,
+          '_all': bool,
+      },
+      total=False,
+  )
+  
+  MCountAggregateOutput = TypedDict(
+      'MCountAggregateOutput',
+      {
+          'id': int,
+          'int': int,
+          'optional_int': int,
+          'float': int,
+          'optional_float': int,
+          'string': int,
+          'optional_string': int,
+          'enum': int,
+          'optional_enum': int,
+          'boolean': int,
+          'optional_boolean': int,
+          '_all': int,
+      },
+      total=False,
+  )
   
   
   MKeys = Literal[
@@ -29141,6 +30437,49 @@
   
   
   
+  NCountAggregateInput = TypedDict(
+      'NCountAggregateInput',
+      {
+          'id': bool,
+          'int': bool,
+          'optional_int': bool,
+          'float': bool,
+          'optional_float': bool,
+          'string': bool,
+          'optional_string': bool,
+          'json_': bool,
+          'optional_json': bool,
+          'enum': bool,
+          'optional_enum': bool,
+          'boolean': bool,
+          'optional_boolean': bool,
+          '_all': bool,
+      },
+      total=False,
+  )
+  
+  NCountAggregateOutput = TypedDict(
+      'NCountAggregateOutput',
+      {
+          'id': int,
+          'int': int,
+          'optional_int': int,
+          'float': int,
+          'optional_float': int,
+          'string': int,
+          'optional_string': int,
+          'json_': int,
+          'optional_json': int,
+          'enum': int,
+          'optional_enum': int,
+          'boolean': int,
+          'optional_boolean': int,
+          '_all': int,
+      },
+      total=False,
+  )
+  
+  
   NKeys = Literal[
       'id',
       'm',
@@ -30044,6 +31383,45 @@
       boolean: Union[bool, 'types.BooleanFilter']
       optional_boolean: Union[bool, 'types.BooleanFilter']
   
+  
+  
+  OneOptionalCountAggregateInput = TypedDict(
+      'OneOptionalCountAggregateInput',
+      {
+          'id': bool,
+          'int': bool,
+          'optional_int': bool,
+          'float': bool,
+          'optional_float': bool,
+          'string': bool,
+          'optional_string': bool,
+          'enum': bool,
+          'optional_enum': bool,
+          'boolean': bool,
+          'optional_boolean': bool,
+          '_all': bool,
+      },
+      total=False,
+  )
+  
+  OneOptionalCountAggregateOutput = TypedDict(
+      'OneOptionalCountAggregateOutput',
+      {
+          'id': int,
+          'int': int,
+          'optional_int': int,
+          'float': int,
+          'optional_float': int,
+          'string': int,
+          'optional_string': int,
+          'enum': int,
+          'optional_enum': int,
+          'boolean': int,
+          'optional_boolean': int,
+          '_all': int,
+      },
+      total=False,
+  )
   
   
   OneOptionalKeys = Literal[
@@ -30953,6 +32331,47 @@
   
   
   
+  ManyRequiredCountAggregateInput = TypedDict(
+      'ManyRequiredCountAggregateInput',
+      {
+          'id': bool,
+          'one_optional_id': bool,
+          'int': bool,
+          'optional_int': bool,
+          'float': bool,
+          'optional_float': bool,
+          'string': bool,
+          'optional_string': bool,
+          'enum': bool,
+          'optional_enum': bool,
+          'boolean': bool,
+          'optional_boolean': bool,
+          '_all': bool,
+      },
+      total=False,
+  )
+  
+  ManyRequiredCountAggregateOutput = TypedDict(
+      'ManyRequiredCountAggregateOutput',
+      {
+          'id': int,
+          'one_optional_id': int,
+          'int': int,
+          'optional_int': int,
+          'float': int,
+          'optional_float': int,
+          'string': int,
+          'optional_string': int,
+          'enum': int,
+          'optional_enum': int,
+          'boolean': int,
+          'optional_boolean': int,
+          '_all': int,
+      },
+      total=False,
+  )
+  
+  
   ManyRequiredKeys = Literal[
       'id',
       'one',
@@ -31834,6 +33253,41 @@
   
   
   
+  ACountAggregateInput = TypedDict(
+      'ACountAggregateInput',
+      {
+          'id': bool,
+          'email': bool,
+          'name': bool,
+          'int': bool,
+          'sInt': bool,
+          'inc_int': bool,
+          'inc_sInt': bool,
+          'bInt': bool,
+          'inc_bInt': bool,
+          '_all': bool,
+      },
+      total=False,
+  )
+  
+  ACountAggregateOutput = TypedDict(
+      'ACountAggregateOutput',
+      {
+          'id': int,
+          'email': int,
+          'name': int,
+          'int': int,
+          'sInt': int,
+          'inc_int': int,
+          'inc_sInt': int,
+          'bInt': int,
+          'inc_bInt': int,
+          '_all': int,
+      },
+      total=False,
+  )
+  
+  
   AKeys = Literal[
       'id',
       'email',
@@ -32659,6 +34113,29 @@
       float: Union[float, 'types.FloatFilter']
       d_float: Union[float, 'types.FloatFilter']
   
+  
+  
+  BCountAggregateInput = TypedDict(
+      'BCountAggregateInput',
+      {
+          'id': bool,
+          'float': bool,
+          'd_float': bool,
+          '_all': bool,
+      },
+      total=False,
+  )
+  
+  BCountAggregateOutput = TypedDict(
+      'BCountAggregateOutput',
+      {
+          'id': int,
+          'float': int,
+          'd_float': int,
+          '_all': int,
+      },
+      total=False,
+  )
   
   
   BKeys = Literal[
@@ -33514,6 +34991,37 @@
   
   
   
+  CCountAggregateInput = TypedDict(
+      'CCountAggregateInput',
+      {
+          'id': bool,
+          'char': bool,
+          'v_char': bool,
+          'text': bool,
+          'bit': bool,
+          'v_bit': bool,
+          'uuid': bool,
+          '_all': bool,
+      },
+      total=False,
+  )
+  
+  CCountAggregateOutput = TypedDict(
+      'CCountAggregateOutput',
+      {
+          'id': int,
+          'char': int,
+          'v_char': int,
+          'text': int,
+          'bit': int,
+          'v_bit': int,
+          'uuid': int,
+          '_all': int,
+      },
+      total=False,
+  )
+  
+  
   CKeys = Literal[
       'id',
       'char',
@@ -34355,6 +35863,33 @@
   
   
   
+  DCountAggregateInput = TypedDict(
+      'DCountAggregateInput',
+      {
+          'id': bool,
+          'bool': bool,
+          'xml': bool,
+          'json_': bool,
+          'jsonb': bool,
+          '_all': bool,
+      },
+      total=False,
+  )
+  
+  DCountAggregateOutput = TypedDict(
+      'DCountAggregateOutput',
+      {
+          'id': int,
+          'bool': int,
+          'xml': int,
+          'json_': int,
+          'jsonb': int,
+          '_all': int,
+      },
+      total=False,
+  )
+  
+  
   DKeys = Literal[
       'id',
       'bool',
@@ -35184,6 +36719,31 @@
       time: Union[datetime.datetime, 'types.DateTimeFilter']
       ts: Union[datetime.datetime, 'types.DateTimeFilter']
   
+  
+  
+  ECountAggregateInput = TypedDict(
+      'ECountAggregateInput',
+      {
+          'id': bool,
+          'date': bool,
+          'time': bool,
+          'ts': bool,
+          '_all': bool,
+      },
+      total=False,
+  )
+  
+  ECountAggregateOutput = TypedDict(
+      'ECountAggregateOutput',
+      {
+          'id': int,
+          'date': int,
+          'time': int,
+          'ts': int,
+          '_all': int,
+      },
+      total=False,
+  )
   
   
   EKeys = Literal[

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive.ambr
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive.ambr
@@ -244,38 +244,42 @@
       @overload
       async def count(
           self,
+          select: None = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.PostWhereInput] = None,
           cursor: Optional[types.PostWhereUniqueInput] = None,
           order: Optional[Union[types.PostOrderByInput, List[types.PostOrderByInput]]] = None,
-          select: None = None,
       ) -> int:
           ...
   
       @overload
       async def count(
           self,
+          select: types.PostCountAggregateInput,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.PostWhereInput] = None,
           cursor: Optional[types.PostWhereUniqueInput] = None,
           order: Optional[Union[types.PostOrderByInput, List[types.PostOrderByInput]]] = None,
-          select: types.PostCountAggregateInput = ...,
       ) -> types.PostCountAggregateOutput:
           ...
   
       async def count(
           self,
+          select: Optional[types.PostCountAggregateInput] = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.PostWhereInput] = None,
           cursor: Optional[types.PostWhereUniqueInput] = None,
           order: Optional[Union[types.PostOrderByInput, List[types.PostOrderByInput]]] = None,
-          select: Optional[types.PostCountAggregateInput] = None,
       ) -> Union[int, types.PostCountAggregateOutput]:
           # TODO: this selection building should be moved to the QueryBuilder
-          if select is None:
+          #
+          # note the distinction between checking for `not select` here `select is None`
+          # later is to handle the case that the given select dictionary is empty, this
+          # is a limitation of our types.
+          if not select:
               root_selection = ['_count { _all }']
           else:
   
@@ -300,7 +304,7 @@
           if select is None:
               return cast(int, resp['data']['result']['_count']['_all'])
           else:
-              return resp['data']['result']['_count']
+              return cast(types.PostCountAggregateOutput, resp['data']['result']['_count'])
   
       async def delete_many(
           self,
@@ -518,38 +522,42 @@
       @overload
       async def count(
           self,
+          select: None = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.UserWhereInput] = None,
           cursor: Optional[types.UserWhereUniqueInput] = None,
           order: Optional[Union[types.UserOrderByInput, List[types.UserOrderByInput]]] = None,
-          select: None = None,
       ) -> int:
           ...
   
       @overload
       async def count(
           self,
+          select: types.UserCountAggregateInput,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.UserWhereInput] = None,
           cursor: Optional[types.UserWhereUniqueInput] = None,
           order: Optional[Union[types.UserOrderByInput, List[types.UserOrderByInput]]] = None,
-          select: types.UserCountAggregateInput = ...,
       ) -> types.UserCountAggregateOutput:
           ...
   
       async def count(
           self,
+          select: Optional[types.UserCountAggregateInput] = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.UserWhereInput] = None,
           cursor: Optional[types.UserWhereUniqueInput] = None,
           order: Optional[Union[types.UserOrderByInput, List[types.UserOrderByInput]]] = None,
-          select: Optional[types.UserCountAggregateInput] = None,
       ) -> Union[int, types.UserCountAggregateOutput]:
           # TODO: this selection building should be moved to the QueryBuilder
-          if select is None:
+          #
+          # note the distinction between checking for `not select` here `select is None`
+          # later is to handle the case that the given select dictionary is empty, this
+          # is a limitation of our types.
+          if not select:
               root_selection = ['_count { _all }']
           else:
   
@@ -574,7 +582,7 @@
           if select is None:
               return cast(int, resp['data']['result']['_count']['_all'])
           else:
-              return resp['data']['result']['_count']
+              return cast(types.UserCountAggregateOutput, resp['data']['result']['_count'])
   
       async def delete_many(
           self,
@@ -792,38 +800,42 @@
       @overload
       async def count(
           self,
+          select: None = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.MWhereInput] = None,
           cursor: Optional[types.MWhereUniqueInput] = None,
           order: Optional[Union[types.MOrderByInput, List[types.MOrderByInput]]] = None,
-          select: None = None,
       ) -> int:
           ...
   
       @overload
       async def count(
           self,
+          select: types.MCountAggregateInput,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.MWhereInput] = None,
           cursor: Optional[types.MWhereUniqueInput] = None,
           order: Optional[Union[types.MOrderByInput, List[types.MOrderByInput]]] = None,
-          select: types.MCountAggregateInput = ...,
       ) -> types.MCountAggregateOutput:
           ...
   
       async def count(
           self,
+          select: Optional[types.MCountAggregateInput] = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.MWhereInput] = None,
           cursor: Optional[types.MWhereUniqueInput] = None,
           order: Optional[Union[types.MOrderByInput, List[types.MOrderByInput]]] = None,
-          select: Optional[types.MCountAggregateInput] = None,
       ) -> Union[int, types.MCountAggregateOutput]:
           # TODO: this selection building should be moved to the QueryBuilder
-          if select is None:
+          #
+          # note the distinction between checking for `not select` here `select is None`
+          # later is to handle the case that the given select dictionary is empty, this
+          # is a limitation of our types.
+          if not select:
               root_selection = ['_count { _all }']
           else:
   
@@ -848,7 +860,7 @@
           if select is None:
               return cast(int, resp['data']['result']['_count']['_all'])
           else:
-              return resp['data']['result']['_count']
+              return cast(types.MCountAggregateOutput, resp['data']['result']['_count'])
   
       async def delete_many(
           self,
@@ -1066,38 +1078,42 @@
       @overload
       async def count(
           self,
+          select: None = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.NWhereInput] = None,
           cursor: Optional[types.NWhereUniqueInput] = None,
           order: Optional[Union[types.NOrderByInput, List[types.NOrderByInput]]] = None,
-          select: None = None,
       ) -> int:
           ...
   
       @overload
       async def count(
           self,
+          select: types.NCountAggregateInput,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.NWhereInput] = None,
           cursor: Optional[types.NWhereUniqueInput] = None,
           order: Optional[Union[types.NOrderByInput, List[types.NOrderByInput]]] = None,
-          select: types.NCountAggregateInput = ...,
       ) -> types.NCountAggregateOutput:
           ...
   
       async def count(
           self,
+          select: Optional[types.NCountAggregateInput] = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.NWhereInput] = None,
           cursor: Optional[types.NWhereUniqueInput] = None,
           order: Optional[Union[types.NOrderByInput, List[types.NOrderByInput]]] = None,
-          select: Optional[types.NCountAggregateInput] = None,
       ) -> Union[int, types.NCountAggregateOutput]:
           # TODO: this selection building should be moved to the QueryBuilder
-          if select is None:
+          #
+          # note the distinction between checking for `not select` here `select is None`
+          # later is to handle the case that the given select dictionary is empty, this
+          # is a limitation of our types.
+          if not select:
               root_selection = ['_count { _all }']
           else:
   
@@ -1122,7 +1138,7 @@
           if select is None:
               return cast(int, resp['data']['result']['_count']['_all'])
           else:
-              return resp['data']['result']['_count']
+              return cast(types.NCountAggregateOutput, resp['data']['result']['_count'])
   
       async def delete_many(
           self,
@@ -1340,38 +1356,42 @@
       @overload
       async def count(
           self,
+          select: None = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.OneOptionalWhereInput] = None,
           cursor: Optional[types.OneOptionalWhereUniqueInput] = None,
           order: Optional[Union[types.OneOptionalOrderByInput, List[types.OneOptionalOrderByInput]]] = None,
-          select: None = None,
       ) -> int:
           ...
   
       @overload
       async def count(
           self,
+          select: types.OneOptionalCountAggregateInput,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.OneOptionalWhereInput] = None,
           cursor: Optional[types.OneOptionalWhereUniqueInput] = None,
           order: Optional[Union[types.OneOptionalOrderByInput, List[types.OneOptionalOrderByInput]]] = None,
-          select: types.OneOptionalCountAggregateInput = ...,
       ) -> types.OneOptionalCountAggregateOutput:
           ...
   
       async def count(
           self,
+          select: Optional[types.OneOptionalCountAggregateInput] = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.OneOptionalWhereInput] = None,
           cursor: Optional[types.OneOptionalWhereUniqueInput] = None,
           order: Optional[Union[types.OneOptionalOrderByInput, List[types.OneOptionalOrderByInput]]] = None,
-          select: Optional[types.OneOptionalCountAggregateInput] = None,
       ) -> Union[int, types.OneOptionalCountAggregateOutput]:
           # TODO: this selection building should be moved to the QueryBuilder
-          if select is None:
+          #
+          # note the distinction between checking for `not select` here `select is None`
+          # later is to handle the case that the given select dictionary is empty, this
+          # is a limitation of our types.
+          if not select:
               root_selection = ['_count { _all }']
           else:
   
@@ -1396,7 +1416,7 @@
           if select is None:
               return cast(int, resp['data']['result']['_count']['_all'])
           else:
-              return resp['data']['result']['_count']
+              return cast(types.OneOptionalCountAggregateOutput, resp['data']['result']['_count'])
   
       async def delete_many(
           self,
@@ -1614,38 +1634,42 @@
       @overload
       async def count(
           self,
+          select: None = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.ManyRequiredWhereInput] = None,
           cursor: Optional[types.ManyRequiredWhereUniqueInput] = None,
           order: Optional[Union[types.ManyRequiredOrderByInput, List[types.ManyRequiredOrderByInput]]] = None,
-          select: None = None,
       ) -> int:
           ...
   
       @overload
       async def count(
           self,
+          select: types.ManyRequiredCountAggregateInput,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.ManyRequiredWhereInput] = None,
           cursor: Optional[types.ManyRequiredWhereUniqueInput] = None,
           order: Optional[Union[types.ManyRequiredOrderByInput, List[types.ManyRequiredOrderByInput]]] = None,
-          select: types.ManyRequiredCountAggregateInput = ...,
       ) -> types.ManyRequiredCountAggregateOutput:
           ...
   
       async def count(
           self,
+          select: Optional[types.ManyRequiredCountAggregateInput] = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.ManyRequiredWhereInput] = None,
           cursor: Optional[types.ManyRequiredWhereUniqueInput] = None,
           order: Optional[Union[types.ManyRequiredOrderByInput, List[types.ManyRequiredOrderByInput]]] = None,
-          select: Optional[types.ManyRequiredCountAggregateInput] = None,
       ) -> Union[int, types.ManyRequiredCountAggregateOutput]:
           # TODO: this selection building should be moved to the QueryBuilder
-          if select is None:
+          #
+          # note the distinction between checking for `not select` here `select is None`
+          # later is to handle the case that the given select dictionary is empty, this
+          # is a limitation of our types.
+          if not select:
               root_selection = ['_count { _all }']
           else:
   
@@ -1670,7 +1694,7 @@
           if select is None:
               return cast(int, resp['data']['result']['_count']['_all'])
           else:
-              return resp['data']['result']['_count']
+              return cast(types.ManyRequiredCountAggregateOutput, resp['data']['result']['_count'])
   
       async def delete_many(
           self,
@@ -1888,38 +1912,42 @@
       @overload
       async def count(
           self,
+          select: None = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.AWhereInput] = None,
           cursor: Optional[types.AWhereUniqueInput] = None,
           order: Optional[Union[types.AOrderByInput, List[types.AOrderByInput]]] = None,
-          select: None = None,
       ) -> int:
           ...
   
       @overload
       async def count(
           self,
+          select: types.ACountAggregateInput,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.AWhereInput] = None,
           cursor: Optional[types.AWhereUniqueInput] = None,
           order: Optional[Union[types.AOrderByInput, List[types.AOrderByInput]]] = None,
-          select: types.ACountAggregateInput = ...,
       ) -> types.ACountAggregateOutput:
           ...
   
       async def count(
           self,
+          select: Optional[types.ACountAggregateInput] = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.AWhereInput] = None,
           cursor: Optional[types.AWhereUniqueInput] = None,
           order: Optional[Union[types.AOrderByInput, List[types.AOrderByInput]]] = None,
-          select: Optional[types.ACountAggregateInput] = None,
       ) -> Union[int, types.ACountAggregateOutput]:
           # TODO: this selection building should be moved to the QueryBuilder
-          if select is None:
+          #
+          # note the distinction between checking for `not select` here `select is None`
+          # later is to handle the case that the given select dictionary is empty, this
+          # is a limitation of our types.
+          if not select:
               root_selection = ['_count { _all }']
           else:
   
@@ -1944,7 +1972,7 @@
           if select is None:
               return cast(int, resp['data']['result']['_count']['_all'])
           else:
-              return resp['data']['result']['_count']
+              return cast(types.ACountAggregateOutput, resp['data']['result']['_count'])
   
       async def delete_many(
           self,
@@ -2162,38 +2190,42 @@
       @overload
       async def count(
           self,
+          select: None = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.BWhereInput] = None,
           cursor: Optional[types.BWhereUniqueInput] = None,
           order: Optional[Union[types.BOrderByInput, List[types.BOrderByInput]]] = None,
-          select: None = None,
       ) -> int:
           ...
   
       @overload
       async def count(
           self,
+          select: types.BCountAggregateInput,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.BWhereInput] = None,
           cursor: Optional[types.BWhereUniqueInput] = None,
           order: Optional[Union[types.BOrderByInput, List[types.BOrderByInput]]] = None,
-          select: types.BCountAggregateInput = ...,
       ) -> types.BCountAggregateOutput:
           ...
   
       async def count(
           self,
+          select: Optional[types.BCountAggregateInput] = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.BWhereInput] = None,
           cursor: Optional[types.BWhereUniqueInput] = None,
           order: Optional[Union[types.BOrderByInput, List[types.BOrderByInput]]] = None,
-          select: Optional[types.BCountAggregateInput] = None,
       ) -> Union[int, types.BCountAggregateOutput]:
           # TODO: this selection building should be moved to the QueryBuilder
-          if select is None:
+          #
+          # note the distinction between checking for `not select` here `select is None`
+          # later is to handle the case that the given select dictionary is empty, this
+          # is a limitation of our types.
+          if not select:
               root_selection = ['_count { _all }']
           else:
   
@@ -2218,7 +2250,7 @@
           if select is None:
               return cast(int, resp['data']['result']['_count']['_all'])
           else:
-              return resp['data']['result']['_count']
+              return cast(types.BCountAggregateOutput, resp['data']['result']['_count'])
   
       async def delete_many(
           self,
@@ -2436,38 +2468,42 @@
       @overload
       async def count(
           self,
+          select: None = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.CWhereInput] = None,
           cursor: Optional[types.CWhereUniqueInput] = None,
           order: Optional[Union[types.COrderByInput, List[types.COrderByInput]]] = None,
-          select: None = None,
       ) -> int:
           ...
   
       @overload
       async def count(
           self,
+          select: types.CCountAggregateInput,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.CWhereInput] = None,
           cursor: Optional[types.CWhereUniqueInput] = None,
           order: Optional[Union[types.COrderByInput, List[types.COrderByInput]]] = None,
-          select: types.CCountAggregateInput = ...,
       ) -> types.CCountAggregateOutput:
           ...
   
       async def count(
           self,
+          select: Optional[types.CCountAggregateInput] = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.CWhereInput] = None,
           cursor: Optional[types.CWhereUniqueInput] = None,
           order: Optional[Union[types.COrderByInput, List[types.COrderByInput]]] = None,
-          select: Optional[types.CCountAggregateInput] = None,
       ) -> Union[int, types.CCountAggregateOutput]:
           # TODO: this selection building should be moved to the QueryBuilder
-          if select is None:
+          #
+          # note the distinction between checking for `not select` here `select is None`
+          # later is to handle the case that the given select dictionary is empty, this
+          # is a limitation of our types.
+          if not select:
               root_selection = ['_count { _all }']
           else:
   
@@ -2492,7 +2528,7 @@
           if select is None:
               return cast(int, resp['data']['result']['_count']['_all'])
           else:
-              return resp['data']['result']['_count']
+              return cast(types.CCountAggregateOutput, resp['data']['result']['_count'])
   
       async def delete_many(
           self,
@@ -2710,38 +2746,42 @@
       @overload
       async def count(
           self,
+          select: None = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.DWhereInput] = None,
           cursor: Optional[types.DWhereUniqueInput] = None,
           order: Optional[Union[types.DOrderByInput, List[types.DOrderByInput]]] = None,
-          select: None = None,
       ) -> int:
           ...
   
       @overload
       async def count(
           self,
+          select: types.DCountAggregateInput,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.DWhereInput] = None,
           cursor: Optional[types.DWhereUniqueInput] = None,
           order: Optional[Union[types.DOrderByInput, List[types.DOrderByInput]]] = None,
-          select: types.DCountAggregateInput = ...,
       ) -> types.DCountAggregateOutput:
           ...
   
       async def count(
           self,
+          select: Optional[types.DCountAggregateInput] = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.DWhereInput] = None,
           cursor: Optional[types.DWhereUniqueInput] = None,
           order: Optional[Union[types.DOrderByInput, List[types.DOrderByInput]]] = None,
-          select: Optional[types.DCountAggregateInput] = None,
       ) -> Union[int, types.DCountAggregateOutput]:
           # TODO: this selection building should be moved to the QueryBuilder
-          if select is None:
+          #
+          # note the distinction between checking for `not select` here `select is None`
+          # later is to handle the case that the given select dictionary is empty, this
+          # is a limitation of our types.
+          if not select:
               root_selection = ['_count { _all }']
           else:
   
@@ -2766,7 +2806,7 @@
           if select is None:
               return cast(int, resp['data']['result']['_count']['_all'])
           else:
-              return resp['data']['result']['_count']
+              return cast(types.DCountAggregateOutput, resp['data']['result']['_count'])
   
       async def delete_many(
           self,
@@ -2984,38 +3024,42 @@
       @overload
       async def count(
           self,
+          select: None = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.EWhereInput] = None,
           cursor: Optional[types.EWhereUniqueInput] = None,
           order: Optional[Union[types.EOrderByInput, List[types.EOrderByInput]]] = None,
-          select: None = None,
       ) -> int:
           ...
   
       @overload
       async def count(
           self,
+          select: types.ECountAggregateInput,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.EWhereInput] = None,
           cursor: Optional[types.EWhereUniqueInput] = None,
           order: Optional[Union[types.EOrderByInput, List[types.EOrderByInput]]] = None,
-          select: types.ECountAggregateInput = ...,
       ) -> types.ECountAggregateOutput:
           ...
   
       async def count(
           self,
+          select: Optional[types.ECountAggregateInput] = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.EWhereInput] = None,
           cursor: Optional[types.EWhereUniqueInput] = None,
           order: Optional[Union[types.EOrderByInput, List[types.EOrderByInput]]] = None,
-          select: Optional[types.ECountAggregateInput] = None,
       ) -> Union[int, types.ECountAggregateOutput]:
           # TODO: this selection building should be moved to the QueryBuilder
-          if select is None:
+          #
+          # note the distinction between checking for `not select` here `select is None`
+          # later is to handle the case that the given select dictionary is empty, this
+          # is a limitation of our types.
+          if not select:
               root_selection = ['_count { _all }']
           else:
   
@@ -3040,7 +3084,7 @@
           if select is None:
               return cast(int, resp['data']['result']['_count']['_all'])
           else:
-              return resp['data']['result']['_count']
+              return cast(types.ECountAggregateOutput, resp['data']['result']['_count'])
   
       async def delete_many(
           self,
@@ -18629,38 +18673,42 @@
       @overload
       def count(
           self,
+          select: None = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.PostWhereInput] = None,
           cursor: Optional[types.PostWhereUniqueInput] = None,
           order: Optional[Union[types.PostOrderByInput, List[types.PostOrderByInput]]] = None,
-          select: None = None,
       ) -> int:
           ...
   
       @overload
       def count(
           self,
+          select: types.PostCountAggregateInput,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.PostWhereInput] = None,
           cursor: Optional[types.PostWhereUniqueInput] = None,
           order: Optional[Union[types.PostOrderByInput, List[types.PostOrderByInput]]] = None,
-          select: types.PostCountAggregateInput = ...,
       ) -> types.PostCountAggregateOutput:
           ...
   
       def count(
           self,
+          select: Optional[types.PostCountAggregateInput] = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.PostWhereInput] = None,
           cursor: Optional[types.PostWhereUniqueInput] = None,
           order: Optional[Union[types.PostOrderByInput, List[types.PostOrderByInput]]] = None,
-          select: Optional[types.PostCountAggregateInput] = None,
       ) -> Union[int, types.PostCountAggregateOutput]:
           # TODO: this selection building should be moved to the QueryBuilder
-          if select is None:
+          #
+          # note the distinction between checking for `not select` here `select is None`
+          # later is to handle the case that the given select dictionary is empty, this
+          # is a limitation of our types.
+          if not select:
               root_selection = ['_count { _all }']
           else:
   
@@ -18685,7 +18733,7 @@
           if select is None:
               return cast(int, resp['data']['result']['_count']['_all'])
           else:
-              return resp['data']['result']['_count']
+              return cast(types.PostCountAggregateOutput, resp['data']['result']['_count'])
   
       def delete_many(
           self,
@@ -18903,38 +18951,42 @@
       @overload
       def count(
           self,
+          select: None = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.UserWhereInput] = None,
           cursor: Optional[types.UserWhereUniqueInput] = None,
           order: Optional[Union[types.UserOrderByInput, List[types.UserOrderByInput]]] = None,
-          select: None = None,
       ) -> int:
           ...
   
       @overload
       def count(
           self,
+          select: types.UserCountAggregateInput,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.UserWhereInput] = None,
           cursor: Optional[types.UserWhereUniqueInput] = None,
           order: Optional[Union[types.UserOrderByInput, List[types.UserOrderByInput]]] = None,
-          select: types.UserCountAggregateInput = ...,
       ) -> types.UserCountAggregateOutput:
           ...
   
       def count(
           self,
+          select: Optional[types.UserCountAggregateInput] = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.UserWhereInput] = None,
           cursor: Optional[types.UserWhereUniqueInput] = None,
           order: Optional[Union[types.UserOrderByInput, List[types.UserOrderByInput]]] = None,
-          select: Optional[types.UserCountAggregateInput] = None,
       ) -> Union[int, types.UserCountAggregateOutput]:
           # TODO: this selection building should be moved to the QueryBuilder
-          if select is None:
+          #
+          # note the distinction between checking for `not select` here `select is None`
+          # later is to handle the case that the given select dictionary is empty, this
+          # is a limitation of our types.
+          if not select:
               root_selection = ['_count { _all }']
           else:
   
@@ -18959,7 +19011,7 @@
           if select is None:
               return cast(int, resp['data']['result']['_count']['_all'])
           else:
-              return resp['data']['result']['_count']
+              return cast(types.UserCountAggregateOutput, resp['data']['result']['_count'])
   
       def delete_many(
           self,
@@ -19177,38 +19229,42 @@
       @overload
       def count(
           self,
+          select: None = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.MWhereInput] = None,
           cursor: Optional[types.MWhereUniqueInput] = None,
           order: Optional[Union[types.MOrderByInput, List[types.MOrderByInput]]] = None,
-          select: None = None,
       ) -> int:
           ...
   
       @overload
       def count(
           self,
+          select: types.MCountAggregateInput,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.MWhereInput] = None,
           cursor: Optional[types.MWhereUniqueInput] = None,
           order: Optional[Union[types.MOrderByInput, List[types.MOrderByInput]]] = None,
-          select: types.MCountAggregateInput = ...,
       ) -> types.MCountAggregateOutput:
           ...
   
       def count(
           self,
+          select: Optional[types.MCountAggregateInput] = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.MWhereInput] = None,
           cursor: Optional[types.MWhereUniqueInput] = None,
           order: Optional[Union[types.MOrderByInput, List[types.MOrderByInput]]] = None,
-          select: Optional[types.MCountAggregateInput] = None,
       ) -> Union[int, types.MCountAggregateOutput]:
           # TODO: this selection building should be moved to the QueryBuilder
-          if select is None:
+          #
+          # note the distinction between checking for `not select` here `select is None`
+          # later is to handle the case that the given select dictionary is empty, this
+          # is a limitation of our types.
+          if not select:
               root_selection = ['_count { _all }']
           else:
   
@@ -19233,7 +19289,7 @@
           if select is None:
               return cast(int, resp['data']['result']['_count']['_all'])
           else:
-              return resp['data']['result']['_count']
+              return cast(types.MCountAggregateOutput, resp['data']['result']['_count'])
   
       def delete_many(
           self,
@@ -19451,38 +19507,42 @@
       @overload
       def count(
           self,
+          select: None = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.NWhereInput] = None,
           cursor: Optional[types.NWhereUniqueInput] = None,
           order: Optional[Union[types.NOrderByInput, List[types.NOrderByInput]]] = None,
-          select: None = None,
       ) -> int:
           ...
   
       @overload
       def count(
           self,
+          select: types.NCountAggregateInput,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.NWhereInput] = None,
           cursor: Optional[types.NWhereUniqueInput] = None,
           order: Optional[Union[types.NOrderByInput, List[types.NOrderByInput]]] = None,
-          select: types.NCountAggregateInput = ...,
       ) -> types.NCountAggregateOutput:
           ...
   
       def count(
           self,
+          select: Optional[types.NCountAggregateInput] = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.NWhereInput] = None,
           cursor: Optional[types.NWhereUniqueInput] = None,
           order: Optional[Union[types.NOrderByInput, List[types.NOrderByInput]]] = None,
-          select: Optional[types.NCountAggregateInput] = None,
       ) -> Union[int, types.NCountAggregateOutput]:
           # TODO: this selection building should be moved to the QueryBuilder
-          if select is None:
+          #
+          # note the distinction between checking for `not select` here `select is None`
+          # later is to handle the case that the given select dictionary is empty, this
+          # is a limitation of our types.
+          if not select:
               root_selection = ['_count { _all }']
           else:
   
@@ -19507,7 +19567,7 @@
           if select is None:
               return cast(int, resp['data']['result']['_count']['_all'])
           else:
-              return resp['data']['result']['_count']
+              return cast(types.NCountAggregateOutput, resp['data']['result']['_count'])
   
       def delete_many(
           self,
@@ -19725,38 +19785,42 @@
       @overload
       def count(
           self,
+          select: None = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.OneOptionalWhereInput] = None,
           cursor: Optional[types.OneOptionalWhereUniqueInput] = None,
           order: Optional[Union[types.OneOptionalOrderByInput, List[types.OneOptionalOrderByInput]]] = None,
-          select: None = None,
       ) -> int:
           ...
   
       @overload
       def count(
           self,
+          select: types.OneOptionalCountAggregateInput,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.OneOptionalWhereInput] = None,
           cursor: Optional[types.OneOptionalWhereUniqueInput] = None,
           order: Optional[Union[types.OneOptionalOrderByInput, List[types.OneOptionalOrderByInput]]] = None,
-          select: types.OneOptionalCountAggregateInput = ...,
       ) -> types.OneOptionalCountAggregateOutput:
           ...
   
       def count(
           self,
+          select: Optional[types.OneOptionalCountAggregateInput] = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.OneOptionalWhereInput] = None,
           cursor: Optional[types.OneOptionalWhereUniqueInput] = None,
           order: Optional[Union[types.OneOptionalOrderByInput, List[types.OneOptionalOrderByInput]]] = None,
-          select: Optional[types.OneOptionalCountAggregateInput] = None,
       ) -> Union[int, types.OneOptionalCountAggregateOutput]:
           # TODO: this selection building should be moved to the QueryBuilder
-          if select is None:
+          #
+          # note the distinction between checking for `not select` here `select is None`
+          # later is to handle the case that the given select dictionary is empty, this
+          # is a limitation of our types.
+          if not select:
               root_selection = ['_count { _all }']
           else:
   
@@ -19781,7 +19845,7 @@
           if select is None:
               return cast(int, resp['data']['result']['_count']['_all'])
           else:
-              return resp['data']['result']['_count']
+              return cast(types.OneOptionalCountAggregateOutput, resp['data']['result']['_count'])
   
       def delete_many(
           self,
@@ -19999,38 +20063,42 @@
       @overload
       def count(
           self,
+          select: None = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.ManyRequiredWhereInput] = None,
           cursor: Optional[types.ManyRequiredWhereUniqueInput] = None,
           order: Optional[Union[types.ManyRequiredOrderByInput, List[types.ManyRequiredOrderByInput]]] = None,
-          select: None = None,
       ) -> int:
           ...
   
       @overload
       def count(
           self,
+          select: types.ManyRequiredCountAggregateInput,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.ManyRequiredWhereInput] = None,
           cursor: Optional[types.ManyRequiredWhereUniqueInput] = None,
           order: Optional[Union[types.ManyRequiredOrderByInput, List[types.ManyRequiredOrderByInput]]] = None,
-          select: types.ManyRequiredCountAggregateInput = ...,
       ) -> types.ManyRequiredCountAggregateOutput:
           ...
   
       def count(
           self,
+          select: Optional[types.ManyRequiredCountAggregateInput] = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.ManyRequiredWhereInput] = None,
           cursor: Optional[types.ManyRequiredWhereUniqueInput] = None,
           order: Optional[Union[types.ManyRequiredOrderByInput, List[types.ManyRequiredOrderByInput]]] = None,
-          select: Optional[types.ManyRequiredCountAggregateInput] = None,
       ) -> Union[int, types.ManyRequiredCountAggregateOutput]:
           # TODO: this selection building should be moved to the QueryBuilder
-          if select is None:
+          #
+          # note the distinction between checking for `not select` here `select is None`
+          # later is to handle the case that the given select dictionary is empty, this
+          # is a limitation of our types.
+          if not select:
               root_selection = ['_count { _all }']
           else:
   
@@ -20055,7 +20123,7 @@
           if select is None:
               return cast(int, resp['data']['result']['_count']['_all'])
           else:
-              return resp['data']['result']['_count']
+              return cast(types.ManyRequiredCountAggregateOutput, resp['data']['result']['_count'])
   
       def delete_many(
           self,
@@ -20273,38 +20341,42 @@
       @overload
       def count(
           self,
+          select: None = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.AWhereInput] = None,
           cursor: Optional[types.AWhereUniqueInput] = None,
           order: Optional[Union[types.AOrderByInput, List[types.AOrderByInput]]] = None,
-          select: None = None,
       ) -> int:
           ...
   
       @overload
       def count(
           self,
+          select: types.ACountAggregateInput,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.AWhereInput] = None,
           cursor: Optional[types.AWhereUniqueInput] = None,
           order: Optional[Union[types.AOrderByInput, List[types.AOrderByInput]]] = None,
-          select: types.ACountAggregateInput = ...,
       ) -> types.ACountAggregateOutput:
           ...
   
       def count(
           self,
+          select: Optional[types.ACountAggregateInput] = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.AWhereInput] = None,
           cursor: Optional[types.AWhereUniqueInput] = None,
           order: Optional[Union[types.AOrderByInput, List[types.AOrderByInput]]] = None,
-          select: Optional[types.ACountAggregateInput] = None,
       ) -> Union[int, types.ACountAggregateOutput]:
           # TODO: this selection building should be moved to the QueryBuilder
-          if select is None:
+          #
+          # note the distinction between checking for `not select` here `select is None`
+          # later is to handle the case that the given select dictionary is empty, this
+          # is a limitation of our types.
+          if not select:
               root_selection = ['_count { _all }']
           else:
   
@@ -20329,7 +20401,7 @@
           if select is None:
               return cast(int, resp['data']['result']['_count']['_all'])
           else:
-              return resp['data']['result']['_count']
+              return cast(types.ACountAggregateOutput, resp['data']['result']['_count'])
   
       def delete_many(
           self,
@@ -20547,38 +20619,42 @@
       @overload
       def count(
           self,
+          select: None = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.BWhereInput] = None,
           cursor: Optional[types.BWhereUniqueInput] = None,
           order: Optional[Union[types.BOrderByInput, List[types.BOrderByInput]]] = None,
-          select: None = None,
       ) -> int:
           ...
   
       @overload
       def count(
           self,
+          select: types.BCountAggregateInput,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.BWhereInput] = None,
           cursor: Optional[types.BWhereUniqueInput] = None,
           order: Optional[Union[types.BOrderByInput, List[types.BOrderByInput]]] = None,
-          select: types.BCountAggregateInput = ...,
       ) -> types.BCountAggregateOutput:
           ...
   
       def count(
           self,
+          select: Optional[types.BCountAggregateInput] = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.BWhereInput] = None,
           cursor: Optional[types.BWhereUniqueInput] = None,
           order: Optional[Union[types.BOrderByInput, List[types.BOrderByInput]]] = None,
-          select: Optional[types.BCountAggregateInput] = None,
       ) -> Union[int, types.BCountAggregateOutput]:
           # TODO: this selection building should be moved to the QueryBuilder
-          if select is None:
+          #
+          # note the distinction between checking for `not select` here `select is None`
+          # later is to handle the case that the given select dictionary is empty, this
+          # is a limitation of our types.
+          if not select:
               root_selection = ['_count { _all }']
           else:
   
@@ -20603,7 +20679,7 @@
           if select is None:
               return cast(int, resp['data']['result']['_count']['_all'])
           else:
-              return resp['data']['result']['_count']
+              return cast(types.BCountAggregateOutput, resp['data']['result']['_count'])
   
       def delete_many(
           self,
@@ -20821,38 +20897,42 @@
       @overload
       def count(
           self,
+          select: None = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.CWhereInput] = None,
           cursor: Optional[types.CWhereUniqueInput] = None,
           order: Optional[Union[types.COrderByInput, List[types.COrderByInput]]] = None,
-          select: None = None,
       ) -> int:
           ...
   
       @overload
       def count(
           self,
+          select: types.CCountAggregateInput,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.CWhereInput] = None,
           cursor: Optional[types.CWhereUniqueInput] = None,
           order: Optional[Union[types.COrderByInput, List[types.COrderByInput]]] = None,
-          select: types.CCountAggregateInput = ...,
       ) -> types.CCountAggregateOutput:
           ...
   
       def count(
           self,
+          select: Optional[types.CCountAggregateInput] = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.CWhereInput] = None,
           cursor: Optional[types.CWhereUniqueInput] = None,
           order: Optional[Union[types.COrderByInput, List[types.COrderByInput]]] = None,
-          select: Optional[types.CCountAggregateInput] = None,
       ) -> Union[int, types.CCountAggregateOutput]:
           # TODO: this selection building should be moved to the QueryBuilder
-          if select is None:
+          #
+          # note the distinction between checking for `not select` here `select is None`
+          # later is to handle the case that the given select dictionary is empty, this
+          # is a limitation of our types.
+          if not select:
               root_selection = ['_count { _all }']
           else:
   
@@ -20877,7 +20957,7 @@
           if select is None:
               return cast(int, resp['data']['result']['_count']['_all'])
           else:
-              return resp['data']['result']['_count']
+              return cast(types.CCountAggregateOutput, resp['data']['result']['_count'])
   
       def delete_many(
           self,
@@ -21095,38 +21175,42 @@
       @overload
       def count(
           self,
+          select: None = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.DWhereInput] = None,
           cursor: Optional[types.DWhereUniqueInput] = None,
           order: Optional[Union[types.DOrderByInput, List[types.DOrderByInput]]] = None,
-          select: None = None,
       ) -> int:
           ...
   
       @overload
       def count(
           self,
+          select: types.DCountAggregateInput,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.DWhereInput] = None,
           cursor: Optional[types.DWhereUniqueInput] = None,
           order: Optional[Union[types.DOrderByInput, List[types.DOrderByInput]]] = None,
-          select: types.DCountAggregateInput = ...,
       ) -> types.DCountAggregateOutput:
           ...
   
       def count(
           self,
+          select: Optional[types.DCountAggregateInput] = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.DWhereInput] = None,
           cursor: Optional[types.DWhereUniqueInput] = None,
           order: Optional[Union[types.DOrderByInput, List[types.DOrderByInput]]] = None,
-          select: Optional[types.DCountAggregateInput] = None,
       ) -> Union[int, types.DCountAggregateOutput]:
           # TODO: this selection building should be moved to the QueryBuilder
-          if select is None:
+          #
+          # note the distinction between checking for `not select` here `select is None`
+          # later is to handle the case that the given select dictionary is empty, this
+          # is a limitation of our types.
+          if not select:
               root_selection = ['_count { _all }']
           else:
   
@@ -21151,7 +21235,7 @@
           if select is None:
               return cast(int, resp['data']['result']['_count']['_all'])
           else:
-              return resp['data']['result']['_count']
+              return cast(types.DCountAggregateOutput, resp['data']['result']['_count'])
   
       def delete_many(
           self,
@@ -21369,38 +21453,42 @@
       @overload
       def count(
           self,
+          select: None = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.EWhereInput] = None,
           cursor: Optional[types.EWhereUniqueInput] = None,
           order: Optional[Union[types.EOrderByInput, List[types.EOrderByInput]]] = None,
-          select: None = None,
       ) -> int:
           ...
   
       @overload
       def count(
           self,
+          select: types.ECountAggregateInput,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.EWhereInput] = None,
           cursor: Optional[types.EWhereUniqueInput] = None,
           order: Optional[Union[types.EOrderByInput, List[types.EOrderByInput]]] = None,
-          select: types.ECountAggregateInput = ...,
       ) -> types.ECountAggregateOutput:
           ...
   
       def count(
           self,
+          select: Optional[types.ECountAggregateInput] = None,
           take: Optional[int] = None,
           skip: Optional[int] = None,
           where: Optional[types.EWhereInput] = None,
           cursor: Optional[types.EWhereUniqueInput] = None,
           order: Optional[Union[types.EOrderByInput, List[types.EOrderByInput]]] = None,
-          select: Optional[types.ECountAggregateInput] = None,
       ) -> Union[int, types.ECountAggregateOutput]:
           # TODO: this selection building should be moved to the QueryBuilder
-          if select is None:
+          #
+          # note the distinction between checking for `not select` here `select is None`
+          # later is to handle the case that the given select dictionary is empty, this
+          # is a limitation of our types.
+          if not select:
               root_selection = ['_count { _all }']
           else:
   
@@ -21425,7 +21513,7 @@
           if select is None:
               return cast(int, resp['data']['result']['_count']['_all'])
           else:
-              return resp['data']['result']['_count']
+              return cast(types.ECountAggregateOutput, resp['data']['result']['_count'])
   
       def delete_many(
           self,

--- a/typesafety/mypy/test_mypy.yml
+++ b/typesafety/mypy/test_mypy.yml
@@ -240,3 +240,10 @@
         },
       )
       reveal_type(user.hello)  # N: Revealed type is "builtins.str"
+
+    async def test_count_select(client: Client) -> None:
+      count = await client.post.count()
+      reveal_type(count)  # N: Revealed type is "builtins.int"
+
+      results = await client.post.count(select={'desc': True})
+      reveal_type(results)  # N: Revealed type is "prisma.types.PostCreateInput"

--- a/typesafety/mypy/test_mypy.yml
+++ b/typesafety/mypy/test_mypy.yml
@@ -250,4 +250,4 @@
       results = await client.post.count(select={'desc': True})
       desc_count = results.get('desc')
       if desc_count is not None:
-        reveal_type(desc_count)  # N: Revealed type is "int"
+        reveal_type(desc_count)  # N: Revealed type is "builtins.int"

--- a/typesafety/mypy/test_mypy.yml
+++ b/typesafety/mypy/test_mypy.yml
@@ -243,7 +243,11 @@
 
     async def test_count_select(client: Client) -> None:
       count = await client.post.count()
-      reveal_type(count)  # N: Revealed type is "builtins.int"
+      reveal_type(count)  # N: Revealed type is "builtins.int*"
 
+      # NOTE: we can't just reveal_type(results) as mypy prints an overly verbose type, e.g.
+      # TypedDict('prisma.types.PostCountAggregateOutput', {'id'?: builtins.int})
       results = await client.post.count(select={'desc': True})
-      reveal_type(results)  # N: Revealed type is "prisma.types.PostCreateInput"
+      desc_count = results.get('desc')
+      if desc_count is not None:
+        reveal_type(desc_count)  # N: Revealed type is "int"

--- a/typesafety/pyright/count.py
+++ b/typesafety/pyright/count.py
@@ -1,0 +1,45 @@
+from prisma import Client
+
+
+# TODO: more tests
+
+
+async def main(client: Client) -> None:
+    # case: no arguments
+    total = await client.post.count()
+    reveal_type(total)  # T: int
+
+
+async def select(client: Client) -> None:
+    # case: None
+    total = await client.post.count(select=None)
+    reveal_type(total)  # T: int
+
+    # case: empty
+    count = await client.post.count(select={})
+    reveal_type(count)  # T: PostCountAggregateOutput
+
+    # case: valid fields
+    count = await client.post.count(
+        select={
+            '_all': True,
+            'views': True,
+            'created_at': True,
+            'desc': False,
+        },
+    )
+    reveal_type(count)  # T: PostCountAggregateOutput
+
+    # case: invalid field
+    await client.post.count(
+        select={  # E: Argument of type "dict[str, bool]" cannot be assigned to parameter "select" of type "PostCountAggregateInput" in function "count"
+            'foo': True,
+        },
+    )
+
+    # case: invalid type
+    await client.post.count(
+        select={  # E: Argument of type "dict[str, int]" cannot be assigned to parameter "select" of type "PostCountAggregateInput" in function "count"
+            'author_id': 1,
+        },
+    )


### PR DESCRIPTION
closes #13 

```py
# {'email': 10}
count = await client.user.count(
    select={
        'email': True,
    },
)
```