### PR TITLE
chore(package): fix python version metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     long_description_content_type='text/markdown',
     packages=find_packages(where='src', include=['prisma', 'prisma.*']),
     package_dir={'': 'src'},
-    python_requires='>=3',
+    python_requires='>=3.7.0',
     package_data={'': ['generator/templates/**/*.py.jinja', 'py.typed']},
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
## Change Summary

The package metadata now lists the minimum python version required as Python 3.7. It was previously just Python 3.

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
