### PR TITLE
chore: attempt to fix codecov early reports

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,7 @@
 coverage:
+  require_ci_to_pass: yes
+  notify:
+    wait_for_ci: yes
   status:
     project:
       # default is required to exist


### PR DESCRIPTION
Currently, codecov is reporting it's status before all of our CI has passed, this is annoying as it means commits get flagged as failing when they are not.