### PR TITLE
feat(client): expose client engine type

### DIFF
--- a/src/prisma/generator/models.py
+++ b/src/prisma/generator/models.py
@@ -372,7 +372,8 @@ class Config(BaseSettings):
                 'Prisma Client Python does not support native engine bindings yet.'
             )
         else:  # pragma: no cover
-            assert_never(value)
+            # NOTE: the exhaustiveness check is broken for mypy
+            assert_never(value)  # type: ignore
 
 
 class DMMF(BaseModel):

--- a/src/prisma/generator/models.py
+++ b/src/prisma/generator/models.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import enum
 import importlib
@@ -38,7 +39,7 @@ except ImportError:
 
 
 from .utils import Faker, Sampler, clean_multiline
-from ..utils import DEBUG_GENERATOR
+from ..utils import DEBUG_GENERATOR, assert_never
 from .._compat import validator, root_validator
 from .._constants import QUERY_BUILDER_ALIASES
 from ..errors import UnsupportedListTypeError
@@ -125,6 +126,12 @@ class BaseModel(PydanticBaseModel):
 class InterfaceChoices(str, enum.Enum):
     sync = 'sync'
     asyncio = 'asyncio'
+
+
+class EngineType(str, enum.Enum):
+    binary = 'binary'
+    library = 'library'
+    dataproxy = 'dataproxy'
 
 
 class Module(BaseModel):
@@ -278,6 +285,7 @@ class Config(BaseSettings):
     interface: InterfaceChoices = InterfaceChoices.asyncio
     partial_type_generator: Optional[Module]
     recursive_type_depth: int = FieldInfo(default=5)
+    engine_type: EngineType = FieldInfo(default=EngineType.binary)
 
     class Config(BaseSettings.Config):
         extra: Extra = Extra.forbid
@@ -294,6 +302,21 @@ class Config(BaseSettings):
         ) -> Tuple[SettingsSourceCallable, ...]:
             # prioritise env settings over init settings
             return env_settings, init_settings, file_secret_settings
