### PR TITLE
chore(lint): fix invalid pyright configuration comments

### DIFF
--- a/src/prisma/binaries/constants.py
+++ b/src/prisma/binaries/constants.py
@@ -47,7 +47,7 @@ GLOBAL_TEMP_DIR = (
 )
 
 # local file path for the prisma CLI
-if platform.name() == 'windows':  # pyright: reportConstantRedefinition=false
+if platform.name() == 'windows':
     PRISMA_CLI_NAME = f'prisma-cli-{platform.name()}.exe'
 else:
-    PRISMA_CLI_NAME = f'prisma-cli-{platform.name()}'
+    PRISMA_CLI_NAME = f'prisma-cli-{platform.name()}'  # pyright: ignore[reportConstantRedefinition]

--- a/src/prisma/generator/models.py
+++ b/src/prisma/generator/models.py
@@ -390,7 +390,9 @@ class Config(BaseSettings):
         cls, value: Optional[str]
     ) -> Optional[Module]:
         try:
-            return Module(spec=value)  # pyright: reportGeneralTypeIssues=false
+            return Module(
+                spec=value  # pyright: ignore[reportGeneralTypeIssues]
+            )
         except ValueError:
             if value is None:
                 # no config value passed and the default location was not found

--- a/src/prisma/generator/templates/client.py.jinja
+++ b/src/prisma/generator/templates/client.py.jinja
@@ -99,7 +99,7 @@ def get_client() -> 'Prisma':
         return registered
 
     client = registered()
-    if not isinstance(client, Prisma):  # pyright: reportUnnecessaryIsInstance=false
+    if not isinstance(client, Prisma):  # pyright: ignore[reportUnnecessaryIsInstance]
         raise TypeError(
             f'Registered function returned {client} instead of a {Prisma} instance.'
         )

--- a/src/prisma/generator/templates/fields.py.jinja
+++ b/src/prisma/generator/templates/fields.py.jinja
@@ -64,10 +64,10 @@ class Json(_PydanticJson):
             ...
 
         @overload
-        def __getitem__(self, i: '_JsonKeys') -> 'Serializable':  # pyright: reportIncompatibleMethodOverride=false
+        def __getitem__(self, i: '_JsonKeys') -> 'Serializable':
             ...
 
-        def __getitem__(self, i: Union['_JsonKeys', slice]) -> 'Serializable':
+        def __getitem__(self, i: Union['_JsonKeys', slice]) -> 'Serializable':  # pyright: ignore[reportIncompatibleMethodOverride]
             ...
 
 

--- a/src/prisma/generator/templates/models.py.jinja
+++ b/src/prisma/generator/templates/models.py.jinja
@@ -222,7 +222,7 @@ class {{ model.name }}(BaseModel):
         {% endfor %}
     }
 {% else -%}
-    _{{ model.name }}_relational_fields: Set[str] = set()  # pyright: reportUnusedVariable=false
+    _{{ model.name }}_relational_fields: Set[str] = set()  # pyright: ignore[reportUnusedVariable]
 {% endif %}
 _{{ model.name }}_fields: Dict['types.{{ model.name }}Keys', PartialModelField] = {
     {% for field in model.all_fields %}

--- a/src/prisma/generator/templates/types.py.jinja
+++ b/src/prisma/generator/templates/types.py.jinja
@@ -517,7 +517,7 @@ class {{ model.name }}UpdateOneWithoutRelationsInput(TypedDict, total=False):
 
 class {{ model.name }}UpsertInput(TypedDict):
     create: '{{ model.name }}CreateInput'
-    update: '{{ model.name }}UpdateInput'  # pyright: reportIncompatibleMethodOverride=false
+    update: '{{ model.name }}UpdateInput'  # pyright: ignore[reportIncompatibleMethodOverride]
 
 
 {{ render_type(model_schema.order_by) }}

--- a/src/prisma/http_abstract.py
+++ b/src/prisma/http_abstract.py
@@ -89,7 +89,7 @@ class AbstractHTTP(ABC, Generic[Session, Response]):
     @session.setter
     def session(
         self, value: Optional[Session]
-    ) -> None:  # pyright: reportPropertyTypeMismatch=false
+    ) -> None:  # pyright: ignore[reportPropertyTypeMismatch]
         self._session = value
 
     def should_close(self) -> bool:

