### PR TITLE
chore(deps): remove redundant backport dependency

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,5 +4,4 @@ pydantic>=1.8.0
 click>=7.1.2
 python-dotenv>=0.12.0
 typing-extensions>=3.7
-contextvars; python_version < '3.7'
 cached-property; python_version < '3.8'

--- a/tox.ini
+++ b/tox.ini
@@ -108,7 +108,6 @@ deps =
     black==21.11b1
     pylint==2.6.0
     mypy==0.910
-    types-contextvars
     pyright>=0.0.7
 
 commands =
@@ -125,7 +124,6 @@ deps =
     {[testenv]deps}
     mypy==0.910
     types-mock
-    types-contextvars
 
 commands =
     coverage run -m mypy --show-traceback --namespace-packages --package prisma --package tests


### PR DESCRIPTION
## Change Summary

Remove `contextvars` from requirements as it is no longer used due to dropping support for Python 3.6

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass without significant drop in coverage
- [x] Documentation reflects changes where applicable
- [x] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
