### PR TITLE
chore(tests): fix local no event loop error

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -30,11 +30,16 @@ def no_event_loop() -> Iterator[None]:
     except RuntimeError:
         current = None
 
-    try:
-        asyncio.set_event_loop(None)
+    # if there is no running loop then we don't touch the event loop
+    # as this can cause weird issues breaking other tests
+    if not current:  # pragma: no cover
         yield
-    finally:
-        asyncio.set_event_loop(current)
+    else:
+        try:
+            asyncio.set_event_loop(None)
+            yield
+        finally:
+            asyncio.set_event_loop(current)
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -34,7 +34,7 @@ def no_event_loop() -> Iterator[None]:
     # as this can cause weird issues breaking other tests
     if not current:  # pragma: no cover
         yield
-    else:
+    else:  # pragma: no cover
         try:
             asyncio.set_event_loop(None)
             yield


### PR DESCRIPTION
## Change Summary

Fixes local broken tests due to missing event loop. This could happen if you ran `test_engine.py` by itself as it would unconditionally set the event loop to None. This has been changed to only touch the event loop if one is already running.

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
