### PR TITLE
refactor(tests): tests must be explicitly marked for model-based access

### DIFF
--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -143,6 +143,19 @@ async def test_example(client: Client) -> None:
     ...
 ```
 
+If the test you are writing makes use of model-based access then you must mark the test like so:
+
+```py
+import pytest
+
+@pytest.mark.prisma
+@pytest.mark.asyncio
+async def test_example() -> None:
+    """Test docstring"""
+    ...
+```
+
+
 The tests can then be ran with tox, e.g.
 
 ```sh

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 markers =
-  persist_data: Marker for signifying that data should not be cleared on teardown.
+  persist_data: Signifies that data should not be cleared between test runs.
+  prisma: This marker must be used to enable model-based access.
 
 # NOTE: this is required to stop pytest from loading conftest.py files
 # for our integration tests, as pytest eagerly loads conftests backwards

--- a/src/prisma/testing.py
+++ b/src/prisma/testing.py
@@ -1,12 +1,13 @@
 import contextlib
-from typing import Iterator
+from typing import Iterator, Optional
 
 from . import client as _client
+from .client import RegisteredClient
 from .errors import ClientNotRegisteredError
 
 
 @contextlib.contextmanager
-def reset_client() -> Iterator[None]:
+def reset_client(new_client: Optional[RegisteredClient] = None) -> Iterator[None]:
     """Context manager to unregister the current client
 
     Once the context manager exits, the registered client is set back to it's original state
@@ -17,7 +18,7 @@ def reset_client() -> Iterator[None]:
         raise ClientNotRegisteredError()
 
     try:
-        _client._registered_client = None
+        _client._registered_client = new_client
         yield
     finally:
         _client._registered_client = client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,7 +86,7 @@ def patch_prisma_fixture(request: 'FixtureRequest') -> Iterator[None]:
         def _disable_access() -> None:
             raise RuntimeError(
                 'Tests that access the prisma client must be decorated with: '
-                '@pytest.mark.prisma '
+                '@pytest.mark.prisma'
             )
 
         with reset_client(_disable_access):  # type: ignore

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import pytest
 import prisma
 from prisma import Client
 from prisma.cli import setup_logging
+from prisma.testing import reset_client
 from prisma.utils import get_or_create_event_loop
 
 from .utils import Runner, Testdir
@@ -76,23 +77,43 @@ def pytest_collection_modifyitems(
     items.sort(key=lambda item: item.__class__.__name__ == 'IntegrationTestItem')
 
 
-@pytest.fixture(name='cleanup_client', autouse=True)
-async def cleanup_client_fixture(request: 'FixtureRequest', client: Client) -> None:
-    if not client.is_connected():  # pragma: no cover
-        await client.connect()
+@pytest.fixture(autouse=True)
+def patch_prisma_fixture(request: 'FixtureRequest') -> Iterator[None]:
+    if request_has_client(request):
+        return
+
+    def _disable_access() -> None:
+        raise RuntimeError(
+            'Tests that access the prisma client must be decorated with: '
+            '@pytest.mark.prisma '
+        )
+
+    with reset_client(_disable_access):  # type: ignore
+        yield
+
+
+@pytest.fixture(name='setup_client', autouse=True)
+async def setup_client_fixture(request: 'FixtureRequest') -> None:
+    if not request_has_client(request):
+        return
 
     item = request.node
-    if not isinstance(item, pytest.Item) or marked_persist_data(item):
+    if item.get_closest_marker('persist_data') is not None:
         return
+
+    client = prisma.get_client()
+    if not client.is_connected():  # pragma: no cover
+        await client.connect()
 
     await cleanup_client(client)
 
 
-def marked_persist_data(item: pytest.Item) -> bool:
-    for marker in item.iter_markers():
-        if marker.name == 'persist_data':
-            return True
-    return False
+def request_has_client(request: 'FixtureRequest') -> bool:
+    """Return whether or not the current request uses the prisma client"""
+    return (
+        request.node.get_closest_marker('prisma') is not None
+        or 'client' in request.fixturenames
+    )
 
 
 async def cleanup_client(client: Client) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,19 +77,20 @@ def pytest_collection_modifyitems(
     items.sort(key=lambda item: item.__class__.__name__ == 'IntegrationTestItem')
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(name='patch_prisma', autouse=True)
 def patch_prisma_fixture(request: 'FixtureRequest') -> Iterator[None]:
     if request_has_client(request):
-        return
-
-    def _disable_access() -> None:
-        raise RuntimeError(
-            'Tests that access the prisma client must be decorated with: '
-            '@pytest.mark.prisma '
-        )
-
-    with reset_client(_disable_access):  # type: ignore
         yield
+    else:
+
+        def _disable_access() -> None:
+            raise RuntimeError(
+                'Tests that access the prisma client must be decorated with: '
+                '@pytest.mark.prisma '
+            )
+
+        with reset_client(_disable_access):  # type: ignore
+            yield
 
 
 @pytest.fixture(name='setup_client', autouse=True)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -43,3 +43,12 @@ async def test_logs_sql_queries(testdir: Testdir) -> None:
         await client.disconnect()
 
     assert 'SELECT `main`.`User`.`id' in file.read_text()
+
+
+@pytest.mark.asyncio
+async def test_unmarked_test_disallowed_client() -> None:
+    """Test case that isn't marked with @pytest.mark.prisma cannot access the client"""
+    with pytest.raises(RuntimeError) as exc:
+        await User.prisma().create({'name': 'Robert'})
+
+    assert '@pytest.mark.prisma' in exc.value.args[0]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,6 +12,7 @@ async def create_user() -> User:
     return user
 
 
