### PR TITLE
fix(validator): always require typing-extensions

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,4 +4,4 @@ pydantic>=1.8.0
 click>=7.1.2
 python-dotenv>=0.12.0
 contextvars; python_version < '3.7'
-typing-extensions>=3.7; python_version < '3.9'
+typing-extensions>=3.7; python_version < '3.9.2'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,5 +3,5 @@ jinja2>=2.11.2
 pydantic>=1.8.0
 click>=7.1.2
 python-dotenv>=0.12.0
+typing-extensions>=3.7
 contextvars; python_version < '3.7'
-typing-extensions>=3.7; python_version < '3.9.2'

--- a/src/prisma/_types.py
+++ b/src/prisma/_types.py
@@ -1,23 +1,12 @@
-import sys
 from typing import Callable, Coroutine, TypeVar, Any
+from typing_extensions import (
+    TypedDict as TypedDict,
+    Protocol as Protocol,
+    Literal as Literal,
+    runtime_checkable as runtime_checkable,
+)
 
 from pydantic import BaseModel
-
-
-if sys.version_info >= (3, 9, 2):
-    from typing import (  # pylint: disable=no-name-in-module, unused-import
-        TypedDict as TypedDict,
-        Protocol as Protocol,
-        Literal as Literal,
-        runtime_checkable as runtime_checkable,
-    )
-else:
-    from typing_extensions import (
-        TypedDict as TypedDict,
-        Protocol as Protocol,
-        Literal as Literal,
-        runtime_checkable as runtime_checkable,
-    )
 
 
 Method = Literal['GET', 'POST']

--- a/src/prisma/_types.py
+++ b/src/prisma/_types.py
@@ -4,7 +4,7 @@ from typing import Callable, Coroutine, TypeVar, Any
 from pydantic import BaseModel
 
 
-if sys.version_info >= (3, 9):
+if sys.version_info >= (3, 9, 2):
     from typing import (  # pylint: disable=no-name-in-module, unused-import
         TypedDict as TypedDict,
         Protocol as Protocol,

--- a/src/prisma/generator/templates/_header.py.jinja
+++ b/src/prisma/generator/templates/_header.py.jinja
@@ -25,10 +25,6 @@ from typing import (
     overload,
     cast,
 )
-
-if sys.version_info >= (3, 9, 2):
-    from typing import TypedDict, Literal
-else:
-    from typing_extensions import TypedDict, Literal
+from typing_extensions import TypedDict, Literal
 
 

--- a/src/prisma/generator/templates/_header.py.jinja
+++ b/src/prisma/generator/templates/_header.py.jinja
@@ -26,7 +26,7 @@ from typing import (
     cast,
 )
 
-if sys.version_info >= (3, 9):
+if sys.version_info >= (3, 9, 2):
     from typing import TypedDict, Literal
 else:
     from typing_extensions import TypedDict, Literal

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive.ambr
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive.ambr
@@ -28,7 +28,7 @@
       cast,
   )
   
-  if sys.version_info >= (3, 9):
+  if sys.version_info >= (3, 9, 2):
       from typing import TypedDict, Literal
   else:
       from typing_extensions import TypedDict, Literal
@@ -3134,7 +3134,7 @@
       cast,
   )
   
-  if sys.version_info >= (3, 9):
+  if sys.version_info >= (3, 9, 2):
       from typing import TypedDict, Literal
   else:
       from typing_extensions import TypedDict, Literal
@@ -3988,7 +3988,7 @@
       cast,
   )
   
-  if sys.version_info >= (3, 9):
+  if sys.version_info >= (3, 9, 2):
       from typing import TypedDict, Literal
   else:
       from typing_extensions import TypedDict, Literal
@@ -5788,7 +5788,7 @@
       cast,
   )
   
-  if sys.version_info >= (3, 9):
+  if sys.version_info >= (3, 9, 2):
       from typing import TypedDict, Literal
   else:
       from typing_extensions import TypedDict, Literal
