### PR TITLE
feat(typings): more accurate types for internal utility functions

### DIFF
--- a/src/prisma/_types.py
+++ b/src/prisma/_types.py
@@ -1,6 +1,7 @@
 from typing import Callable, Coroutine, TypeVar, Type, Tuple, Any
 from pydantic import BaseModel
 from typing_extensions import (
+    TypeGuard as TypeGuard,
     TypedDict as TypedDict,
     Protocol as Protocol,
     Literal as Literal,
@@ -14,8 +15,8 @@ CallableT = TypeVar('CallableT', bound='FuncType')
 BaseModelT = TypeVar('BaseModelT', bound=BaseModel)
 
 # TODO: use a TypeVar everywhere
-FuncType = Callable[..., Any]
-CoroType = Callable[..., Coroutine[Any, Any, Any]]
+FuncType = Callable[..., object]
+CoroType = Callable[..., Coroutine[Any, Any, object]]
 
 
 @runtime_checkable

--- a/src/prisma/cli/commands/dev.py
+++ b/src/prisma/cli/commands/dev.py
@@ -12,7 +12,7 @@ def cli() -> None:
     """Commands for developing Prisma Client Python"""
 
 
-@cli.command()
+@cli.command
 @options.schema
 @options.skip_generate
 def playground(schema: Optional[str], skip_generate: bool) -> None:

--- a/src/prisma/utils.py
+++ b/src/prisma/utils.py
@@ -6,9 +6,12 @@ import logging
 import warnings
 import contextlib
 from importlib.util import find_spec
-from typing import Any, Union, Dict, Iterator, Coroutine, NoReturn
+from typing import Any, TypeVar, Union, Dict, Iterator, Coroutine, NoReturn
 
-from ._types import FuncType, CoroType
+from ._types import FuncType, CoroType, TypeGuard
+
+
+_T = TypeVar('_T')
 
 
 def _env_bool(key: str) -> bool:
@@ -36,20 +39,21 @@ def setup_logging() -> None:
 
 
 def maybe_async_run(
-    func: Union[FuncType, CoroType], *args: Any, **kwargs: Any
-) -> Any:
+    func: Union[FuncType, CoroType],
+    *args: Any,
+    **kwargs: Any,
+) -> object:
     if is_coroutine(func):
         return async_run(func(*args, **kwargs))
     return func(*args, **kwargs)
 
 
-# TODO: TypeVar return
-def async_run(coro: Coroutine[Any, Any, Any]) -> Any:
+def async_run(coro: Coroutine[Any, Any, _T]) -> _T:
     """Execute the coroutine and return the result."""
     return get_or_create_event_loop().run_until_complete(coro)
 
 
-def is_coroutine(obj: Any) -> bool:
+def is_coroutine(obj: Any) -> TypeGuard[CoroType]:
     return asyncio.iscoroutinefunction(obj) or inspect.isgeneratorfunction(obj)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -112,7 +112,7 @@ deps =
     interrogate==1.5.0
     blue==0.7.0
     mypy==0.910
-    pyright==1.1.231
+    pyright==1.1.236
     slotscheck==0.14.0
 
 commands =


### PR DESCRIPTION
## Change Summary

- Add TypeGuard to `is_coroutine`
- Add TypeVar to `async_run`
- Return `object` instead of `Any` for `maybe_async_run`

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