+@pytest.mark.prisma
 @pytest.mark.asyncio
 async def test_create() -> None:
     """Creating a record using model-based access"""
@@ -39,6 +40,7 @@ async def test_create() -> None:
     assert user.posts[0].title == 'My first post!'
 
 
+@pytest.mark.prisma
 @pytest.mark.asyncio
 async def test_delete() -> None:
     """Deleting a record using model-based access"""
@@ -61,6 +63,7 @@ async def test_delete() -> None:
     assert deleted2.name == 'Robert'
 
 
+@pytest.mark.prisma
 @pytest.mark.asyncio
 async def test_find_unique() -> None:
     """Finding a unique record using model-based access"""
@@ -81,6 +84,7 @@ async def test_find_unique() -> None:
     assert found.name == 'Robert'
 
 
+@pytest.mark.prisma
 @pytest.mark.asyncio
 async def test_find_many() -> None:
     """Finding many records using model-based access"""
@@ -105,6 +109,7 @@ async def test_find_many() -> None:
     assert found[1].id == users[1].id
 
 
+@pytest.mark.prisma
 @pytest.mark.asyncio
 async def test_find_first() -> None:
     """Finding a record using model-based access"""
@@ -118,6 +123,7 @@ async def test_find_first() -> None:
     assert found.name == 'Robert'
 
 
+@pytest.mark.prisma
 @pytest.mark.asyncio
 async def test_update() -> None:
     """Updating a record using model-based access"""
@@ -137,6 +143,7 @@ async def test_update() -> None:
     assert updated.name == 'Tegan'
 
 
+@pytest.mark.prisma
 @pytest.mark.asyncio
 async def test_upsert() -> None:
     """Upserting a record using model-based access"""
@@ -157,6 +164,7 @@ async def test_upsert() -> None:
     assert new.name == 'Robert 2'
 
 
+@pytest.mark.prisma
 @pytest.mark.asyncio
 async def test_update_many() -> None:
     """Updating many records using model-based access"""
@@ -195,6 +203,7 @@ async def test_update_many() -> None:
     assert user.name == 'Tegan'
 
 
+@pytest.mark.prisma
 @pytest.mark.asyncio
 async def test_count() -> None:
     """Counting records using model-based access"""
@@ -206,6 +215,7 @@ async def test_count() -> None:
     assert total == 0
 
 
+@pytest.mark.prisma
 @pytest.mark.asyncio
 async def test_delete_many() -> None:
     """Deleting many records using model-based access"""
@@ -223,6 +233,7 @@ async def test_delete_many() -> None:
     assert await User.prisma().count() == 2
 
 
+@pytest.mark.prisma
 @pytest.mark.asyncio
 async def test_query_raw() -> None:
     """Ensure results are transformed to the expected BaseModel"""
@@ -237,6 +248,7 @@ async def test_query_raw() -> None:
     assert results[0].name == 'Tegan'
 
 
+@pytest.mark.prisma
 @pytest.mark.asyncio
 async def test_query_first() -> None:
     """Ensure results are transformed to the expected BaseModel"""

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -4,6 +4,7 @@ from prisma import Client, register, get_client
 from prisma.testing import reset_client
 
 
+@pytest.mark.prisma
 def test_reset_client() -> None:
     """Resetting and re-registering the registered client works as expected"""
     original = get_client()


### PR DESCRIPTION
this is done to reduce redundant database cleanup