### PR TITLE
fix(generator): make the generator provider optional

### DIFF
--- a/src/prisma/generator/models.py
+++ b/src/prisma/generator/models.py
@@ -188,7 +188,7 @@ class Datasource(BaseModel):
 class Generator(BaseModel):
     name: str
     output: 'ValueFromEnvVar'
-    provider: 'ValueFromEnvVar'
+    provider: 'OptionalValueFromEnvVar'
     config: 'Config'
     binary_targets: List['ValueFromEnvVar'] = FieldInfo(alias='binaryTargets')
     preview_features: List[str] = FieldInfo(alias='previewFeatures')


### PR DESCRIPTION
For some reason Prisma is sending a generator with no provider value, we actually don't use this anywhere so it's safe to just make it `Optional`.

closes #120 