### PR TITLE
refactor(package): make http.py only available post-generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,7 @@ venv.bak/
 tmp/
 
 # generated code
+src/prisma/http.py
 src/prisma/types.py
 src/prisma/enums.py
 src/prisma/client.py
@@ -132,7 +133,6 @@ src/prisma/partials.py
 src/prisma/engine/http.py
 src/prisma/engine/query.py
 src/prisma/engine/abstract.py
-src/prisma/http.py.original
 
 # debug files
 src/prisma/generator/debug-data.json

--- a/src/prisma/_async_http.py
+++ b/src/prisma/_async_http.py
@@ -14,12 +14,7 @@ class HTTP(AbstractHTTP[httpx.AsyncClient, httpx.Response]):
     session: httpx.AsyncClient
 
     async def download(self, url: str, dest: str) -> None:
-        # pyright thinks that stream() doesn't return a context manager
-        # due to how httpx handles compatability imports
-        # https://github.com/encode/httpx/discussions/1829
-        async with self.session.stream(
-            'GET', url, timeout=None
-        ) as resp:  # pyright: reportGeneralTypeIssues=false
+        async with self.session.stream('GET', url, timeout=None) as resp:
             resp.raise_for_status()
             with open(dest, 'wb') as fd:
                 async for chunk in resp.aiter_bytes():
@@ -32,7 +27,7 @@ class HTTP(AbstractHTTP[httpx.AsyncClient, httpx.Response]):
         self.session = httpx.AsyncClient(**self.session_kwargs)
 
     async def close(self) -> None:
-        if not self.closed:
+        if self.should_close():
             await self.session.aclose()
 
             # mypy doesn't like us assigning None as the type of

--- a/src/prisma/_sync_http.py
+++ b/src/prisma/_sync_http.py
@@ -26,7 +26,7 @@ class HTTP(AbstractHTTP[httpx.Client, httpx.Response]):
         self.session = httpx.Client(**self.session_kwargs)
 
     def close(self) -> None:
-        if not self.closed:
+        if self.should_close():
             self.session.close()
             self.session = None  # type: ignore[assignment]
 

--- a/src/prisma/binaries/utils.py
+++ b/src/prisma/binaries/utils.py
@@ -3,8 +3,7 @@ import gzip
 import shutil
 from pathlib import Path
 
-from ..http import client
-from ..utils import maybe_async_run
+from .._sync_http import client
 
 
 def download(url: str, to: str) -> None:
@@ -12,7 +11,7 @@ def download(url: str, to: str) -> None:
 
     tmp = to + '.tmp'
     tar = to + '.gz.tmp'
-    maybe_async_run(client.download, url, tar)
+    client.download(url, tar)
 
     # decompress to a tmp file before replacing the original
     with gzip.open(tar, 'rb') as f_in:

--- a/src/prisma/cli/cli.py
+++ b/src/prisma/cli/cli.py
@@ -10,8 +10,8 @@ from . import prisma
 from .utils import error
 from .custom import cli
 
-from .. import http
-from ..utils import maybe_async_run, DEBUG
+from .. import _sync_http as http
+from ..utils import DEBUG
 from ..generator import Generator
 
 
@@ -93,7 +93,7 @@ def cleanup(do_cleanup: bool = True) -> Iterator[None]:
         yield
     finally:
         if do_cleanup:
-            maybe_async_run(http.client.close)
+            http.client.close()
 
 
 if __name__ == '__main__':

--- a/src/prisma/engine/errors.py
+++ b/src/prisma/engine/errors.py
@@ -1,5 +1,7 @@
-from ..http import Response
+from typing import Any
+
 from ..errors import PrismaError
