### PR TITLE
fix(client): export Client alias

### DIFF
--- a/src/prisma/generator/templates/client.py.jinja
+++ b/src/prisma/generator/templates/client.py.jinja
@@ -14,6 +14,7 @@ from .generator.models import EngineType
 __all__ = (
     'ENGINE_TYPE',
     'Prisma',
+    'Client',
     'load_env',
     'register',
     'get_client',

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -156,3 +156,10 @@ async def test_custom_http_options(monkeypatch: 'MonkeyPatch') -> None:
             'trust_env': False,
         },
     )
+
+
+def test_old_client_alias() -> None:
+    """Ensure that Prisma can be imported from the root package under the Client alias"""
+    from prisma import Client, Prisma
+
+    assert Client == Prisma

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
@@ -41,6 +41,7 @@ from .generator.models import EngineType
 __all__ = (
     'ENGINE_TYPE',
     'Prisma',
+    'Client',
     'load_env',
     'register',
     'get_client',

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
@@ -41,6 +41,7 @@ from .generator.models import EngineType
 __all__ = (
     'ENGINE_TYPE',
     'Prisma',
+    'Client',
     'load_env',
     'register',
     'get_client',


### PR DESCRIPTION
## Change Summary

We forgot to actually continue to export the old `Client` alias when we changed it to `Prisma`

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass without significant drop in coverage
- [x] Documentation reflects changes where applicable
- [x] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
