### PR TITLE
chore(package): drop support for Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,11 +23,8 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     strategy:
-      # TODO: test more python versions
       matrix:
         include:
-          - python-version: 3.6
-            tox-env: py36
           - python-version: 3.7
             tox-env: py37
           - python-version: 3.8

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ async def main() -> None:
     await client.disconnect()
 
 if __name__ == '__main__':
-    asyncio.get_event_loop().run_until_complete(main())
+    asyncio.run(main())
 ```
 
 or like this:
@@ -204,7 +204,7 @@ async def main() -> None:
     await client.disconnect()
 
 if __name__ == '__main__':
-    asyncio.get_event_loop().run_until_complete(main())
+    asyncio.run(main())
 ```
 
 #### Query examples

--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -6,7 +6,7 @@ This document intends to make contribution more accessible by codifying tribal k
 
 ## General Prerequisites
 
-You must have Python >= 3.6 installed on your system.
+You must have Python >= 3.7 installed on your system.
 
 ### Environment Variables
 

--- a/docs/getting_started/setup.md
+++ b/docs/getting_started/setup.md
@@ -38,7 +38,7 @@ async def main() -> None:
     await client.disconnect()
 
 if __name__ == '__main__':
-    asyncio.get_event_loop().run_until_complete(main())
+    asyncio.run(main())
 ```
 
 ## Synchronous client

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ async def main() -> None:
     await client.disconnect()
 
 if __name__ == '__main__':
-    asyncio.get_event_loop().run_until_complete(main())
+    asyncio.run(main())
 ```
 
 or like this:
@@ -204,7 +204,7 @@ async def main() -> None:
     await client.disconnect()
 
 if __name__ == '__main__':