@@ -6026,7 +6026,7 @@
       cast,
   )
   
-  if sys.version_info >= (3, 9):
+  if sys.version_info >= (3, 9, 2):
       from typing import TypedDict, Literal
   else:
       from typing_extensions import TypedDict, Literal
@@ -6073,7 +6073,7 @@
       cast,
   )
   
-  if sys.version_info >= (3, 9):
+  if sys.version_info >= (3, 9, 2):
       from typing import TypedDict, Literal
   else:
       from typing_extensions import TypedDict, Literal
@@ -6221,7 +6221,7 @@
       cast,
   )
   
-  if sys.version_info >= (3, 9):
+  if sys.version_info >= (3, 9, 2):
       from typing import TypedDict, Literal
   else:
       from typing_extensions import TypedDict, Literal
@@ -6265,7 +6265,7 @@
       cast,
   )
   
-  if sys.version_info >= (3, 9):
+  if sys.version_info >= (3, 9, 2):
       from typing import TypedDict, Literal
   else:
       from typing_extensions import TypedDict, Literal
@@ -8176,7 +8176,7 @@
       cast,
   )
   
-  if sys.version_info >= (3, 9):
+  if sys.version_info >= (3, 9, 2):
       from typing import TypedDict, Literal
   else:
       from typing_extensions import TypedDict, Literal
@@ -8226,7 +8226,7 @@
       cast,
   )
   
-  if sys.version_info >= (3, 9):
+  if sys.version_info >= (3, 9, 2):
       from typing import TypedDict, Literal
   else:
       from typing_extensions import TypedDict, Literal
@@ -18649,7 +18649,7 @@
       cast,
   )
   
-  if sys.version_info >= (3, 9):
+  if sys.version_info >= (3, 9, 2):
       from typing import TypedDict, Literal
   else:
       from typing_extensions import TypedDict, Literal
@@ -21755,7 +21755,7 @@
       cast,
   )
   
-  if sys.version_info >= (3, 9):
+  if sys.version_info >= (3, 9, 2):
       from typing import TypedDict, Literal
   else:
       from typing_extensions import TypedDict, Literal
@@ -22609,7 +22609,7 @@
       cast,
   )
   
-  if sys.version_info >= (3, 9):
+  if sys.version_info >= (3, 9, 2):
       from typing import TypedDict, Literal
   else:
       from typing_extensions import TypedDict, Literal
@@ -24409,7 +24409,7 @@
       cast,
   )
   
-  if sys.version_info >= (3, 9):
+  if sys.version_info >= (3, 9, 2):
       from typing import TypedDict, Literal
   else:
       from typing_extensions import TypedDict, Literal
@@ -24640,7 +24640,7 @@
       cast,
   )
   
-  if sys.version_info >= (3, 9):
+  if sys.version_info >= (3, 9, 2):
       from typing import TypedDict, Literal
   else:
       from typing_extensions import TypedDict, Literal
@@ -24687,7 +24687,7 @@
       cast,
   )
   
-  if sys.version_info >= (3, 9):
+  if sys.version_info >= (3, 9, 2):
       from typing import TypedDict, Literal
   else:
       from typing_extensions import TypedDict, Literal
@@ -24835,7 +24835,7 @@
       cast,
   )
   
-  if sys.version_info >= (3, 9):
+  if sys.version_info >= (3, 9, 2):
       from typing import TypedDict, Literal
   else:
       from typing_extensions import TypedDict, Literal
@@ -24879,7 +24879,7 @@
       cast,
   )
   
-  if sys.version_info >= (3, 9):
+  if sys.version_info >= (3, 9, 2):
       from typing import TypedDict, Literal
   else:
       from typing_extensions import TypedDict, Literal
@@ -26790,7 +26790,7 @@
       cast,
   )
   
-  if sys.version_info >= (3, 9):
+  if sys.version_info >= (3, 9, 2):
       from typing import TypedDict, Literal
   else:
       from typing_extensions import TypedDict, Literal
