### PR TITLE
chore(cli/fetch): disable `--force` flag on windows

### DIFF
--- a/src/prisma/cli/commands/fetch.py
+++ b/src/prisma/cli/commands/fetch.py
@@ -1,6 +1,6 @@
-import click
 import platform
 
+import click
 
 from ..utils import error
 

--- a/src/prisma/cli/commands/fetch.py
+++ b/src/prisma/cli/commands/fetch.py
@@ -1,4 +1,8 @@
 import click
+import platform
+
+
+from ..utils import error
 
 
 @click.command('fetch', short_help='Download all required binaries.')
@@ -12,6 +16,9 @@ def cli(force: bool) -> None:
     from ... import binaries
 
     if force:
+        if platform.system().lower() == 'windows':  # pragma: no cover
+            error('The --force flag is not supported on Windows')
+
         binaries.remove_all()
 
     directory = binaries.ensure_cached()

--- a/tests/test_cli/test_fetch.py
+++ b/tests/test_cli/test_fetch.py
@@ -1,10 +1,11 @@
 import random
 import shutil
 
+import pytest
 from click.testing import Result
 
 from prisma import binaries
-from tests.utils import Runner
+from tests.utils import Runner, is_windows
 
 
 # TODO: this could probably mess up other tests if one of these
@@ -36,6 +37,10 @@ def test_fetch_one_binary_missing(runner: Runner) -> None:
     assert_success(runner.invoke(['py', 'fetch']))
 
 
+@pytest.mark.skipif(
+    is_windows(),
+    reason='The --force flag does not work on windows',
+)
 def test_fetch_force(runner: Runner) -> None:
     """Passing --force re-downloads an already existing binary"""
     binary = random.choice(binaries.BINARIES)
@@ -53,6 +58,10 @@ def test_fetch_force(runner: Runner) -> None:
     assert old_stat.st_size == new_stat.st_size
 
 
+@pytest.mark.skipif(
+    is_windows(),
+    reason='The --force flag does not work on windows',
+)
 def test_fetch_force_no_dir(runner: Runner) -> None:
     """Passing --force when the base directory does not exist"""
     binaries.remove_all()
@@ -62,3 +71,14 @@ def test_fetch_force_no_dir(runner: Runner) -> None:
     assert not binary.path.exists()
 
     assert_success(runner.invoke(['py', 'fetch', '--force']))
+
+
+@pytest.mark.skipif(
+    not is_windows(),
+    reason='The --force flag is not supported on windows',
+)
+def test_fetch_force_not_supported(runner: Runner) -> None:  # pragma: no cover
+    """Passing --force is not supported"""
+    result = runner.invoke(['py', 'fetch', '--force'])
+    assert result.exit_code == 1
+    assert result.output == 'The --force flag is not supported on Windows\n'

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import sys
 import uuid
 import inspect
@@ -356,3 +357,8 @@ def async_fixture(
             name=name,
         ),
     )
+
+
+def is_windows() -> bool:
+    """Returns whether or not the current platform is Windows"""
+    return platform.system().lower() == 'windows'


### PR DESCRIPTION
## Change Summary

The `--force` flag is broken on windows.

Quoting HGKx:
> I've ran into a cheeky bug when using tempfiles. They all seem to implement O_EXCL flag which blocks opening them after they're created
and then we're using os.unlink to remove the binaries
but os.unlink tries to open the file?

This is not a high priority fix for me, however getting tests to pass on windows is.

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
