### PR TITLE
feat(project): apply cached-property where applicable

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -29,6 +29,7 @@ disable =
 
   # false positives and pyright catches these anyway
   no-member,
+  no-name-in-module,
 
   # I don't think this is valuable
   too-many-ancestors,

--- a/.pylintrc
+++ b/.pylintrc
@@ -67,6 +67,7 @@ good-names =
   dt,
   fd,
   to,
+  cached_property,
 
 
 [VARIABLES]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,3 +5,4 @@ click>=7.1.2
 python-dotenv>=0.12.0
 typing-extensions>=3.7
 contextvars; python_version < '3.7'
+cached-property; python_version < '3.8'

--- a/src/prisma/_compat.py
+++ b/src/prisma/_compat.py
@@ -1,8 +1,6 @@
 import sys
 from typing import TYPE_CHECKING, Callable
-from asyncio import (  # pylint: disable=no-name-in-module
-    get_running_loop as get_running_loop,
-)
+from asyncio import get_running_loop as get_running_loop
 
 from ._types import CallableT
 

--- a/src/prisma/_compat.py
+++ b/src/prisma/_compat.py
@@ -1,3 +1,4 @@
+import sys
 from typing import TYPE_CHECKING, Callable
 from asyncio import (  # pylint: disable=no-name-in-module
     get_running_loop as get_running_loop,
@@ -40,3 +41,14 @@ else:
         validator as validator,
         root_validator as root_validator,
     )
+
+
+if sys.version_info[:2] < (3, 8):
+    # cached_property doesn't define type hints so just ignore it
+    # it is functionally equivalent to the standard property anyway
+    if TYPE_CHECKING:
+        cached_property = property
+    else:
+        from cached_property import cached_property as cached_property
+else:
+    from functools import cached_property as cached_property

--- a/src/prisma/generator/generator.py
+++ b/src/prisma/generator/generator.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 import os
 import sys
 import json
@@ -131,7 +132,7 @@ class GenericGenerator(ABC, Generic[BaseModelT]):
             if response is not None:
                 jsonrpc.reply(response)
 
-    @property
+    @cached_property
     def data_class(self) -> Type[BaseModelT]:
         """Return the BaseModel used to parse the Prisma DMMF"""
 

--- a/src/prisma/generator/generator.py
+++ b/src/prisma/generator/generator.py
@@ -1,4 +1,3 @@
-from functools import cached_property
 import os
 import sys
 import json
@@ -23,6 +22,7 @@ from .utils import (
 )
 from .. import __version__
 from ..utils import DEBUG_GENERATOR
+from .._compat import cached_property
 from .._types import BaseModelT, InheritsGeneric, get_args
 
 

--- a/src/prisma/generator/models.py
+++ b/src/prisma/generator/models.py
@@ -43,7 +43,7 @@ except ImportError:
 
 from .utils import Faker, Sampler, clean_multiline
 from ..utils import DEBUG_GENERATOR, assert_never
-from .._compat import validator, root_validator
+from .._compat import validator, root_validator, cached_property
 from .._constants import QUERY_BUILDER_ALIASES
 from ..errors import UnsupportedListTypeError
 from ..binaries.constants import ENGINE_VERSION, PRISMA_VERSION
@@ -145,6 +145,7 @@ class BaseModel(PydanticBaseModel):
             Path: _pathlib_serializer,
             machinery.ModuleSpec: _module_spec_serializer,
         }
+        keep_untouched = (cached_property,)
 
 
 class GenericModel(PydanticGenericModel, BaseModel):
@@ -501,7 +502,7 @@ class Model(BaseModel):
                 yield field
 
     # TODO: support combined unique constraints
-    @property
+    @cached_property
     def id_field(self) -> Optional['Field']:
         """Find a field that can be passed to the model's `WhereUnique` filter"""
         for field in self.scalar_fields:  # pragma: no branch

--- a/src/prisma/generator/models.py
+++ b/src/prisma/generator/models.py
@@ -145,7 +145,7 @@ class BaseModel(PydanticBaseModel):
             Path: _pathlib_serializer,
             machinery.ModuleSpec: _module_spec_serializer,
         }
-        keep_untouched = (cached_property,)
+        keep_untouched: Tuple[Type[Any], ...] = (cached_property,)
 
 
 class GenericModel(PydanticGenericModel, BaseModel):

--- a/src/prisma/generator/schema.py
+++ b/src/prisma/generator/schema.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Union
 from pydantic import BaseModel
 
 from .models import AnyData, Model as ModelInfo, PrimaryKey
-from .._compat import root_validator
+from .._compat import root_validator, cached_property
 
 
 class Kind(str, Enum):
@@ -71,7 +71,10 @@ class Schema(BaseModel):
 class Model(BaseModel):
     info: ModelInfo
 
-    @property
+    class Config:
+        keep_untouched = (cached_property,)
+
+    @cached_property
     def where_unique(self) -> PrismaType:
         info = self.info
         model = info.name

--- a/src/prisma/generator/schema.py
+++ b/src/prisma/generator/schema.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Tuple, Type, Union
 
 from pydantic import BaseModel
 
@@ -72,7 +72,7 @@ class Model(BaseModel):
     info: ModelInfo
 
     class Config:
-        keep_untouched = (cached_property,)
+        keep_untouched: Tuple[Type[Any], ...] = (cached_property,)
 
     @cached_property
     def where_unique(self) -> PrismaType:

--- a/src/prisma/mypy.py
+++ b/src/prisma/mypy.py
@@ -6,7 +6,6 @@ import operator
 from configparser import ConfigParser
 from typing import Optional, Callable, Dict, Any, Union, Type as TypingType, cast
 
-# pylint: disable=no-name-in-module
 from mypy.options import Options
 from mypy.errorcodes import ErrorCode
 from mypy.types import (
@@ -32,8 +31,6 @@ from mypy.nodes import (
     SymbolTableNode,
 )
 from mypy.plugin import Plugin, MethodContext, CheckerPluginInterface
-
-# pylint: enable=no-name-in-module
 
 
 # match any direct children of an actions class


### PR DESCRIPTION
## Change Summary

Make use of the standard library's `functools.cached_property` (and it's backport) on expensive to compute properties.

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
