### PR TITLE
chore(tests): update pytest-asyncio to v0.17.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -217,7 +217,7 @@ jobs:
 
       - name: Run tests
         run: |
-          tox -e setup,${{ matrix.tox-env }},report -- tests/integrations/postgresql
+          tox -e setup,${{ matrix.tox-env }},report -- --collect-only tests/integrations/postgresql
         env:
           PRISMA_PY_POSTGRES_URL: postgresql://postgres:postgres@localhost:5432/postgres
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -217,7 +217,7 @@ jobs:
 
       - name: Run tests
         run: |
-          tox -e setup,${{ matrix.tox-env }},report -- --collect-only tests/integrations/postgresql
+          tox -e setup,${{ matrix.tox-env }},report -- tests/integrations/postgresql/test.sh
         env:
           PRISMA_PY_POSTGRES_URL: postgresql://postgres:postgres@localhost:5432/postgres
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -217,7 +217,7 @@ jobs:
 
       - name: Run tests
         run: |
-          tox -e setup,${{ matrix.tox-env }},report -- tests/integrations/postgresql/test.sh
+          tox -e setup,${{ matrix.tox-env }},report -- --confcutdir . tests/integrations/postgresql
         env:
           PRISMA_PY_POSTGRES_URL: postgresql://postgres:postgres@localhost:5432/postgres
 