+from ..http_abstract import AbstractResponse
 
 
 __all__ = (
@@ -12,6 +14,9 @@ __all__ = (
     'NotConnectedError',
     'UnprocessableEntityError',
 )
+
+
+_AnyResponse = AbstractResponse[Any]
 
 
 class EngineError(PrismaError):
@@ -45,9 +50,9 @@ class EngineConnectionError(EngineError):
 
 
 class EngineRequestError(EngineError):
-    response: Response
+    response: _AnyResponse
 
-    def __init__(self, response: Response, body: str):
+    def __init__(self, response: _AnyResponse, body: str):
         self.response = response
 
         # TODO: better error message
@@ -55,7 +60,7 @@ class EngineRequestError(EngineError):
 
 
 class UnprocessableEntityError(EngineRequestError):
-    def __init__(self, response: Response):
+    def __init__(self, response: _AnyResponse):
         super().__init__(
             response,
             (

--- a/src/prisma/engine/utils.py
+++ b/src/prisma/engine/utils.py
@@ -10,7 +10,7 @@ from typing import NoReturn, Dict, Type, Any
 from . import errors
 from .. import errors as prisma_errors
 
-from ..http import Response
+from ..http_abstract import AbstractResponse
 from ..utils import time_since
 from ..binaries import GLOBAL_TEMP_DIR, ENGINE_VERSION, platform
 
@@ -95,7 +95,7 @@ def get_open_port() -> int:
     return int(port)
 
 
-def handle_response_errors(resp: Response, data: Any) -> NoReturn:
+def handle_response_errors(resp: AbstractResponse[Any], data: Any) -> NoReturn:
     for error in data:
         try:
             user_facing = error.get('user_facing_error', {})

--- a/src/prisma/generator/generator.py
+++ b/src/prisma/generator/generator.py
@@ -18,7 +18,6 @@ from .utils import (
     copy_tree,
     is_same_path,
     resolve_template_path,
-    resolve_original_file,
 )
 from .. import __version__
 from ..utils import DEBUG_GENERATOR
@@ -42,9 +41,6 @@ GENERIC_GENERATOR_NAME = 'prisma.generator.generator.GenericGenerator'
 
 # set of templates that should be rendered after every other template
 DEFERRED_TEMPLATES = {'partials.py.jinja'}
-
-# set of templates that override existing modules
-OVERRIDING_TEMPLATES = {'http.py.jinja'}
 
 DEFAULT_ENV = Environment(
     trim_blocks=True,
@@ -233,15 +229,7 @@ def cleanup_templates(rootdir: Path, *, env: Optional[Environment] = None) -> No
 
     for name in env.list_templates():
         file = resolve_template_path(rootdir=rootdir, name=name)
-        original = resolve_original_file(file)
-        if original.exists():
-            if file.exists():
-                log.debug('Removing overridden template at %s', file)
-                file.unlink()
-
-            log.debug('Renaming file at %s to %s', original, file)
-            original.rename(file)
-        elif file.exists() and name not in OVERRIDING_TEMPLATES:
+        if file.exists():
             log.debug('Removing rendered template at %s', file)
             file.unlink()
 
@@ -262,12 +250,6 @@ def render_template(
     file = resolve_template_path(rootdir=rootdir, name=name)
     if not file.parent.exists():
         file.parent.mkdir(parents=True, exist_ok=True)
-
-    if name in OVERRIDING_TEMPLATES and file.exists():
-        original = resolve_original_file(file)
-        if not original.exists():
-            log.debug('Making backup of %s', file)
-            file.rename(original)
 
     file.write_bytes(output.encode(sys.getdefaultencoding()))
     log.debug('Rendered template to %s', file.absolute())

--- a/src/prisma/generator/utils.py
+++ b/src/prisma/generator/utils.py
@@ -71,10 +71,6 @@ def resolve_template_path(rootdir: Path, name: Union[str, Path]) -> Path:
     return rootdir.joinpath(remove_suffix(name, '.jinja'))
 
 
-def resolve_original_file(file: Path) -> Path:
-    return file.parent.joinpath(file.name + '.original')
-
-
 def remove_suffix(path: Union[str, Path], suf: str) -> str:
     """Remove a suffix from a string, if it exists."""
     # modified from https://stackoverflow.com/a/18723694

--- a/src/prisma/http.py
+++ b/src/prisma/http.py
@@ -1,6 +1,0 @@
-# TODO: should we default to asynchronous or synchronous http?
-from ._sync_http import (
-    HTTP as HTTP,
-    Response as Response,
-    client as client,
-)

--- a/src/prisma/http_abstract.py
+++ b/src/prisma/http_abstract.py
@@ -63,6 +63,7 @@ class AbstractHTTP(ABC, Generic[Session, Response]):
             self.open()
             return cast(Session, self._session)
 
+        # TODO: make this not strict, just open a new session
         if session is None:
             raise HTTPClientClosedError()
 
@@ -73,6 +74,9 @@ class AbstractHTTP(ABC, Generic[Session, Response]):
         self, value: Optional[Session]
     ) -> None:  # pyright: reportPropertyTypeMismatch=false
         self._session = value
+
+    def should_close(self) -> bool:
+        return self._session is not _NoneType and not self.closed
 
     def __repr__(self) -> str:
         return str(self)

--- a/tests/test_generation/test_generator.py
+++ b/tests/test_generation/test_generator.py
@@ -14,7 +14,6 @@ from prisma.generator import (
     render_template,
     cleanup_templates,
 )
-from prisma.generator.generator import OVERRIDING_TEMPLATES
 from prisma.generator.utils import Faker, resolve_template_path, copy_tree
 
 from ..utils import Testdir
@@ -33,38 +32,14 @@ def iter_templates_dir(path: Path) -> Iterator[Path]:
         yield resolve_template_path(path, template.relative_to(templates))
 
 
-def is_overrided_file(file: Path) -> bool:
-    # NOTE: this will not work correctly if an overriding template
-    # contains a path separator
-    return file.name + '.jinja' in OVERRIDING_TEMPLATES
-
-
 def assert_module_is_clean(path: Path) -> None:
     for template in iter_templates_dir(path):
-        if is_overrided_file(template):
-            if template.name == 'http.py':
-                content = template.read_text()
-
-                # basic check to ensure that the original file has been reinstated
-                assert 'template' not in content
-            else:  # pragma: no cover
-                assert False, f'Unhandled check for {template}'
-        else:
-            assert not template.exists()
+        assert not template.exists()
 
 
 def assert_module_not_clean(path: Path) -> None:
     for template in iter_templates_dir(path):
-        if is_overrided_file(template):
-            if template.name == 'http.py':
-                content = template.read_text()
-
-                # basic check to ensure that the original file has been replaced
-                assert 'template' in content
-            else:  # pragma: no cover
-                assert False, f'Unhandled check for {template}'
-        else:
-            assert template.exists()
+        assert template.exists()
 
 
 def test_repeated_rstrip_bug(tmp_path: Path) -> None:
@@ -91,21 +66,6 @@ def test_template_cleanup(testdir: Testdir) -> None:
     assert_module_is_clean(path)
 
     # ensure cleaning an already clean module doesn't change anything
-    cleanup_templates(path)
-    assert_module_is_clean(path)
-
-
-def test_template_cleanup_original_files_not_replaced(testdir: Testdir) -> None:
-    """Generating the client twice does not override template backups"""
-    path = testdir.path / 'prisma'
-    assert not path.exists()
-
-    # generate twice to ensure that originals of overriding templates
-    # are not replaced
-    testdir.generate()
-    testdir.generate()
-
-    assert_module_not_clean(path)
     cleanup_templates(path)
     assert_module_is_clean(path)
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -36,6 +36,7 @@ def assert_session_state(http: HTTP, state: State) -> None:
 async def test_request_on_closed_sessions() -> None:
     """Attempting to make a request on a closed session raises an error"""
     http = HTTP()
+    http.open()
     assert http.closed is False
     await http.close()
 


### PR DESCRIPTION
## Change Summary

The previous `http.py` behaviour where it was overridden during generation was confusing for new contributors.

This was also prone to bugs as we only run type checks post-generation where the http client would be an async client, however it could also have been a sync client which we would not check for.

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