+
+    @root_validator(pre=True)
+    @classmethod
+    def transform_engine_type(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        # prioritise env variable over schema option
+        engine_type = os.environ.get('PRISMA_CLIENT_ENGINE_TYPE')
+        if engine_type is None:
+            engine_type = values.get('engineType')
+
+        # only add engine_type if it is present
+        if engine_type is not None:
+            values['engine_type'] = engine_type
+            values.pop('engineType', None)
+
+        return values
 
     @root_validator(pre=True)
     @classmethod
@@ -332,6 +355,23 @@ class Config(BaseSettings):
         if value < -1 or value in {0, 1}:
             raise ValueError('Value must equal -1 or be greater than 1.')
         return value
+
+    @validator('engine_type', always=True, allow_reuse=True)
+    @classmethod
+    def engine_type_validator(cls, value: EngineType) -> EngineType:
+        if value == EngineType.binary:
+            return value
+
+        if value == EngineType.dataproxy:  # pragma: no cover
+            raise ValueError(
+                'Prisma Client Python does not support the Prisma Data Proxy yet.'
+            )
+        elif value == EngineType.library:  # pragma: no cover
+            raise ValueError(
+                'Prisma Client Python does not support native engine bindings yet.'
+            )
+        else:  # pragma: no cover
+            assert_never(value)
 
 
 class DMMF(BaseModel):

--- a/src/prisma/generator/models.py
+++ b/src/prisma/generator/models.py
@@ -358,11 +358,12 @@ class Config(BaseSettings):
 
     @validator('engine_type', always=True, allow_reuse=True)
     @classmethod
-    def engine_type_validator(cls, value: EngineType) -> EngineType:
+    def engine_type_validator(  # pylint: disable=no-else-raise,inconsistent-return-statements,no-else-return
+        cls, value: EngineType
+    ) -> EngineType:
         if value == EngineType.binary:
             return value
-
-        if value == EngineType.dataproxy:  # pragma: no cover
+        elif value == EngineType.dataproxy:  # pragma: no cover
             raise ValueError(
                 'Prisma Client Python does not support the Prisma Data Proxy yet.'
             )

--- a/src/prisma/generator/templates/client.py.jinja
+++ b/src/prisma/generator/templates/client.py.jinja
@@ -7,9 +7,11 @@ from . import types, models, errors, actions
 from ._types import BaseModelT
 from .engine import AbstractEngine, QueryEngine
 from .builder import QueryBuilder
+from .generator.models import EngineType
 
 
 __all__ = (
+    'ENGINE_TYPE',
     'Client',
     'load_env',
     'register',
@@ -19,6 +21,8 @@ __all__ = (
 SCHEMA = '''
 {{ datamodel }}
 '''
+
+ENGINE_TYPE: EngineType = EngineType.{{ generator.config.engine_type }}
 
 RegisteredClient = Union['Client', Callable[[], 'Client']]
 _registered_client: Optional[RegisteredClient] = None

--- a/src/prisma/utils.py
+++ b/src/prisma/utils.py
@@ -6,7 +6,7 @@ import logging
 import warnings
 import contextlib
 from importlib.util import find_spec
-from typing import Any, Union, Dict, Iterator, Coroutine
+from typing import Any, Union, Dict, Iterator, Coroutine, NoReturn
 
 from ._types import FuncType, CoroType
 
@@ -108,3 +108,11 @@ def get_or_create_event_loop() -> asyncio.AbstractEventLoop:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
             return loop
+
+
+def assert_never(value: NoReturn) -> NoReturn:
+    """Used by type checkers for exhaustive match cases.
+
+    https://github.com/microsoft/pyright/issues/767
+    """
+    assert False, "Unhandled type: {}".format(type(value).__name__)

--- a/src/prisma/utils.py
+++ b/src/prisma/utils.py
@@ -115,4 +115,4 @@ def assert_never(value: NoReturn) -> NoReturn:
 
     https://github.com/microsoft/pyright/issues/767
     """
-    assert False, "Unhandled type: {}".format(type(value).__name__)
+    assert False, "Unhandled type: {}".format(type(value).__name__)  # pragma: no cover

--- a/tests/data/schema.prisma
+++ b/tests/data/schema.prisma
@@ -8,7 +8,6 @@ generator db {
   interface              = "asyncio"
   recursive_type_depth   = 5
   partial_type_generator = "tests/scripts/partial_type_generator.py"
-  engineType             = "binary"
 }
 
 model Post {

--- a/tests/data/schema.prisma
+++ b/tests/data/schema.prisma
@@ -8,6 +8,7 @@ generator db {
   interface              = "asyncio"
   recursive_type_depth   = 5
   partial_type_generator = "tests/scripts/partial_type_generator.py"
+  engineType             = "binary"
 }
 
 model Post {

--- a/tests/integrations/postgresql/schema.prisma
+++ b/tests/integrations/postgresql/schema.prisma
@@ -7,6 +7,7 @@ generator db {
   provider             = "coverage run -m prisma"
   interface            = "asyncio"
   recursive_type_depth = -1
+  engineType           = "binary"
 }
 
 model User {

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import pytest
-from prisma import Client, get_client, errors, engine
+from prisma import ENGINE_TYPE, Client, get_client, errors, engine
 from prisma.testing import reset_client
 from prisma.cli.prisma import run
 
@@ -74,3 +74,8 @@ def test_auto_register() -> None:
 
         client = Client(auto_register=True)
         assert get_client() == client
+
+
+def test_engine_type() -> None:
+    """The exported ENGINE_TYPE enum matches the actual engine type"""
+    assert ENGINE_TYPE.value == 'binary'

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive.ambr
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive.ambr
@@ -10735,9 +10735,11 @@
   from ._types import BaseModelT
   from .engine import AbstractEngine, QueryEngine
   from .builder import QueryBuilder
+  from .generator.models import EngineType
   
   
   __all__ = (
+      'ENGINE_TYPE',
       'Client',
       'load_env',
       'register',
@@ -10922,6 +10924,8 @@
   }
   
   '''
+  
+  ENGINE_TYPE: EngineType = EngineType.binary
   
   RegisteredClient = Union['Client', Callable[[], 'Client']]
   _registered_client: Optional[RegisteredClient] = None
@@ -38601,9 +38605,11 @@
   from ._types import BaseModelT
   from .engine import AbstractEngine, QueryEngine
   from .builder import QueryBuilder
+  from .generator.models import EngineType
   
   
   __all__ = (
+      'ENGINE_TYPE',
       'Client',
       'load_env',
       'register',
@@ -38788,6 +38794,8 @@
   }
   
   '''
+  
+  ENGINE_TYPE: EngineType = EngineType.binary
   
   RegisteredClient = Union['Client', Callable[[], 'Client']]
   _registered_client: Optional[RegisteredClient] = None


### PR DESCRIPTION
we currently only support the binary option but this will be useful in the future