--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -122,6 +122,12 @@ You can run the integration tests only with the following command:
 tox -e py39 -- tests/integrations/
 ```
 
+Or a specific test:
+
+```sh
+tox -e py39 -- --confcutdir . tests/integrations/postgresql
+```
+
 !!! warning
     You may also need to update the root `pytest.ini` file to include your integration test in the `norecursedirs` option if you run pytest within the integration test
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,10 @@ markers =
   persist_data: Signifies that data should not be cleared between test runs.
   prisma: This marker must be used to enable model-based access.
 
+
+# asyncio fixtures and tests must be explicitly marked
+asyncio_mode = strict
+
 # NOTE: this is required to stop pytest from loading conftest.py files
 # for our integration tests, as pytest eagerly loads conftests backwards
 # we cannot use a hook to ignore them as the integration conftest files

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from prisma.cli import setup_logging
 from prisma.testing import reset_client
 from prisma.utils import get_or_create_event_loop
 
-from .utils import Runner, Testdir
+from .utils import Runner, Testdir, async_fixture
 
 
 if TYPE_CHECKING:
@@ -30,7 +30,7 @@ LOGGING_CONTEXT_MANAGER = setup_logging(use_handler=False)
 prisma.register(Client())
 
 
-@pytest.fixture(name='client', scope='session')
+@async_fixture(name='client', scope='session')
 async def client_fixture() -> Client:
     client = prisma.get_client()
     await client.connect()
@@ -93,7 +93,7 @@ def patch_prisma_fixture(request: 'FixtureRequest') -> Iterator[None]:
             yield
 
 
-@pytest.fixture(name='setup_client', autouse=True)
+@async_fixture(name='setup_client', autouse=True)
 async def setup_client_fixture(request: 'FixtureRequest') -> None:
     if not request_has_client(request):
         return

--- a/tests/integrations/custom-generator/test.sh
+++ b/tests/integrations/custom-generator/test.sh
@@ -8,7 +8,8 @@ set +x
 source .venv/bin/activate
 set -x
 
-pip install -U 'pyright>=0.0.10' 'pytest'
+# TODO: pytest-asyncio should not be required
+pip install -U 'pyright>=0.0.10' 'pytest==6.2.4' pytest-asyncio==0.17.0
 pip install -U --force-reinstall ../../../.tests_cache/dist/*.whl
 
 rm -f generated.md 2.md

--- a/tests/integrations/postgresql/pyproject.toml
+++ b/tests/integrations/postgresql/pyproject.toml
@@ -7,6 +7,3 @@ typeCheckingMode = "strict"
 
 [tool.black]
 skip-string-normalization = true
-
-[tool.pytest.ini_options]
-asyncio_mode = 'auto'

--- a/tests/integrations/postgresql/pyproject.toml
+++ b/tests/integrations/postgresql/pyproject.toml
@@ -7,3 +7,6 @@ typeCheckingMode = "strict"
 
 [tool.black]
 skip-string-normalization = true
+
+[tool.pytest.ini_options]
+asyncio_mode = 'auto'

--- a/tests/integrations/postgresql/pytest.ini
+++ b/tests/integrations/postgresql/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+# asyncio fixtures and tests dont have to be explicitly marked
+asyncio_mode = auto

--- a/tests/integrations/postgresql/requirements.txt
+++ b/tests/integrations/postgresql/requirements.txt
@@ -1,4 +1,4 @@
-pytest
-pytest-asyncio
+pytest==6.2.4
+pytest-asyncio==0.17.0
 pyright
 coverage==6.1.1

--- a/tests/integrations/sync/test.sh
+++ b/tests/integrations/sync/test.sh
@@ -8,7 +8,8 @@ set +x
 source .venv/bin/activate
 set -x
 
-pip install -U pytest pyright coverage==6.1.1
+# TODO: pytest-asyncio should not be required
+pip install -U pytest==6.2.4 pytest-asyncio==0.17.0 pyright coverage==6.1.1
 pip install -U --force-reinstall ../../../.tests_cache/dist/*.whl
 
 # required due to https://github.com/RobertCraigie/prisma-client-py/issues/35

--- a/tests/test_include.py
+++ b/tests/test_include.py
@@ -12,8 +12,10 @@ import pytest
 from prisma import Client
 from prisma.models import Post
 
+from .utils import async_fixture
 
-@pytest.fixture(scope='module', name='user_id')
+
+@async_fixture(scope='module', name='user_id')
 async def user_id_fixture(client: Client) -> str:
     user = await client.user.create({'name': 'Robert'})
     posts = await create_or_get_posts(client, user.id)
@@ -26,7 +28,7 @@ async def user_id_fixture(client: Client) -> str:
     return user.id
 
 
-@pytest.fixture(scope='module', name='posts')
+@async_fixture(scope='module', name='posts')
 async def posts_fixture(client: Client, user_id: str) -> List[Post]:
     return await create_or_get_posts(client, user_id)
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -2,11 +2,13 @@ import pytest
 import prisma
 from prisma import Client
 
+from .utils import async_fixture
+
 
 # TODO: update persist_data stuff, some tests shouldn't have it
 
 
-@pytest.fixture(scope='module', name='user_id')
+@async_fixture(scope='module', name='user_id')
 async def user_id_fixture(client: Client) -> str:
     user = await client.user.create({'name': 'Robert'})
     return user.id

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from typing import (
     Any,
     Callable,
+    Iterable,
     Mapping,
     Optional,
     List,
@@ -22,6 +23,7 @@ from typing import (
 
 import py
 import click
+import pytest_asyncio  # type: ignore
 from click.testing import CliRunner, Result
 
 from prisma.cli import main
@@ -29,6 +31,8 @@ from prisma._types import FuncType
 
 
 if TYPE_CHECKING:
+    from _pytest.config import Config
+    from _pytest.fixtures import FixtureFunctionMarker, _Scope
     from _pytest.monkeypatch import MonkeyPatch
     from _pytest.pytester import RunResult, Testdir as PytestTestdir
 
@@ -326,3 +330,29 @@ def patch_method(
     real_meth = getattr(obj, attr)
     patcher.setattr(obj, attr, wrapper, raising=True)
     return lambda: captured
+
+
+def async_fixture(
+    scope: "Union[_Scope, Callable[[str, Config], _Scope]]" = "function",
+    params: Optional[Iterable[object]] = None,
+    autouse: bool = False,
+    ids: Optional[
+        Union[
+            Iterable[Union[None, str, float, int, bool]],
+            Callable[[Any], Optional[object]],
+        ]
+    ] = None,
+    name: Optional[str] = None,
+) -> 'FixtureFunctionMarker':
+    """Wrapper over pytest_asyncio.fixture providing type hints"""
+    return cast(
+        'FixtureFunctionMarker',
+        pytest_asyncio.fixture(
+            None,
+            scope=scope,
+            params=params,
+            autouse=autouse,
+            ids=ids,
+            name=name,
+        ),
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -68,6 +68,8 @@ commands =
 deps =
     {[testenv:setup]deps}
     pytest-pyright
+    # TODO: this should not be required
+    pytest-asyncio
 
 commands_pre =
     python scripts/cleanup.py

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     pytest-sugar
     mock==4.0.3
     pytest-mock==3.6.1
-    pytest-asyncio==0.14.0
+    pytest-asyncio==0.17.0
     pytest-subprocess==1.1.2
     coverage==6.1.1
     syrupy==1.3.1


### PR DESCRIPTION
## Change Summary

Bumps internal testing dependency `pytest-asyncio` from `v0.14.0` to `v0.17.0`, this requires async fixtures to be explicitly marked.

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
