### PR TITLE
feat(package): add __slots__

### DIFF
--- a/src/prisma/_async_http.py
+++ b/src/prisma/_async_http.py
@@ -13,6 +13,8 @@ __all__ = ('HTTP', 'Response', 'client')
 class HTTP(AbstractHTTP[httpx.AsyncClient, httpx.Response]):
     session: httpx.AsyncClient
 
+    __slots__ = ()
+
     async def download(self, url: str, dest: str) -> None:
         async with self.session.stream('GET', url, timeout=None) as resp:
             resp.raise_for_status()
@@ -42,6 +44,8 @@ client: HTTP = HTTP()
 
 
 class Response(AbstractResponse[httpx.Response]):
+    __slots__ = ()
+
     @property
     def status(self) -> int:
         return self.original.status_code

--- a/src/prisma/_sync_http.py
+++ b/src/prisma/_sync_http.py
@@ -12,6 +12,8 @@ __all__ = ('HTTP', 'Response', 'client')
 class HTTP(AbstractHTTP[httpx.Client, httpx.Response]):
     session: httpx.Client
 
+    __slots__ = ()
+
     def download(self, url: str, dest: str) -> None:
         with self.session.stream('GET', url, timeout=None) as resp:
             resp.raise_for_status()
@@ -38,6 +40,8 @@ client: HTTP = HTTP()
 
 
 class Response(AbstractResponse[httpx.Response]):
+    __slots__ = ()
+
     @property
     def status(self) -> int:
         return self.original.status_code

--- a/src/prisma/generator/templates/actions.py.jinja
+++ b/src/prisma/generator/templates/actions.py.jinja
@@ -42,6 +42,11 @@ class {{ model.name }}Actions(Generic[BaseModelT]):
 {% set ModelType = "'models.%s'" % model.name %}
 class {{ model.name }}Actions:
 {% endif %}
+    __slots__ = (
+        '_client',
+        '_model',
+    )
+
     def __init__(self, client: 'Client', model: Type[{{ ModelType }}]) -> None:
         self._client = client
         self._model = model

--- a/src/prisma/generator/templates/builder.py.jinja
+++ b/src/prisma/generator/templates/builder.py.jinja
@@ -72,6 +72,15 @@ class QueryBuilder:
     # list of fields to select
     root_selection: Optional[List[str]]
 