@@ -26840,7 +26840,7 @@
       cast,
   )
   
-  if sys.version_info >= (3, 9):
+  if sys.version_info >= (3, 9, 2):
       from typing import TypedDict, Literal
   else:
       from typing_extensions import TypedDict, Literal

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive.ambr
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive.ambr
@@ -27,11 +27,7 @@
       overload,
       cast,
   )
-  
-  if sys.version_info >= (3, 9, 2):
-      from typing import TypedDict, Literal
-  else:
-      from typing_extensions import TypedDict, Literal
+  from typing_extensions import TypedDict, Literal
   
   # -- template actions.py.jinja --
   from . import types, errors
@@ -3133,11 +3129,7 @@
       overload,
       cast,
   )
-  
-  if sys.version_info >= (3, 9, 2):
-      from typing import TypedDict, Literal
-  else:
-      from typing_extensions import TypedDict, Literal
+  from typing_extensions import TypedDict, Literal
   
   # -- template builder.py.jinja --
   
@@ -3987,11 +3979,7 @@
       overload,
       cast,
   )
-  
-  if sys.version_info >= (3, 9, 2):
-      from typing import TypedDict, Literal
-  else:
-      from typing_extensions import TypedDict, Literal
+  from typing_extensions import TypedDict, Literal
   
   # -- template client.py.jinja --
   from types import TracebackType
@@ -5787,11 +5775,7 @@
       overload,
       cast,
   )
-  
-  if sys.version_info >= (3, 9, 2):
-      from typing import TypedDict, Literal
-  else:
-      from typing_extensions import TypedDict, Literal
+  from typing_extensions import TypedDict, Literal
   
   # -- template engine/query.py.jinja --
   
@@ -6025,11 +6009,7 @@
       overload,
       cast,
   )
-  
-  if sys.version_info >= (3, 9, 2):
-      from typing import TypedDict, Literal
-  else:
-      from typing_extensions import TypedDict, Literal
+  from typing_extensions import TypedDict, Literal
   
   # -- template enums.py.jinja --
   from enum import Enum
@@ -6072,11 +6052,7 @@
       overload,
       cast,
   )
-  
-  if sys.version_info >= (3, 9, 2):
-      from typing import TypedDict, Literal
-  else:
-      from typing_extensions import TypedDict, Literal
+  from typing_extensions import TypedDict, Literal
   
   # -- template fields.py.jinja --
   import base64
@@ -6220,11 +6196,7 @@
       overload,
       cast,
   )
-  
-  if sys.version_info >= (3, 9, 2):
-      from typing import TypedDict, Literal
-  else:
-      from typing_extensions import TypedDict, Literal
+  from typing_extensions import TypedDict, Literal
   
   # -- template http.py.jinja --
   from ._async_http import (
@@ -6264,11 +6236,7 @@
       overload,
       cast,
   )
-  
-  if sys.version_info >= (3, 9, 2):
-      from typing import TypedDict, Literal
-  else:
-      from typing_extensions import TypedDict, Literal
+  from typing_extensions import TypedDict, Literal
   
   # -- template models.py.jinja --
   import os
@@ -8175,11 +8143,7 @@
       overload,
       cast,
   )
-  
-  if sys.version_info >= (3, 9, 2):
-      from typing import TypedDict, Literal
-  else:
-      from typing_extensions import TypedDict, Literal
+  from typing_extensions import TypedDict, Literal
   
   # -- template partials.py.jinja --
   from pydantic import BaseModel, Field, validator
@@ -8225,11 +8189,7 @@
       overload,
       cast,
   )
-  
-  if sys.version_info >= (3, 9, 2):
-      from typing import TypedDict, Literal
-  else:
-      from typing_extensions import TypedDict, Literal
+  from typing_extensions import TypedDict, Literal
   
   # -- template types.py.jinja --
   from .utils import _NoneType
@@ -18648,11 +18608,7 @@
       overload,
       cast,
   )