-    asyncio.get_event_loop().run_until_complete(main())
+    asyncio.run(main())
 ```
 
 #### Query examples

--- a/docs/src_examples/async/index.py
+++ b/docs/src_examples/async/index.py
@@ -23,4 +23,4 @@ async def main() -> None:
 
 
 if __name__ == '__main__':
-    asyncio.get_event_loop().run_until_complete(main())
+    asyncio.run(main())

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,6 @@ setup(
         'Topic :: Database :: Database Engines/Servers',
         'Topic :: Database :: Front-Ends',
         'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/src/prisma/_compat.py
+++ b/src/prisma/_compat.py
@@ -1,17 +1,9 @@
-import sys
 from typing import TYPE_CHECKING, Callable
+from asyncio import (  # pylint: disable=no-name-in-module
+    get_running_loop as get_running_loop,
+)
 
 from ._types import CallableT
-
-
-if sys.version_info[:2] == (3, 6):
-    # as far as I am aware the semantics of this are the same
-    # on python 3.6
-    from asyncio import get_event_loop as get_running_loop
-else:
-    from asyncio import (  # pylint: disable=no-name-in-module
-        get_running_loop as get_running_loop,
-    )
 
 
 if TYPE_CHECKING:

--- a/src/prisma/_types.py
+++ b/src/prisma/_types.py
@@ -1,28 +1,12 @@
-import sys
 from typing import Callable, Coroutine, TypeVar, Type, Tuple, Any
 from pydantic import BaseModel
-
-
-if sys.version_info[:2] > (3, 6):
-    from typing_extensions import (
-        TypedDict as TypedDict,
-        Protocol as Protocol,
-        Literal as Literal,
-        get_args as get_args,
-        runtime_checkable as runtime_checkable,
-    )
-else:
-    from typing_extensions import (
-        TypedDict as TypedDict,
-        Protocol as Protocol,
-        Literal as Literal,
-        runtime_checkable as runtime_checkable,
-    )
-
-    # TODO: type as NoReturn?
-    def get_args(typ: Any) -> Tuple[Any, ...]:
-        raise RuntimeError('Generic arguments cannot be resolved on python 3.6')
-
+from typing_extensions import (
+    TypedDict as TypedDict,
+    Protocol as Protocol,
+    Literal as Literal,
+    get_args as get_args,
+    runtime_checkable as runtime_checkable,
+)
 
 Method = Literal['GET', 'POST']
 

--- a/src/prisma/generator/generator.py
+++ b/src/prisma/generator/generator.py
@@ -133,17 +133,7 @@ class GenericGenerator(ABC, Generic[BaseModelT]):
 
     @property
     def data_class(self) -> Type[BaseModelT]:
-        """Return the BaseModel used to parse the Prisma DMMF
-
-        This must be implemented by subclasses to support python3.6 so
-        that generic type arguments cannot be resolved.
-        """
-        if sys.version_info[:2] == (3, 6):
-            raise RuntimeError(
-                'Generic arguments cannot be resolved on Python 3.6;\n'
-                'This can be resolved by overriding the `data_class` property '
-                'on the generator.'
-            )
+        """Return the BaseModel used to parse the Prisma DMMF"""
 
         # we need to cast to object as otherwise pyright correctly marks the code as unreachable,
         # this is because __orig_bases__ is not present in the typeshed stubs as it is
@@ -233,13 +223,6 @@ class Generator(BaseGenerator):
             raise
 
         log.debug('Finished generating the prisma python client')
-
-    if sys.version_info[:2] == (3, 6):
-        # only explicitly specify the Data class at runtime on Python 3.6
-        # so that our generic type resolver can be easily tested
-        @property
-        def data_class(self) -> Type[Data]:
-            return Data
 
 
 def cleanup_templates(rootdir: Path, *, env: Optional[Environment] = None) -> None:

--- a/tests/integrations/custom-generator/generator.py
+++ b/tests/integrations/custom-generator/generator.py
@@ -1,6 +1,3 @@
-import sys
-from typing import Type
-
 from pathlib import Path
 from pydantic import BaseModel
 from prisma.generator import GenericGenerator, Manifest, models

--- a/tests/integrations/custom-generator/generator.py
+++ b/tests/integrations/custom-generator/generator.py
@@ -36,13 +36,6 @@ class MyGenerator(GenericGenerator[Data]):
         output = Path(data.generator.output.value)
         output.write_text('\n'.join(lines))
 
-    if sys.version_info[:2] == (3, 6):
-        # only explicitly specify the Data class at runtime on Python 3.6
-        # so that our generic type resolver can be easily tested
-        @property
-        def data_class(self) -> Type[Data]:
-            return Data
-
 
 Data.update_forward_refs()
 GeneratorData.update_forward_refs()

--- a/tests/test_generation/test_generator.py
+++ b/tests/test_generation/test_generator.py
@@ -8,7 +8,6 @@ from jinja2 import Environment, FileSystemLoader
 from prisma import __version__
 from prisma.generator import (
     BASE_PACKAGE_DIR,
-    Data,
     Manifest,
     Generator,
     GenericGenerator,
@@ -162,30 +161,6 @@ def test_invoke_outside_generation() -> None:
     )
 
 
-@pytest.mark.skipif(
-    sys.version_info[:2] != (3, 6), reason='Test is only valid on python 3.6'
-)
-def test_data_class_required_py36() -> None:
-    """Due to internal Generic workings, we cannot resolve generic arguments
-    on python 3.6, our solution is that a `data_class` property must be required.
-    """
-
-    class MyGenerator(GenericGenerator[Data]):
-        def get_manifest(self) -> Manifest:  # pragma: no cover
-            return super().get_manifest()
-
-        def generate(self, data: Data) -> None:  # pragma: no cover
-            return super().generate(data)
-
-    with pytest.raises(RuntimeError) as exc:
-        MyGenerator().data_class
-
-    assert 'data_class' in exc.value.args[0]
-
-
-@pytest.mark.skipif(
-    sys.version_info[:2] == (3, 6), reason='Test is not valid on python 3.6'
-)
 def test_invalid_type_argument() -> None:
     """Non-BaseModel argument to GenericGenerator raises an error"""
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,10 @@
 envlist =
     setup,
     lint,
-    py36,
     py37,
     py38,
     py39,
+    py310,
     integrations,
     typesafety-mypy,
     typesafety-pyright,


### PR DESCRIPTION
## Change Summary

closes #87 

Quite a few of our dependencies are dropping support for Python 3.6 in their latest releases and Python 3.6 reached it's EOL on the 23rd of December 2021

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
