### PR TITLE
feat(types): add support for in/not_in for Bytes

### DIFF
--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -414,6 +414,8 @@ profile = await db.profile.find_first(
         # or
         'image': {
             'equals': Base64.encode(b'my binary data'),
+            'in': [Base64.encode(b'my binary data')],
+            'not_in': [Base64.encode(b'my other binary data')],
             'not': Base64(b'WW91IGZvdW5kIGFuIGVhc3RlciBlZ2chIExldCBAUm9iZXJ0Q3JhaWdpZSBrbm93IDop'),
         },
     },

--- a/src/prisma/generator/templates/types.py.jinja
+++ b/src/prisma/generator/templates/types.py.jinja
@@ -275,6 +275,8 @@ class FloatWithAggregatesFilter(FloatFilter, total=False):
     '{{ name }}',
     {
         'equals': 'fields.Base64',
+        'in': List['fields.Base64'],
+        'not_in': List['fields.Base64'],
         {%+ if next != '' -%}
             'not': Union['fields.Base64', '{{ next }}'],
         {% endif %}

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[types.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[types.py].raw
@@ -369,6 +369,8 @@ BytesFilter = TypedDict(
     'BytesFilter',
     {
         'equals': 'fields.Base64',
+        'in': List['fields.Base64'],
+        'not_in': List['fields.Base64'],
         'not': Union['fields.Base64', 'BytesFilterRecursive1'],
     },
     total=False,
@@ -379,6 +381,8 @@ BytesFilterRecursive1 = TypedDict(
     'BytesFilterRecursive1',
     {
         'equals': 'fields.Base64',
+        'in': List['fields.Base64'],
+        'not_in': List['fields.Base64'],
         'not': Union['fields.Base64', 'BytesFilterRecursive2'],
     },
     total=False,
@@ -389,6 +393,8 @@ BytesFilterRecursive2 = TypedDict(
     'BytesFilterRecursive2',
     {
         'equals': 'fields.Base64',
+        'in': List['fields.Base64'],
+        'not_in': List['fields.Base64'],
             },
     total=False,
 )

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[types.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[types.py].raw
@@ -369,6 +369,8 @@ BytesFilter = TypedDict(
     'BytesFilter',
     {
         'equals': 'fields.Base64',
+        'in': List['fields.Base64'],
+        'not_in': List['fields.Base64'],
         'not': Union['fields.Base64', 'BytesFilterRecursive1'],
     },
     total=False,
@@ -379,6 +381,8 @@ BytesFilterRecursive1 = TypedDict(
     'BytesFilterRecursive1',
     {
         'equals': 'fields.Base64',
+        'in': List['fields.Base64'],
+        'not_in': List['fields.Base64'],
         'not': Union['fields.Base64', 'BytesFilterRecursive2'],
     },
     total=False,
@@ -389,6 +393,8 @@ BytesFilterRecursive2 = TypedDict(
     'BytesFilterRecursive2',
     {
         'equals': 'fields.Base64',
+        'in': List['fields.Base64'],
+        'not_in': List['fields.Base64'],
             },
     total=False,
 )

--- a/tests/test_types/test_bytes.py
+++ b/tests/test_types/test_bytes.py
@@ -60,6 +60,15 @@ async def test_filtering(client: Prisma) -> None:
     assert found is not None
     assert found.bytes.decode() == b'a'
 
+    found = await client.types.find_first(
+        where={
+            'bytes': {
+                'in': [Base64.encode(b'c')],
+            },
+        },
+    )
+    assert found is None
+
     found = await client.types.find_many(
         where={
             'bytes': {

--- a/tests/test_types/test_bytes.py
+++ b/tests/test_types/test_bytes.py
@@ -69,15 +69,14 @@ async def test_filtering(client: Prisma) -> None:
     )
     assert found is None
 
-    found = await client.types.find_many(
+    found_list = await client.types.find_many(
         where={
             'bytes': {
                 'not_in': [Base64.encode(b'a'), Base64.encode(b'c')],
             }
         },
     )
-    assert found is not None
-    found_values = {record.bytes.decode() for record in found}
+    found_values = {record.bytes.decode() for record in found_list}
     assert found_values == {b'b', b'foo bar'}
 
 

--- a/tests/test_types/test_bytes.py
+++ b/tests/test_types/test_bytes.py
@@ -50,6 +50,27 @@ async def test_filtering(client: Prisma) -> None:
     assert found is not None
     assert found.bytes.decode() == b'a'
 
+    found = await client.types.find_first(
+        where={
+            'bytes': {
+                'in': [Base64.encode(b'a'), Base64.encode(b'c')],
+            }
+        },
+    )
+    assert found is not None
+    assert found.bytes.decode() == b'a'
+
+    found = await client.types.find_many(
+        where={
+            'bytes': {
+                'not_in': [Base64.encode(b'a'), Base64.encode(b'c')],
+            }
+        },
+    )
+    assert found is not None
+    found_values = {record.bytes.decode() for record in found}
+    assert found_values == {b'b', b'foo bar'}
+
 
 @pytest.mark.asyncio
 async def test_json(client: Prisma) -> None:


### PR DESCRIPTION
## Change Summary

Closes #156 
Adds support for filtering `Bytes` fields by `in`/`not_in`.

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass without significant drop in coverage
- [x] Documentation reflects changes where applicable
- [x] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
