### PR TITLE
feat(client): support removing the http timeout

### DIFF
--- a/docs/reference/client.md
+++ b/docs/reference/client.md
@@ -90,6 +90,16 @@ client = Client(
 
 Will then use a 10 second timeout for all http operations.
 
+You can also remove the timeout by passing None, for example:
+
+```py
+client = Client(
+    http={
+        'timeout': None,
+    },
+)
+```
+
 Not all options that HTTPX support are supported by Prisma Client Python, a full list can be found below:
 
 ```py
@@ -98,7 +108,7 @@ class HttpConfig(TypedDict, total=False):
     http1: bool
     http2: bool
     limits: httpx.Limits
-    timeout: Union[float, httpx.Timeout]
+    timeout: Union[None, float, httpx.Timeout]
     trust_env: bool
     max_redirects: int
 ```

--- a/src/prisma/generator/templates/types.py.jinja
+++ b/src/prisma/generator/templates/types.py.jinja
@@ -89,7 +89,7 @@ class HttpConfig(TypedDict, total=False):
     http1: bool
     http2: bool
     limits: httpx.Limits
-    timeout: Union[float, httpx.Timeout]
+    timeout: Union[None, float, httpx.Timeout]
     trust_env: bool
     max_redirects: int
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[types.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[types.py].raw
@@ -61,7 +61,7 @@ class HttpConfig(TypedDict, total=False):
     http1: bool
     http2: bool
     limits: httpx.Limits
-    timeout: Union[float, httpx.Timeout]
+    timeout: Union[None, float, httpx.Timeout]
     trust_env: bool
     max_redirects: int
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[types.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[types.py].raw
@@ -61,7 +61,7 @@ class HttpConfig(TypedDict, total=False):
     http1: bool
     http2: bool
     limits: httpx.Limits
-    timeout: Union[float, httpx.Timeout]
+    timeout: Union[None, float, httpx.Timeout]
     trust_env: bool
     max_redirects: int
 


### PR DESCRIPTION
## Change Summary

This supports removing the HTTP timeout from the client.

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
