### PR TITLE
feat(client): export query batcher for alternative API style

### DIFF
--- a/src/prisma/generator/templates/client.py.jinja
+++ b/src/prisma/generator/templates/client.py.jinja
@@ -13,6 +13,7 @@ from .generator.models import EngineType
 
 __all__ = (
     'ENGINE_TYPE',
+    'Batch',
     'Prisma',
     'Client',
     'load_env',

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
@@ -41,6 +41,7 @@ from .generator.models import EngineType
 
 __all__ = (
     'ENGINE_TYPE',
+    'Batch',
     'Prisma',
     'Client',
     'load_env',

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
@@ -41,6 +41,7 @@ from .generator.models import EngineType
 
 __all__ = (
     'ENGINE_TYPE',
+    'Batch',
     'Prisma',
     'Client',
     'load_env',


### PR DESCRIPTION
## Change Summary

Export `Batch` so it can be used like so:

```py
from prisma import Batch, Prisma

prisma = Prisma()
async with Batch(prisma) as batcher:
    ...
```

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