--- a/src/prisma/utils.py
+++ b/src/prisma/utils.py
@@ -19,7 +19,7 @@ DEBUG = _env_bool('PRISMA_PY_DEBUG')
 DEBUG_GENERATOR = _env_bool('PRISMA_PY_DEBUG_GENERATOR')
 
 
-class _NoneType:  # pyright: reportUnusedClass=false
+class _NoneType:  # pyright: ignore[reportUnusedClass]
     def __bool__(self) -> bool:
         return False
 

--- a/src/prisma/validator.py
+++ b/src/prisma/validator.py
@@ -79,7 +79,7 @@ def validate(type: Type[T], data: Any) -> T:
         # incorrectly inferred type as we have verified that the given type
         # is indeed a TypedDict
         model = create_model_from_typeddict(
-            type, __config__=Config  # pyright: reportGeneralTypeIssues=false
+            type, __config__=Config  # pyright: ignore[reportGeneralTypeIssues]
         )
         model.update_forward_refs(**vars(_get_module(type)))
         type.__pydantic_model__ = model  # type: ignore

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -157,9 +157,7 @@ class IntegrationTestItem(pytest.Item):
 
 class IntegrationTestFile(pytest.File):
     @classmethod
-    def from_parent(
-        cls, *args: Any, **kwargs: Any
-    ) -> 'IntegrationTestFile':  # pyright: reportIncompatibleMethodOverride=false
+    def from_parent(cls, *args: Any, **kwargs: Any) -> 'IntegrationTestFile':
         return cast(
             IntegrationTestFile,
             super().from_parent(*args, **kwargs),  # type: ignore[no-untyped-call]

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -202,7 +202,7 @@ def test_custom_serialization(snapshot: SnapshotAssertion) -> None:
             self.arg = arg
 
     @serializer.register(Foo)
-    def custom_serializer(inst: Foo) -> int:  # pyright: reportUnusedFunction=false
+    def custom_serializer(inst: Foo) -> int:  # pyright: ignore[reportUnusedFunction]
         return inst.arg
 
     query = QueryBuilder(

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
@@ -302,7 +302,7 @@ def get_client() -> 'Prisma':
         return registered
 
     client = registered()
-    if not isinstance(client, Prisma):  # pyright: reportUnnecessaryIsInstance=false
+    if not isinstance(client, Prisma):  # pyright: ignore[reportUnnecessaryIsInstance]
         raise TypeError(
             f'Registered function returned {client} instead of a {Prisma} instance.'
         )

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[fields.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[fields.py].raw
@@ -91,10 +91,10 @@ class Json(_PydanticJson):
             ...
 
         @overload
-        def __getitem__(self, i: '_JsonKeys') -> 'Serializable':  # pyright: reportIncompatibleMethodOverride=false
+        def __getitem__(self, i: '_JsonKeys') -> 'Serializable':
             ...
 
-        def __getitem__(self, i: Union['_JsonKeys', slice]) -> 'Serializable':
+        def __getitem__(self, i: Union['_JsonKeys', slice]) -> 'Serializable':  # pyright: ignore[reportIncompatibleMethodOverride]
             ...
 
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[models.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[models.py].raw
@@ -1986,7 +1986,7 @@ _ManyRequired_fields: Dict['types.ManyRequiredKeys', PartialModelField] = {
     },
 }
 
-_Lists_relational_fields: Set[str] = set()  # pyright: reportUnusedVariable=false
+_Lists_relational_fields: Set[str] = set()  # pyright: ignore[reportUnusedVariable]
 _Lists_fields: Dict['types.ListsKeys', PartialModelField] = {
     'id': {
         'name': 'id',
@@ -2044,7 +2044,7 @@ _Lists_fields: Dict['types.ListsKeys', PartialModelField] = {
     },
 }
 
-_A_relational_fields: Set[str] = set()  # pyright: reportUnusedVariable=false
+_A_relational_fields: Set[str] = set()  # pyright: ignore[reportUnusedVariable]
 _A_fields: Dict['types.AKeys', PartialModelField] = {
     'email': {
         'name': 'email',
@@ -2102,7 +2102,7 @@ _A_fields: Dict['types.AKeys', PartialModelField] = {
     },
 }
 
-_B_relational_fields: Set[str] = set()  # pyright: reportUnusedVariable=false
+_B_relational_fields: Set[str] = set()  # pyright: ignore[reportUnusedVariable]
 _B_fields: Dict['types.BKeys', PartialModelField] = {
     'id': {
         'name': 'id',
@@ -2124,7 +2124,7 @@ _B_fields: Dict['types.BKeys', PartialModelField] = {
     },
 }
 
-_C_relational_fields: Set[str] = set()  # pyright: reportUnusedVariable=false
+_C_relational_fields: Set[str] = set()  # pyright: ignore[reportUnusedVariable]
 _C_fields: Dict['types.CKeys', PartialModelField] = {
     'char': {
         'name': 'char',
@@ -2164,7 +2164,7 @@ _C_fields: Dict['types.CKeys', PartialModelField] = {
     },
 }
 
-_D_relational_fields: Set[str] = set()  # pyright: reportUnusedVariable=false
+_D_relational_fields: Set[str] = set()  # pyright: ignore[reportUnusedVariable]
 _D_fields: Dict['types.DKeys', PartialModelField] = {
     'id': {
         'name': 'id',
@@ -2204,7 +2204,7 @@ _D_fields: Dict['types.DKeys', PartialModelField] = {
     },
 }
 
-_E_relational_fields: Set[str] = set()  # pyright: reportUnusedVariable=false
+_E_relational_fields: Set[str] = set()  # pyright: ignore[reportUnusedVariable]
 _E_fields: Dict['types.EKeys', PartialModelField] = {
     'id': {
         'name': 'id',

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[types.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[types.py].raw
@@ -972,7 +972,7 @@ class PostUpdateOneWithoutRelationsInput(TypedDict, total=False):
 
 class PostUpsertInput(TypedDict):
     create: 'PostCreateInput'
-    update: 'PostUpdateInput'  # pyright: reportIncompatibleMethodOverride=false
+    update: 'PostUpdateInput'  # pyright: ignore[reportIncompatibleMethodOverride]
 
 
 _Post_id_OrderByInput = TypedDict(
@@ -2131,7 +2131,7 @@ class UserUpdateOneWithoutRelationsInput(TypedDict, total=False):
 
 class UserUpsertInput(TypedDict):
     create: 'UserCreateInput'
-    update: 'UserUpdateInput'  # pyright: reportIncompatibleMethodOverride=false
+    update: 'UserUpdateInput'  # pyright: ignore[reportIncompatibleMethodOverride]
 
 
 _User_id_OrderByInput = TypedDict(
@@ -3422,7 +3422,7 @@ class MUpdateOneWithoutRelationsInput(TypedDict, total=False):
 
 class MUpsertInput(TypedDict):
     create: 'MCreateInput'
-    update: 'MUpdateInput'  # pyright: reportIncompatibleMethodOverride=false
+    update: 'MUpdateInput'  # pyright: ignore[reportIncompatibleMethodOverride]
 
 
 _M_id_OrderByInput = TypedDict(
@@ -4698,7 +4698,7 @@ class NUpdateOneWithoutRelationsInput(TypedDict, total=False):
 
 class NUpsertInput(TypedDict):
     create: 'NCreateInput'
-    update: 'NUpdateInput'  # pyright: reportIncompatibleMethodOverride=false
+    update: 'NUpdateInput'  # pyright: ignore[reportIncompatibleMethodOverride]
 
 
 _N_id_OrderByInput = TypedDict(
@@ -6012,7 +6012,7 @@ class OneOptionalUpdateOneWithoutRelationsInput(TypedDict, total=False):
 
 class OneOptionalUpsertInput(TypedDict):
     create: 'OneOptionalCreateInput'
-    update: 'OneOptionalUpdateInput'  # pyright: reportIncompatibleMethodOverride=false
+    update: 'OneOptionalUpdateInput'  # pyright: ignore[reportIncompatibleMethodOverride]
 
 
 _OneOptional_id_OrderByInput = TypedDict(
@@ -7280,7 +7280,7 @@ class ManyRequiredUpdateOneWithoutRelationsInput(TypedDict, total=False):
 
 class ManyRequiredUpsertInput(TypedDict):
     create: 'ManyRequiredCreateInput'
-    update: 'ManyRequiredUpdateInput'  # pyright: reportIncompatibleMethodOverride=false
+    update: 'ManyRequiredUpdateInput'  # pyright: ignore[reportIncompatibleMethodOverride]
 
 
 _ManyRequired_id_OrderByInput = TypedDict(
@@ -8564,7 +8564,7 @@ class ListsUpdateOneWithoutRelationsInput(TypedDict, total=False):
 
 class ListsUpsertInput(TypedDict):
     create: 'ListsCreateInput'
-    update: 'ListsUpdateInput'  # pyright: reportIncompatibleMethodOverride=false
+    update: 'ListsUpdateInput'  # pyright: ignore[reportIncompatibleMethodOverride]
 
 
 _Lists_id_OrderByInput = TypedDict(
@@ -9784,7 +9784,7 @@ class AUpdateOneWithoutRelationsInput(TypedDict, total=False):
 
 class AUpsertInput(TypedDict):
     create: 'ACreateInput'
-    update: 'AUpdateInput'  # pyright: reportIncompatibleMethodOverride=false
+    update: 'AUpdateInput'  # pyright: ignore[reportIncompatibleMethodOverride]
 
 
 _A_email_OrderByInput = TypedDict(
@@ -10988,7 +10988,7 @@ class BUpdateOneWithoutRelationsInput(TypedDict, total=False):
 
 class BUpsertInput(TypedDict):
     create: 'BCreateInput'
-    update: 'BUpdateInput'  # pyright: reportIncompatibleMethodOverride=false
+    update: 'BUpdateInput'  # pyright: ignore[reportIncompatibleMethodOverride]
 
 
 _B_id_OrderByInput = TypedDict(
@@ -12043,7 +12043,7 @@ class CUpdateOneWithoutRelationsInput(TypedDict, total=False):
 
 class CUpsertInput(TypedDict):
     create: 'CCreateInput'
-    update: 'CUpdateInput'  # pyright: reportIncompatibleMethodOverride=false
+    update: 'CUpdateInput'  # pyright: ignore[reportIncompatibleMethodOverride]
 
 
 _C_char_OrderByInput = TypedDict(
@@ -13152,7 +13152,7 @@ class DUpdateOneWithoutRelationsInput(TypedDict, total=False):
 
 class DUpsertInput(TypedDict):
     create: 'DCreateInput'
-    update: 'DUpdateInput'  # pyright: reportIncompatibleMethodOverride=false
+    update: 'DUpdateInput'  # pyright: ignore[reportIncompatibleMethodOverride]
 
 
 _D_id_OrderByInput = TypedDict(
@@ -14253,7 +14253,7 @@ class EUpdateOneWithoutRelationsInput(TypedDict, total=False):
 
 class EUpsertInput(TypedDict):
     create: 'ECreateInput'
-    update: 'EUpdateInput'  # pyright: reportIncompatibleMethodOverride=false
+    update: 'EUpdateInput'  # pyright: ignore[reportIncompatibleMethodOverride]
 
 
 _E_id_OrderByInput = TypedDict(

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
@@ -302,7 +302,7 @@ def get_client() -> 'Prisma':
         return registered
 
     client = registered()
-    if not isinstance(client, Prisma):  # pyright: reportUnnecessaryIsInstance=false
+    if not isinstance(client, Prisma):  # pyright: ignore[reportUnnecessaryIsInstance]
         raise TypeError(
             f'Registered function returned {client} instead of a {Prisma} instance.'
         )

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[fields.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[fields.py].raw
@@ -91,10 +91,10 @@ class Json(_PydanticJson):
             ...
 
         @overload
-        def __getitem__(self, i: '_JsonKeys') -> 'Serializable':  # pyright: reportIncompatibleMethodOverride=false
+        def __getitem__(self, i: '_JsonKeys') -> 'Serializable':
             ...
 
-        def __getitem__(self, i: Union['_JsonKeys', slice]) -> 'Serializable':
+        def __getitem__(self, i: Union['_JsonKeys', slice]) -> 'Serializable':  # pyright: ignore[reportIncompatibleMethodOverride]
             ...
 
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[models.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[models.py].raw
@@ -1986,7 +1986,7 @@ _ManyRequired_fields: Dict['types.ManyRequiredKeys', PartialModelField] = {
     },
 }
 
-_Lists_relational_fields: Set[str] = set()  # pyright: reportUnusedVariable=false
+_Lists_relational_fields: Set[str] = set()  # pyright: ignore[reportUnusedVariable]
 _Lists_fields: Dict['types.ListsKeys', PartialModelField] = {
     'id': {
         'name': 'id',
@@ -2044,7 +2044,7 @@ _Lists_fields: Dict['types.ListsKeys', PartialModelField] = {
     },
 }
 
-_A_relational_fields: Set[str] = set()  # pyright: reportUnusedVariable=false
+_A_relational_fields: Set[str] = set()  # pyright: ignore[reportUnusedVariable]
 _A_fields: Dict['types.AKeys', PartialModelField] = {
     'email': {
         'name': 'email',
@@ -2102,7 +2102,7 @@ _A_fields: Dict['types.AKeys', PartialModelField] = {
     },
 }
 
-_B_relational_fields: Set[str] = set()  # pyright: reportUnusedVariable=false
+_B_relational_fields: Set[str] = set()  # pyright: ignore[reportUnusedVariable]
 _B_fields: Dict['types.BKeys', PartialModelField] = {
     'id': {
         'name': 'id',
@@ -2124,7 +2124,7 @@ _B_fields: Dict['types.BKeys', PartialModelField] = {
     },
 }
 
-_C_relational_fields: Set[str] = set()  # pyright: reportUnusedVariable=false
+_C_relational_fields: Set[str] = set()  # pyright: ignore[reportUnusedVariable]
 _C_fields: Dict['types.CKeys', PartialModelField] = {
     'char': {
         'name': 'char',
@@ -2164,7 +2164,7 @@ _C_fields: Dict['types.CKeys', PartialModelField] = {
     },
 }
 
-_D_relational_fields: Set[str] = set()  # pyright: reportUnusedVariable=false
+_D_relational_fields: Set[str] = set()  # pyright: ignore[reportUnusedVariable]
 _D_fields: Dict['types.DKeys', PartialModelField] = {
     'id': {
         'name': 'id',
@@ -2204,7 +2204,7 @@ _D_fields: Dict['types.DKeys', PartialModelField] = {
     },
 }
 
-_E_relational_fields: Set[str] = set()  # pyright: reportUnusedVariable=false
+_E_relational_fields: Set[str] = set()  # pyright: ignore[reportUnusedVariable]
 _E_fields: Dict['types.EKeys', PartialModelField] = {
     'id': {
         'name': 'id',

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[types.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[types.py].raw
@@ -972,7 +972,7 @@ class PostUpdateOneWithoutRelationsInput(TypedDict, total=False):
 
 class PostUpsertInput(TypedDict):
     create: 'PostCreateInput'
-    update: 'PostUpdateInput'  # pyright: reportIncompatibleMethodOverride=false
+    update: 'PostUpdateInput'  # pyright: ignore[reportIncompatibleMethodOverride]
 
 
 _Post_id_OrderByInput = TypedDict(
@@ -2131,7 +2131,7 @@ class UserUpdateOneWithoutRelationsInput(TypedDict, total=False):
 
 class UserUpsertInput(TypedDict):
     create: 'UserCreateInput'
-    update: 'UserUpdateInput'  # pyright: reportIncompatibleMethodOverride=false
+    update: 'UserUpdateInput'  # pyright: ignore[reportIncompatibleMethodOverride]
 
 
 _User_id_OrderByInput = TypedDict(
@@ -3422,7 +3422,7 @@ class MUpdateOneWithoutRelationsInput(TypedDict, total=False):
 
 class MUpsertInput(TypedDict):
     create: 'MCreateInput'
-    update: 'MUpdateInput'  # pyright: reportIncompatibleMethodOverride=false
+    update: 'MUpdateInput'  # pyright: ignore[reportIncompatibleMethodOverride]
 
 
 _M_id_OrderByInput = TypedDict(
@@ -4698,7 +4698,7 @@ class NUpdateOneWithoutRelationsInput(TypedDict, total=False):
 
 class NUpsertInput(TypedDict):
     create: 'NCreateInput'
-    update: 'NUpdateInput'  # pyright: reportIncompatibleMethodOverride=false
+    update: 'NUpdateInput'  # pyright: ignore[reportIncompatibleMethodOverride]
 
 
 _N_id_OrderByInput = TypedDict(
@@ -6012,7 +6012,7 @@ class OneOptionalUpdateOneWithoutRelationsInput(TypedDict, total=False):
 
 class OneOptionalUpsertInput(TypedDict):
     create: 'OneOptionalCreateInput'
-    update: 'OneOptionalUpdateInput'  # pyright: reportIncompatibleMethodOverride=false
+    update: 'OneOptionalUpdateInput'  # pyright: ignore[reportIncompatibleMethodOverride]
 
 
 _OneOptional_id_OrderByInput = TypedDict(
@@ -7280,7 +7280,7 @@ class ManyRequiredUpdateOneWithoutRelationsInput(TypedDict, total=False):
 
 class ManyRequiredUpsertInput(TypedDict):
     create: 'ManyRequiredCreateInput'
-    update: 'ManyRequiredUpdateInput'  # pyright: reportIncompatibleMethodOverride=false
+    update: 'ManyRequiredUpdateInput'  # pyright: ignore[reportIncompatibleMethodOverride]
 
 
 _ManyRequired_id_OrderByInput = TypedDict(
@@ -8564,7 +8564,7 @@ class ListsUpdateOneWithoutRelationsInput(TypedDict, total=False):
 
 class ListsUpsertInput(TypedDict):
     create: 'ListsCreateInput'
-    update: 'ListsUpdateInput'  # pyright: reportIncompatibleMethodOverride=false
+    update: 'ListsUpdateInput'  # pyright: ignore[reportIncompatibleMethodOverride]
 
 
 _Lists_id_OrderByInput = TypedDict(
@@ -9784,7 +9784,7 @@ class AUpdateOneWithoutRelationsInput(TypedDict, total=False):
 
 class AUpsertInput(TypedDict):
     create: 'ACreateInput'
-    update: 'AUpdateInput'  # pyright: reportIncompatibleMethodOverride=false
+    update: 'AUpdateInput'  # pyright: ignore[reportIncompatibleMethodOverride]
 
 
 _A_email_OrderByInput = TypedDict(
@@ -10988,7 +10988,7 @@ class BUpdateOneWithoutRelationsInput(TypedDict, total=False):
 
 class BUpsertInput(TypedDict):
     create: 'BCreateInput'
-    update: 'BUpdateInput'  # pyright: reportIncompatibleMethodOverride=false
+    update: 'BUpdateInput'  # pyright: ignore[reportIncompatibleMethodOverride]
 
 
 _B_id_OrderByInput = TypedDict(
@@ -12043,7 +12043,7 @@ class CUpdateOneWithoutRelationsInput(TypedDict, total=False):
 
 class CUpsertInput(TypedDict):
     create: 'CCreateInput'
-    update: 'CUpdateInput'  # pyright: reportIncompatibleMethodOverride=false
+    update: 'CUpdateInput'  # pyright: ignore[reportIncompatibleMethodOverride]
 
 
 _C_char_OrderByInput = TypedDict(
@@ -13152,7 +13152,7 @@ class DUpdateOneWithoutRelationsInput(TypedDict, total=False):
 
 class DUpsertInput(TypedDict):
     create: 'DCreateInput'
-    update: 'DUpdateInput'  # pyright: reportIncompatibleMethodOverride=false
+    update: 'DUpdateInput'  # pyright: ignore[reportIncompatibleMethodOverride]
 
 
 _D_id_OrderByInput = TypedDict(
@@ -14253,7 +14253,7 @@ class EUpdateOneWithoutRelationsInput(TypedDict, total=False):
 
 class EUpsertInput(TypedDict):
     create: 'ECreateInput'
-    update: 'EUpdateInput'  # pyright: reportIncompatibleMethodOverride=false
+    update: 'EUpdateInput'  # pyright: ignore[reportIncompatibleMethodOverride]
 
 
 _E_id_OrderByInput = TypedDict(

--- a/tests/test_generation/test_generator.py
+++ b/tests/test_generation/test_generator.py
@@ -109,9 +109,8 @@ def test_invalid_type_argument() -> None:
         def generate(self, data: Path) -> None:  # pragma: no cover
             return super().generate(data)
 
-    # TODO: pyright regression?
     with pytest.raises(TypeError) as exc:
-        MyGenerator().data_class  # pyright: reportGeneralTypeIssues=false
+        MyGenerator().data_class
 
     assert 'pathlib.Path' in exc.value.args[0]
     assert 'pydantic.main.BaseModel' in exc.value.args[0]
@@ -131,7 +130,7 @@ def test_generator_subclass_mismatch() -> None:
     """Attempting to subclass Generator instead of BaseGenerator raises an error"""
     with pytest.raises(TypeError) as exc:
 
-        class MyGenerator(Generator):  # pyright: reportUnusedClass=false
+        class MyGenerator(Generator):  # pyright: ignore[reportUnusedClass]
             ...
 
     message = exc.value.args[0]

--- a/tests/test_generation/test_models.py
+++ b/tests/test_generation/test_models.py
@@ -24,8 +24,8 @@ def test_recursive_type_depth() -> None:
 
     with pytest.raises(ValidationError) as exc:
         Config(
-            recursive_type_depth='a'
-        )  # pyright: reportGeneralTypeIssues=false
+            recursive_type_depth='a'  # pyright: ignore[reportGeneralTypeIssues]
+        )
 
     assert exc.match('value is not a valid integer')
 

--- a/tests/test_group_by.py
+++ b/tests/test_group_by.py
@@ -138,7 +138,7 @@ async def test_order_mismatched_arguments(client: Prisma) -> None:
     with pytest.raises(prisma.errors.InputError) as exc:
         await client.profile.group_by(
             ['city'],
-            order={  # pyright: reportGeneralTypeIssues=false
+            order={
                 'country': 'asc',
             },
         )

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -42,7 +42,7 @@ async def test_request_on_closed_sessions() -> None:
 
     # mypy thinks that http.closed is Literal[False]
     # when it is in fact a bool
-    closed = cast(bool, http.closed)  # pyright: reportUnnecessaryCast = false
+    closed = cast(bool, http.closed)
     assert closed is True
 
     with pytest.raises(HTTPClientClosedError):

--- a/tests/test_include.py
+++ b/tests/test_include.py
@@ -83,9 +83,12 @@ async def test_find_unique_include(client: Prisma, user_id: str) -> None:
     )
     assert user is not None
     assert user.name == 'Robert'
-    assert len(user.posts) == 4  # pyright: reportGeneralTypeIssues=false
+    assert len(user.posts) == 4  # pyright: ignore[reportGeneralTypeIssues]
 
-    for i, post in enumerate(user.posts, start=1):
+    for i, post in enumerate(
+        user.posts,  # pyright: ignore[reportGeneralTypeIssues]
+        start=1,
+    ):
         assert post.author is None
         assert post.author_id == user.id
         assert post.title == f'Post {i}'
@@ -96,10 +99,17 @@ async def test_find_unique_include(client: Prisma, user_id: str) -> None:
 async def test_find_unique_include_take(client: Prisma, user_id: str) -> None:
     """Including a one-to-many relationship with take limits amount of returned models"""
     user = await client.user.find_unique(
-        where={'id': user_id}, include={'posts': {'take': 1}}
+        where={
+            'id': user_id,
+        },
+        include={
+            'posts': {
+                'take': 1,
+            },
+        },
     )
     assert user is not None
-    assert len(user.posts) == 1  # pyright: reportGeneralTypeIssues=false
+    assert len(user.posts) == 1  # pyright: ignore[reportGeneralTypeIssues]
 
 
 @pytest.mark.asyncio
@@ -113,7 +123,7 @@ async def test_find_unique_include_where(
         include={'posts': {'where': {'created_at': posts[0].created_at}}},
     )
     assert user is not None
-    assert len(user.posts) == 1  # pyright: reportGeneralTypeIssues=false
+    assert len(user.posts) == 1  # pyright: ignore[reportGeneralTypeIssues]
     assert user.posts[0].id == posts[0].id
 
 
@@ -130,7 +140,7 @@ async def test_find_unique_include_pagination(
         },
     )
     assert user is not None
-    assert len(user.posts) == 1  # pyright: reportGeneralTypeIssues=false
+    assert len(user.posts) == 1  # pyright: ignore[reportGeneralTypeIssues]
     assert user.posts[0].id == posts[1].id
 
     user = await client.user.find_unique(
@@ -140,7 +150,7 @@ async def test_find_unique_include_pagination(
         },
     )
     assert user is not None
-    assert len(user.posts) == 1  # pyright: reportGeneralTypeIssues=false
+    assert len(user.posts) == 1  # pyright: ignore[reportGeneralTypeIssues]
     assert user.posts[0].id == posts[0].id
 
 
@@ -161,7 +171,7 @@ async def test_find_unique_include_nested_where_or(
     assert user is not None
 
     assert posts[0].published is False
-    assert len(user.posts) == 3  # pyright: reportGeneralTypeIssues=false
+    assert len(user.posts) == 3  # pyright: ignore[reportGeneralTypeIssues]
 
     assert user.posts[0].id == posts[0].id
     assert user.posts[1].id == posts[1].id

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,6 +5,9 @@ from prisma.models import User
 from prisma.errors import UnsupportedSubclassWarning
 
 
+# pyright: reportUnusedClass=false
+
+
 async def create_user() -> User:
     user = await User.prisma().create(
         data={
@@ -273,18 +276,14 @@ def test_subclassing_warns() -> None:
     """
     with pytest.warns(UnsupportedSubclassWarning):
 
-        class MyUser(User):  # pyright: reportUnusedClass=false
+        class MyUser(User):
             pass
 
-    class MyUser2(
-        User, warn_subclass=False
-    ):  # pyright: reportUnusedClass=false
+    class MyUser2(User, warn_subclass=False):
         pass
 
     # ensure other arguments can be passed to support multiple inheritance
-    class MyUser3(
-        User, warn_subclass=False, foo=1
-    ):  # pyright: reportUnusedClass=false
+    class MyUser3(User, warn_subclass=False, foo=1):
         pass
 
 

--- a/tests/test_types/test_bigint.py
+++ b/tests/test_types/test_bigint.py
@@ -194,7 +194,7 @@ async def test_atomic_update_invalid_input(client: Prisma) -> None:
             where={
                 'id': 1,
             },
-            data={  # pyright: reportGeneralTypeIssues=false
+            data={  # pyright: ignore[reportGeneralTypeIssues]
                 'bigint': {  # type: ignore
                     'divide': 1,
                     'multiply': 2,

--- a/tests/test_types/test_float.py
+++ b/tests/test_types/test_float.py
@@ -194,7 +194,7 @@ async def test_atomic_update_invalid_input(client: Prisma) -> None:
             where={
                 'id': 1,
             },
-            data={  # pyright: reportGeneralTypeIssues=false
+            data={  # pyright: ignore[reportGeneralTypeIssues]
                 'float_': {  # type: ignore
                     'divide': 1,
                     'multiply': 2,

--- a/tests/test_types/test_int.py
+++ b/tests/test_types/test_int.py
@@ -194,7 +194,7 @@ async def test_atomic_update_invalid_input(client: Prisma) -> None:
             where={
                 'id': 1,
             },
-            data={  # pyright: reportGeneralTypeIssues=false
+            data={
                 'integer': {  # type: ignore
                     'divide': 1,
                     'multiply': 2,

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -55,7 +55,7 @@ async def test_update_with_create_disconnect(
         where={'id': user_id}, include={'posts': True}
     )
     assert user is not None
-    assert len(user.posts) == 0  # pyright: reportGeneralTypeIssues=false
+    assert len(user.posts) == 0
 
     updated = await client.user.update(
         where={'id': user_id},
@@ -63,7 +63,7 @@ async def test_update_with_create_disconnect(
         include={'posts': True},
     )
     assert updated is not None
-    assert len(updated.posts) == 1  # pyright: reportGeneralTypeIssues=false
+    assert len(updated.posts) == 1
 
     if method == 'disconnect':
         # pyright: reportOptionalSubscript=false

--- a/tox.ini
+++ b/tox.ini
@@ -112,7 +112,7 @@ deps =
     interrogate==1.5.0
     blue==0.7.0
     mypy==0.910
-    pyright==1.1.225
+    pyright==1.1.231
     slotscheck==0.14.0
 
 commands =


### PR DESCRIPTION
## Change Summary

These comments disabled the diagnostic for the entire module when I only intended for them to be disabled on an individual line. This PR fixes that and removes some redundant comments

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
