### PR TITLE
feat(fields): add support for comparing Bytes field instances

### DIFF
--- a/src/prisma/generator/templates/fields.py.jinja
+++ b/src/prisma/generator/templates/fields.py.jinja
@@ -105,6 +105,12 @@ class Base64:
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}({self._raw})'  # type: ignore[str-bytes-safe]
 
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, Base64):
+            return self._raw == other._raw
+
+        return False
+
     @classmethod
     def _internal_from_prisma(cls, value: str) -> 'Base64':
         return cls(bytes(value, BASE64_ENCODING))

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,0 +1,9 @@
+from prisma import Base64
+
+
+def test_base64_eq() -> None:
+    """Base64 field instances can be compared"""
+    data = Base64.encode(b'foo')
+    assert (data == Base64.encode(b'foo')) is True
+    assert (data == Base64.encode(b'foo1')) is False
+    assert (data == b'foo') is False

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive.ambr
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive.ambr
@@ -6152,6 +6152,12 @@
       def __repr__(self) -> str:
           return f'{self.__class__.__name__}({self._raw})'  # type: ignore[str-bytes-safe]
   
+      def __eq__(self, other: Any) -> bool:
+          if isinstance(other, Base64):
+              return self._raw == other._raw
+  
+          return False
+  
       @classmethod
       def _internal_from_prisma(cls, value: str) -> 'Base64':
           return cls(bytes(value, BASE64_ENCODING))
@@ -24722,6 +24728,12 @@
   
       def __repr__(self) -> str:
           return f'{self.__class__.__name__}({self._raw})'  # type: ignore[str-bytes-safe]
+  
+      def __eq__(self, other: Any) -> bool:
+          if isinstance(other, Base64):
+              return self._raw == other._raw
+  
+          return False
   
       @classmethod
       def _internal_from_prisma(cls, value: str) -> 'Base64':


### PR DESCRIPTION
Support for:

```py
from prisma import Base64

assert Base64.encode(b'foo') == Base64.encode(b'foo')
```