+    __slots__ = (
+        'method',
+        'operation',
+        'model',
+        'include',
+        'arguments',
+        'root_selection',
+    )
+
     def __init__(
         self,
         *,
@@ -186,6 +195,8 @@ class QueryBuilder:
 
 
 class AbstractNode(ABC):
+    __slots__ = ()
+
     @abstractmethod
     def render(self) -> Optional[str]:
         """Render the node to a string
@@ -209,6 +220,13 @@ class Node(AbstractNode):
     indent: str
     builder: QueryBuilder
     children: List[ChildType]
+
+    __slots__ = (
+        'joiner',
+        'indent',
+        'builder',
+        'children',
+    )
 
     def __init__(
         self,
@@ -310,6 +328,9 @@ class RootNode(Node):
         <children>
     }
     """
+
+    __slots__ = ()
+
     {% raw %}
     def enter(self) -> str:
         return f'{self.builder.operation} {{'
@@ -341,6 +362,9 @@ class ResultNode(Node):
     result: executeRaw
         <children>
     """
+
+    __slots__ = ()
+
     def __init__(self, indent: str = '', **kwargs: Any) -> None:
         super().__init__(indent=indent, **kwargs)
 
@@ -376,6 +400,8 @@ class Arguments(Node):
     )
     """
     arguments: Dict[str, Any]
+
+    __slots__ = ('arguments',)
 
     def __init__(self, arguments: Dict[str, Any], **kwargs: Any) -> None:
         super().__init__(**kwargs)
@@ -430,6 +456,8 @@ class Data(Node):
     """
     data: Mapping[str, Any]
 
+    __slots__ = ('data',)
+
     def __init__(
         self,
         data: Mapping[str, Any],
@@ -464,6 +492,8 @@ class Data(Node):
 
 class ListNode(Node):
     data: Iterable[Any]
+
+    __slots__ = ('data',)
 
     def __init__(self, data: Iterable[Any], joiner: str = ',\n', **kwargs: Any) -> None:
         super().__init__(joiner=joiner, **kwargs)
@@ -529,6 +559,12 @@ class Selection(Node):
     model: Optional[str]
     include: Optional[Dict[str, Any]]
     root_selection: Optional[List[str]]
+
+    __slots__ = (
+        'model',
+        'include',
+        'root_selection',
+    )
 
     def __init__(
         self,
@@ -624,6 +660,12 @@ class Key(AbstractNode):
     key: str
     sep: str
     node: Node
+
+    __slots__ = (
+        'key',
+        'sep',
+        'node',
+    )
 
     def __init__(self, key: str, node: Node, sep: str = ': ') -> None:
         self.key = key

--- a/src/prisma/generator/templates/client.py.jinja
+++ b/src/prisma/generator/templates/client.py.jinja
@@ -115,6 +115,18 @@ class Prisma:
     {% endif %}
     {% endfor %}
 
+    __slots__ = (
+        {% for model in dmmf.datamodel.models %}
+        '{{ model.name.lower() }}',
+        {% endfor %}
+        '__engine',
+        '_active_provider',
+        '_log_queries',
+        '_datasource',
+        '_connect_timeout',
+        '_http_config',
+    )
+
     def __init__(
         self,
         *,

--- a/src/prisma/generator/templates/fields.py.jinja
+++ b/src/prisma/generator/templates/fields.py.jinja
@@ -72,6 +72,8 @@ class Json(_PydanticJson):
 
 
 class Base64:
+    __slots__ = ('_raw',)
+
     def __init__(self, raw: bytes) -> None:
         self._raw = raw
 

--- a/src/prisma/http_abstract.py
+++ b/src/prisma/http_abstract.py
@@ -32,6 +32,11 @@ DEFAULT_CONFIG: Dict[str, Any] = {
 class AbstractHTTP(ABC, Generic[Session, Response]):
     session_kwargs: Dict[str, Any]
 
+    __slots__ = (
+        '_session',
+        'session_kwargs',
+    )
+
     # NOTE: ParamSpec wouldn't be valid here:
     # https://github.com/microsoft/pyright/issues/2667
     def __init__(self, **kwargs: Any) -> None:
@@ -99,6 +104,8 @@ class AbstractHTTP(ABC, Generic[Session, Response]):
 
 class AbstractResponse(ABC, Generic[Response]):
     original: Response
+
+    __slots__ = ('original',)
 
     def __init__(self, original: Response) -> None:
         self.original = original

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[actions.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[actions.py].raw
@@ -39,6 +39,11 @@ if TYPE_CHECKING:
 
 
 class PostActions:
+    __slots__ = (
+        '_client',
+        '_model',
+    )
+
     def __init__(self, client: 'Client', model: Type['models.Post']) -> None:
         self._client = client
         self._model = model
@@ -953,6 +958,11 @@ class PostActions:
 
 
 class UserActions:
+    __slots__ = (
+        '_client',
+        '_model',
+    )
+
     def __init__(self, client: 'Client', model: Type['models.User']) -> None:
         self._client = client
         self._model = model
@@ -1887,6 +1897,11 @@ class UserActions:
 
 
 class MActions:
+    __slots__ = (
+        '_client',
+        '_model',
+    )
+
     def __init__(self, client: 'Client', model: Type['models.M']) -> None:
         self._client = client
         self._model = model
@@ -2816,6 +2831,11 @@ class MActions:
 
 
 class NActions:
+    __slots__ = (
+        '_client',
+        '_model',
+    )
+
     def __init__(self, client: 'Client', model: Type['models.N']) -> None:
         self._client = client
         self._model = model
@@ -3750,6 +3770,11 @@ class NActions:
 
 
 class OneOptionalActions:
+    __slots__ = (
+        '_client',
+        '_model',
+    )
+
     def __init__(self, client: 'Client', model: Type['models.OneOptional']) -> None:
         self._client = client
         self._model = model
@@ -4679,6 +4704,11 @@ class OneOptionalActions:
 
 
 class ManyRequiredActions:
+    __slots__ = (
+        '_client',
+        '_model',
+    )
+
     def __init__(self, client: 'Client', model: Type['models.ManyRequired']) -> None:
         self._client = client
         self._model = model
@@ -5608,6 +5638,11 @@ class ManyRequiredActions:
 
 
 class ListsActions:
+    __slots__ = (
+        '_client',
+        '_model',
+    )
+
     def __init__(self, client: 'Client', model: Type['models.Lists']) -> None:
         self._client = client
         self._model = model
@@ -6512,6 +6547,11 @@ class ListsActions:
 
 
 class AActions:
+    __slots__ = (
+        '_client',
+        '_model',
+    )
+
     def __init__(self, client: 'Client', model: Type['models.A']) -> None:
         self._client = client
         self._model = model
@@ -7434,6 +7474,11 @@ class AActions:
 
 
 class BActions:
+    __slots__ = (
+        '_client',
+        '_model',
+    )
+
     def __init__(self, client: 'Client', model: Type['models.B']) -> None:
         self._client = client
         self._model = model
@@ -8348,6 +8393,11 @@ class BActions:
 
 
 class CActions:
+    __slots__ = (
+        '_client',
+        '_model',
+    )
+
     def __init__(self, client: 'Client', model: Type['models.C']) -> None:
         self._client = client
         self._model = model
@@ -9274,6 +9324,11 @@ class CActions:
 
 
 class DActions:
+    __slots__ = (
+        '_client',
+        '_model',
+    )
+
     def __init__(self, client: 'Client', model: Type['models.D']) -> None:
         self._client = client
         self._model = model
@@ -10203,6 +10258,11 @@ class DActions:
 
 
 class EActions:
+    __slots__ = (
+        '_client',
+        '_model',
+    )
+
     def __init__(self, client: 'Client', model: Type['models.E']) -> None:
         self._client = client
         self._model = model

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[builder.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[builder.py].raw
@@ -241,6 +241,15 @@ class QueryBuilder:
     # list of fields to select
     root_selection: Optional[List[str]]
 
+    __slots__ = (
+        'method',
+        'operation',
+        'model',
+        'include',
+        'arguments',
+        'root_selection',
+    )
+
     def __init__(
         self,
         *,
@@ -355,6 +364,8 @@ class QueryBuilder:
 
 
 class AbstractNode(ABC):
+    __slots__ = ()
+
     @abstractmethod
     def render(self) -> Optional[str]:
         """Render the node to a string
@@ -378,6 +389,13 @@ class Node(AbstractNode):
     indent: str
     builder: QueryBuilder
     children: List[ChildType]
+
+    __slots__ = (
+        'joiner',
+        'indent',
+        'builder',
+        'children',
+    )
 
     def __init__(
         self,
@@ -480,6 +498,9 @@ class RootNode(Node):
     }
     """
 
+    __slots__ = ()
+
+
     def enter(self) -> str:
         return f'{self.builder.operation} {{'
 
@@ -509,6 +530,9 @@ class ResultNode(Node):
     result: executeRaw
         <children>
     """
+
+    __slots__ = ()
+
     def __init__(self, indent: str = '', **kwargs: Any) -> None:
         super().__init__(indent=indent, **kwargs)
 
@@ -544,6 +568,8 @@ class Arguments(Node):
     )
     """
     arguments: Dict[str, Any]
+
+    __slots__ = ('arguments',)
 
     def __init__(self, arguments: Dict[str, Any], **kwargs: Any) -> None:
         super().__init__(**kwargs)
@@ -598,6 +624,8 @@ class Data(Node):
     """
     data: Mapping[str, Any]
 
