### PR TITLE
chore(types): fix type completeness errors

### DIFF
--- a/src/prisma/_compat.py
+++ b/src/prisma/_compat.py
@@ -1,4 +1,8 @@
 import sys
+from typing import TYPE_CHECKING, Callable
+
+from ._types import CallableT
+
 
 if sys.version_info[:2] == (3, 6):
     # as far as I am aware the semantics of this are the same
@@ -7,4 +11,40 @@ if sys.version_info[:2] == (3, 6):
 else:
     from asyncio import (  # pylint: disable=no-name-in-module
         get_running_loop as get_running_loop,
+    )
+
+
+if TYPE_CHECKING:
+    # in pyright >= 1.190 classmethod is a generic type, this causes errors when
+    # verifying type completeness as pydantic validators are typed to return a
+    # classmethod without any generic parameters.
+    # we fix these errors by overriding the typing of these validator functions
+    # to simply return the callable back unchanged.
+
+    def root_validator(
+        # pylint: disable=unused-argument
+        *,
+        pre: bool = False,
+        allow_reuse: bool = False,
+        skip_on_failure: bool = False,
+    ) -> Callable[[CallableT], CallableT]:
+        ...
+
+    def validator(
+        # pylint: disable=unused-argument
+        *fields: str,
+        pre: bool = ...,
+        each_item: bool = ...,
+        always: bool = ...,
+        check_fields: bool = ...,
+        whole: bool = ...,
+        allow_reuse: bool = ...,
+    ) -> Callable[[CallableT], CallableT]:
+        ...
+
+
+else:
+    from pydantic import (
+        validator as validator,
+        root_validator as root_validator,
     )

--- a/src/prisma/_types.py
+++ b/src/prisma/_types.py
@@ -11,8 +11,9 @@ from pydantic import BaseModel
 
 Method = Literal['GET', 'POST']
 
+CallableT = TypeVar('CallableT', bound='FuncType')
 BaseModelT = TypeVar('BaseModelT', bound=BaseModel)
 
-# TODO: use a TypeVar
+# TODO: use a TypeVar everywhere
 FuncType = Callable[..., Any]
 CoroType = Callable[..., Coroutine[Any, Any, Any]]

--- a/src/prisma/generator/models.py
+++ b/src/prisma/generator/models.py
@@ -28,8 +28,6 @@ from pydantic import (
     BaseSettings,
     Extra,
     Field as FieldInfo,
-    validator,
-    root_validator,
 )
 from pydantic.fields import PrivateAttr
 
@@ -41,6 +39,7 @@ except ImportError:
 
 from .utils import Faker, Sampler, clean_multiline
 from ..utils import DEBUG_GENERATOR
+from .._compat import validator, root_validator
 from .._constants import QUERY_BUILDER_ALIASES
 from ..errors import UnsupportedListTypeError
 from ..binaries.constants import ENGINE_VERSION
@@ -514,7 +513,7 @@ class Field(BaseModel):
 
     _last_sampled: Optional[str] = PrivateAttr()
 
-    @root_validator
+    @root_validator()
     @classmethod
     def scalar_type_validator(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         kind = values.get('kind')

--- a/src/prisma/generator/schema.py
+++ b/src/prisma/generator/schema.py
@@ -2,9 +2,9 @@ from enum import Enum
 from typing import Any, Dict, List, Union
 
 from pydantic import BaseModel
-from pydantic.class_validators import root_validator
 
 from .models import Data, Model as ModelInfo, PrimaryKey
+from .._compat import root_validator
 
 
 class Kind(str, Enum):


### PR DESCRIPTION
Comment copy pasted for context:

```
# in pyright >= 1.190 classmethod is a generic type, this causes errors when
# verifying type completeness as pydantic validators are typed to return a
# classmethod without any generic parameters.
# we fix these errors by overriding the typing of these validator functions
# to simply return the callable back unchanged.
```