### PR TITLE
chore(ci): increase codecov threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -13,9 +13,7 @@ coverage:
         paths:
           - "!tests/"
         target: auto
-
-        # NOTE: flexible on this threshold
-        threshold: 6%
+        threshold: 10%
         branches:
           - main
 


### PR DESCRIPTION
This is an attempt to stop codecov from prematurely failing a commit