-  
-  if sys.version_info >= (3, 9, 2):
-      from typing import TypedDict, Literal
-  else:
-      from typing_extensions import TypedDict, Literal
+  from typing_extensions import TypedDict, Literal
   
   # -- template actions.py.jinja --
   from . import types, errors
@@ -21754,11 +21710,7 @@
       overload,
       cast,
   )
-  
-  if sys.version_info >= (3, 9, 2):
-      from typing import TypedDict, Literal
-  else:
-      from typing_extensions import TypedDict, Literal
+  from typing_extensions import TypedDict, Literal
   
   # -- template builder.py.jinja --
   
@@ -22608,11 +22560,7 @@
       overload,
       cast,
   )
-  
-  if sys.version_info >= (3, 9, 2):
-      from typing import TypedDict, Literal
-  else:
-      from typing_extensions import TypedDict, Literal
+  from typing_extensions import TypedDict, Literal
   
   # -- template client.py.jinja --
   from types import TracebackType
@@ -24408,11 +24356,7 @@
       overload,
       cast,
   )
-  
-  if sys.version_info >= (3, 9, 2):
-      from typing import TypedDict, Literal
-  else:
-      from typing_extensions import TypedDict, Literal
+  from typing_extensions import TypedDict, Literal
   
   # -- template engine/query.py.jinja --
   
@@ -24639,11 +24583,7 @@
       overload,
       cast,
   )
-  
-  if sys.version_info >= (3, 9, 2):
-      from typing import TypedDict, Literal
-  else:
-      from typing_extensions import TypedDict, Literal
+  from typing_extensions import TypedDict, Literal
   
   # -- template enums.py.jinja --
   from enum import Enum
@@ -24686,11 +24626,7 @@
       overload,
       cast,
   )
-  
-  if sys.version_info >= (3, 9, 2):
-      from typing import TypedDict, Literal
-  else:
-      from typing_extensions import TypedDict, Literal
+  from typing_extensions import TypedDict, Literal
   
   # -- template fields.py.jinja --
   import base64
@@ -24834,11 +24770,7 @@
       overload,
       cast,
   )
-  
-  if sys.version_info >= (3, 9, 2):
-      from typing import TypedDict, Literal
-  else:
-      from typing_extensions import TypedDict, Literal
+  from typing_extensions import TypedDict, Literal
   
   # -- template http.py.jinja --
   from ._sync_http import (
@@ -24878,11 +24810,7 @@
       overload,
       cast,
   )
-  
-  if sys.version_info >= (3, 9, 2):
-      from typing import TypedDict, Literal
-  else:
-      from typing_extensions import TypedDict, Literal
+  from typing_extensions import TypedDict, Literal
   
   # -- template models.py.jinja --
   import os
@@ -26789,11 +26717,7 @@
       overload,
       cast,
   )
-  
-  if sys.version_info >= (3, 9, 2):
-      from typing import TypedDict, Literal
-  else:
-      from typing_extensions import TypedDict, Literal
+  from typing_extensions import TypedDict, Literal
   
   # -- template partials.py.jinja --
   from pydantic import BaseModel, Field, validator
@@ -26839,11 +26763,7 @@
       overload,
       cast,
   )
-  
-  if sys.version_info >= (3, 9, 2):
-      from typing import TypedDict, Literal
-  else:
-      from typing_extensions import TypedDict, Literal
+  from typing_extensions import TypedDict, Literal
   
   # -- template types.py.jinja --
   from .utils import _NoneType


### PR DESCRIPTION
fixes #114 

On Python 3.9.0 and Python 3.9.1, `typing.TypedDict` does not correctly hold the `__required_keys__` and `__optional_keys__` attributes, the fix (https://github.com/python/cpython/pull/22736) for this issue was merged on 10/12/2020 and Python 3.9.1 was released on 8/12/2020, as such, the minimum Python version that does not require the use of `typing-extensions` is Python 3.9.2

However, writing our imports this way breaks mypy, reporting 1651 errors :)