### PR TITLE
chore(typesafety/pyright): fix pytest warning

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -72,6 +72,10 @@ deps =
     pytest-asyncio==0.17.0
 
 commands_pre =
+    # for some reason tox installs pytest==7.0.0 even though
+    # we specify pytest==6.2.4 and pytest-pyright is not compatible
+    # with pytest>=7.0.0 yet
+    pip install pytest==6.2.4
     python scripts/cleanup.py
     coverage run -m prisma generate --schema=typesafety/pyright/schema.prisma
 


### PR DESCRIPTION
## Change Summary

Pin `pytest` to `6.2.4` due to incompatibilities with `7.0.0`.

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
