### PR TITLE
feat(http): explicitly check status before downloading

### DIFF
--- a/src/prisma/_async_http.py
+++ b/src/prisma/_async_http.py
@@ -21,6 +21,7 @@ class HTTP(AbstractHTTP[httpx.AsyncClient, httpx.Response]):
         async with self.session.stream(
             'GET', url, timeout=None
         ) as resp:  # pyright: reportGeneralTypeIssues=false
+            resp.raise_for_status()
             with open(dest, 'wb') as fd:
                 async for chunk in resp.aiter_bytes():
                     fd.write(chunk)

--- a/src/prisma/_sync_http.py
+++ b/src/prisma/_sync_http.py
@@ -16,6 +16,7 @@ class HTTP(AbstractHTTP[httpx.Client, httpx.Response]):
 
     def download(self, url: str, dest: str) -> None:
         with self.session.stream('GET', url, timeout=None) as resp:
+            resp.raise_for_status()
             with open(dest, 'wb') as fd:
                 for chunk in resp.iter_bytes():
                     fd.write(chunk)


### PR DESCRIPTION
Not explicitly checking the status would lead to confusing errors when binaries could not be downloaded.

```
$ prisma py fetch
Downloading binaries  [------------------------------------]    0%  prisma-cli-darwin
Traceback (most recent call last):
  File "/prisma-client-py/.venv/bin/prisma", line 33, in <module>
    sys.exit(load_entry_point('prisma', 'console_scripts', 'prisma')())
  File "/prisma-client-py/src/prisma/cli/cli.py", line 36, in main
    cli.main(args[2:], prog_name='prisma py')
  File "/prisma-client-py/.venv/lib/python3.9/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/prisma-client-py/.venv/lib/python3.9/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/prisma-client-py/.venv/lib/python3.9/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/prisma-client-py/.venv/lib/python3.9/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/prisma-client-py/src/prisma/cli/commands/fetch.py", line 17, in cli
    directory = binaries.ensure_cached()
  File "/prisma-client-py/src/prisma/binaries/binaries.py", line 62, in ensure_cached
    binary.download()
  File "/prisma-client-py/src/prisma/binaries/binary.py", line 28, in download
    download(url, str(dest.absolute()))
  File "/prisma-client-py/src/prisma/binaries/utils.py", line 20, in download
    shutil.copyfileobj(f_in, f_out)
  File "/usr/local/Cellar/python@3.9/3.9.1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/shutil.py", line 205, in copyfileobj
    buf = fsrc_read(length)
  File "/usr/local/Cellar/python@3.9/3.9.1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/gzip.py", line 300, in read
    return self._buffer.read(size)
  File "/usr/local/Cellar/python@3.9/3.9.1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/_compression.py", line 68, in readinto
    data = self.read(len(byte_view))
  File "/usr/local/Cellar/python@3.9/3.9.1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/gzip.py", line 487, in read
    if not self._read_gzip_header():
  File "/usr/local/Cellar/python@3.9/3.9.1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/gzip.py", line 435, in _read_gzip_header
    raise BadGzipFile('Not a gzipped file (%r)' % magic)
gzip.BadGzipFile: Not a gzipped file (b'<?')
```