+    __slots__ = ('data',)
+
     def __init__(
         self,
         data: Mapping[str, Any],
@@ -632,6 +660,8 @@ class Data(Node):
 
 class ListNode(Node):
     data: Iterable[Any]
+
+    __slots__ = ('data',)
 
     def __init__(self, data: Iterable[Any], joiner: str = ',\n', **kwargs: Any) -> None:
         super().__init__(joiner=joiner, **kwargs)
@@ -697,6 +727,12 @@ class Selection(Node):
     model: Optional[str]
     include: Optional[Dict[str, Any]]
     root_selection: Optional[List[str]]
+
+    __slots__ = (
+        'model',
+        'include',
+        'root_selection',
+    )
 
     def __init__(
         self,
@@ -792,6 +828,12 @@ class Key(AbstractNode):
     key: str
     sep: str
     node: Node
+
+    __slots__ = (
+        'key',
+        'sep',
+        'node',
+    )
 
     def __init__(self, key: str, node: Node, sep: str = ': ') -> None:
         self.key = key

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
@@ -323,6 +323,27 @@ class Prisma:
     d: 'actions.DActions'
     e: 'actions.EActions'
 
+    __slots__ = (
+        'post',
+        'user',
+        'm',
+        'n',
+        'oneoptional',
+        'manyrequired',
+        'lists',
+        'a',
+        'b',
+        'c',
+        'd',
+        'e',
+        '__engine',
+        '_active_provider',
+        '_log_queries',
+        '_datasource',
+        '_connect_timeout',
+        '_http_config',
+    )
+
     def __init__(
         self,
         *,

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[fields.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[fields.py].raw
@@ -99,6 +99,8 @@ class Json(_PydanticJson):
 
 
 class Base64:
+    __slots__ = ('_raw',)
+
     def __init__(self, raw: bytes) -> None:
         self._raw = raw
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[actions.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[actions.py].raw
@@ -39,6 +39,11 @@ if TYPE_CHECKING:
 
 
 class PostActions:
+    __slots__ = (
+        '_client',
+        '_model',
+    )
+
     def __init__(self, client: 'Client', model: Type['models.Post']) -> None:
         self._client = client
         self._model = model
@@ -953,6 +958,11 @@ class PostActions:
 
 
 class UserActions:
+    __slots__ = (
+        '_client',
+        '_model',
+    )
+
     def __init__(self, client: 'Client', model: Type['models.User']) -> None:
         self._client = client
         self._model = model
@@ -1887,6 +1897,11 @@ class UserActions:
 
 
 class MActions:
+    __slots__ = (
+        '_client',
+        '_model',
+    )
+
     def __init__(self, client: 'Client', model: Type['models.M']) -> None:
         self._client = client
         self._model = model
@@ -2816,6 +2831,11 @@ class MActions:
 
 
 class NActions:
+    __slots__ = (
+        '_client',
+        '_model',
+    )
+
     def __init__(self, client: 'Client', model: Type['models.N']) -> None:
         self._client = client
         self._model = model
@@ -3750,6 +3770,11 @@ class NActions:
 
 
 class OneOptionalActions:
+    __slots__ = (
+        '_client',
+        '_model',
+    )
+
     def __init__(self, client: 'Client', model: Type['models.OneOptional']) -> None:
         self._client = client
         self._model = model
@@ -4679,6 +4704,11 @@ class OneOptionalActions:
 
 
 class ManyRequiredActions:
+    __slots__ = (
+        '_client',
+        '_model',
+    )
+
     def __init__(self, client: 'Client', model: Type['models.ManyRequired']) -> None:
         self._client = client
         self._model = model
@@ -5608,6 +5638,11 @@ class ManyRequiredActions:
 
 
 class ListsActions:
+    __slots__ = (
+        '_client',
+        '_model',
+    )
+
     def __init__(self, client: 'Client', model: Type['models.Lists']) -> None:
         self._client = client
         self._model = model
@@ -6512,6 +6547,11 @@ class ListsActions:
 
 
 class AActions:
+    __slots__ = (
+        '_client',
+        '_model',
+    )
+
     def __init__(self, client: 'Client', model: Type['models.A']) -> None:
         self._client = client
         self._model = model
@@ -7434,6 +7474,11 @@ class AActions:
 
 
 class BActions:
+    __slots__ = (
+        '_client',
+        '_model',
+    )
+
     def __init__(self, client: 'Client', model: Type['models.B']) -> None:
         self._client = client
         self._model = model
@@ -8348,6 +8393,11 @@ class BActions:
 
 
 class CActions:
+    __slots__ = (
+        '_client',
+        '_model',
+    )
+
     def __init__(self, client: 'Client', model: Type['models.C']) -> None:
         self._client = client
         self._model = model
@@ -9274,6 +9324,11 @@ class CActions:
 
 
 class DActions:
+    __slots__ = (
+        '_client',
+        '_model',
+    )
+
     def __init__(self, client: 'Client', model: Type['models.D']) -> None:
         self._client = client
         self._model = model
@@ -10203,6 +10258,11 @@ class DActions:
 
 
 class EActions:
+    __slots__ = (
+        '_client',
+        '_model',
+    )
+
     def __init__(self, client: 'Client', model: Type['models.E']) -> None:
         self._client = client
         self._model = model

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[builder.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[builder.py].raw
@@ -241,6 +241,15 @@ class QueryBuilder:
     # list of fields to select
     root_selection: Optional[List[str]]
 
+    __slots__ = (
+        'method',
+        'operation',
+        'model',
+        'include',
+        'arguments',
+        'root_selection',
+    )
+
     def __init__(
         self,
         *,
@@ -355,6 +364,8 @@ class QueryBuilder:
 
 
 class AbstractNode(ABC):
+    __slots__ = ()
+
     @abstractmethod
     def render(self) -> Optional[str]:
         """Render the node to a string
@@ -378,6 +389,13 @@ class Node(AbstractNode):
     indent: str
     builder: QueryBuilder
     children: List[ChildType]
+
+    __slots__ = (
+        'joiner',
+        'indent',
+        'builder',
+        'children',
+    )
 
     def __init__(
         self,
@@ -480,6 +498,9 @@ class RootNode(Node):
     }
     """
 
+    __slots__ = ()
+
+
     def enter(self) -> str:
         return f'{self.builder.operation} {{'
 
@@ -509,6 +530,9 @@ class ResultNode(Node):
     result: executeRaw
         <children>
     """
+
+    __slots__ = ()
+
     def __init__(self, indent: str = '', **kwargs: Any) -> None:
         super().__init__(indent=indent, **kwargs)
 
@@ -544,6 +568,8 @@ class Arguments(Node):
     )
     """
     arguments: Dict[str, Any]
+
+    __slots__ = ('arguments',)
 
     def __init__(self, arguments: Dict[str, Any], **kwargs: Any) -> None:
         super().__init__(**kwargs)
@@ -598,6 +624,8 @@ class Data(Node):
     """
     data: Mapping[str, Any]
 
+    __slots__ = ('data',)
+
     def __init__(
         self,
         data: Mapping[str, Any],
@@ -632,6 +660,8 @@ class Data(Node):
 
 class ListNode(Node):
     data: Iterable[Any]
+
+    __slots__ = ('data',)
 
     def __init__(self, data: Iterable[Any], joiner: str = ',\n', **kwargs: Any) -> None:
         super().__init__(joiner=joiner, **kwargs)
@@ -697,6 +727,12 @@ class Selection(Node):
     model: Optional[str]
     include: Optional[Dict[str, Any]]
     root_selection: Optional[List[str]]
+
+    __slots__ = (
+        'model',
+        'include',
+        'root_selection',
+    )
 
     def __init__(
         self,
@@ -792,6 +828,12 @@ class Key(AbstractNode):
     key: str
     sep: str
     node: Node
+
+    __slots__ = (
+        'key',
+        'sep',
+        'node',
+    )
 
     def __init__(self, key: str, node: Node, sep: str = ': ') -> None:
         self.key = key

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
@@ -323,6 +323,27 @@ class Prisma:
     d: 'actions.DActions'
     e: 'actions.EActions'
 
+    __slots__ = (
+        'post',
+        'user',
+        'm',
+        'n',
+        'oneoptional',
+        'manyrequired',
+        'lists',
+        'a',
+        'b',
+        'c',
+        'd',
+        'e',
+        '__engine',
+        '_active_provider',
+        '_log_queries',
+        '_datasource',
+        '_connect_timeout',
+        '_http_config',
+    )
+
     def __init__(
         self,
         *,

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[fields.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[fields.py].raw
@@ -99,6 +99,8 @@ class Json(_PydanticJson):
 
 
 class Base64:
+    __slots__ = ('_raw',)
+
     def __init__(self, raw: bytes) -> None:
         self._raw = raw
 

--- a/tox.ini
+++ b/tox.ini
@@ -113,12 +113,14 @@ deps =
     blue==0.7.0
     mypy==0.910
     pyright==1.1.225
+    slotscheck==0.14.0
 
 commands =
     blue --check .
     pyright {envsitepackagesdir}/prisma tests
     pyright --ignoreexternal --verifytypes prisma
     interrogate -v --omit-covered-files --fail-under 100 --whitelist-regex "test_.*" --exclude */.venv/* tests
+    slotscheck -m prisma
 
 
 [testenv:mypy]


### PR DESCRIPTION
## Change Summary

Closes #299 
Adds `__slots__` to:
- `client.Prisma`
- `actions.*Actions`
- `http_abstract.HTTP` (+ sync and async subclasses)
- `http_abstract.Response` (+ sync and async subclasses)
- `QueryBuilder` + `Node` and its subclasses
- the `Base64` field type

I haven't added `__slots__` to models yet, but I would like to. The issue mentions that you're not sure about it, but I frankly can't see any problems it could cause. The `pydantic.BaseModel` superclass is slotted, and should someone need to subclass a model (though why would they?), slots on the model itself shouldn't cause any trouble.

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass without significant drop in coverage
- [x] Documentation reflects changes where applicable
- [x] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
