### PR TITLE
feat(models): support manually constructing models with bytes fields

### DIFF
--- a/src/prisma/generator/templates/fields.py.jinja
+++ b/src/prisma/generator/templates/fields.py.jinja
@@ -112,9 +112,21 @@ class Base64:
         return False
 
     @classmethod
-    def _internal_from_prisma(cls, value: Union[str, List[str]]) -> Union['Base64', List['Base64']]:
+    def _internal_from_prisma(
+        cls,
+        value: Union[str, 'Base64', List[Union[str, 'Base64']]]
+    ) -> Union['Base64', List['Base64']]:
+        if isinstance(value, Base64):
+            return value
+
         if isinstance(value, list):
-            return [cls(bytes(item, BASE64_ENCODING)) for item in value]
+            return [
+                item
+                if isinstance(item, Base64)
+                else
+                cls(bytes(item, BASE64_ENCODING))
+                for item in value
+            ]
 
         return cls(bytes(value, BASE64_ENCODING))
 

--- a/tests/integrations/postgresql/tests/test_arrays.py
+++ b/tests/integrations/postgresql/tests/test_arrays.py
@@ -4,6 +4,7 @@ from typing import Any, List
 import pytest
 from prisma import Client, Json, Base64
 from prisma.enums import Role
+from prisma.models import Lists
 
 
 def _utcnow() -> datetime:
@@ -1502,3 +1503,19 @@ async def test_filtering_enums(client: Client) -> None:
         },
     )
     assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_bytes_constructing(client: Client) -> None:
+    """A list of Base64 fields can be passed to the model constructor"""
+    record = await client.lists.create({})
+    model = Lists.parse_obj(
+        {
+            **record.dict(),
+            'bytes': [
+                Base64.encode(b'foo'),
+                Base64.encode(b'bar'),
+            ],
+        }
+    )
+    assert model.bytes == [Base64.encode(b'foo'), Base64.encode(b'bar')]

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive.ambr
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive.ambr
@@ -6586,9 +6586,21 @@
           return False
   
       @classmethod
-      def _internal_from_prisma(cls, value: Union[str, List[str]]) -> Union['Base64', List['Base64']]:
+      def _internal_from_prisma(
+          cls,
+          value: Union[str, 'Base64', List[Union[str, 'Base64']]]
+      ) -> Union['Base64', List['Base64']]:
+          if isinstance(value, Base64):
+              return value
+  
           if isinstance(value, list):
-              return [cls(bytes(item, BASE64_ENCODING)) for item in value]
+              return [
+                  item
+                  if isinstance(item, Base64)
+                  else
+                  cls(bytes(item, BASE64_ENCODING))
+                  for item in value
+              ]
   
           return cls(bytes(value, BASE64_ENCODING))
   
@@ -27746,9 +27758,21 @@
           return False
   
       @classmethod
-      def _internal_from_prisma(cls, value: Union[str, List[str]]) -> Union['Base64', List['Base64']]:
+      def _internal_from_prisma(
+          cls,
+          value: Union[str, 'Base64', List[Union[str, 'Base64']]]
+      ) -> Union['Base64', List['Base64']]:
+          if isinstance(value, Base64):
+              return value
+  
           if isinstance(value, list):
-              return [cls(bytes(item, BASE64_ENCODING)) for item in value]
+              return [
+                  item
+                  if isinstance(item, Base64)
+                  else
+                  cls(bytes(item, BASE64_ENCODING))
+                  for item in value
+              ]
   
           return cls(bytes(value, BASE64_ENCODING))
   

--- a/tests/test_types/test_bytes.py
+++ b/tests/test_types/test_bytes.py
@@ -62,3 +62,16 @@ async def test_json(client: Client) -> None:
     model = Types.parse_raw(record.json())
     assert isinstance(model.bytes, Base64)
     assert model.bytes.decode() == b'foo'
+
+
+@pytest.mark.asyncio
+async def test_constructing(client: Client) -> None:
+    """Base64 fields can be passed to the model constructor"""
+    record = await client.types.create({})
+    model = Types.parse_obj(
+        {
+            **record.dict(),
+            'bytes': Base64.encode(b'foo'),
+        },
+    )
+    assert model.bytes == Base64.encode(b'foo')


### PR DESCRIPTION
This shouldn't really be used by consumers of this library, however
for correctness sake we should support this