### PR TITLE
feat(typing): change timeout args type to timedelta

### DIFF
--- a/docs/reference/client.md
+++ b/docs/reference/client.md
@@ -38,6 +38,30 @@ db = Prisma(
 )
 ```
 
+## Connection Timeout
+
+You can set the timeout used to connect to the database on a Client level and on an indiviual `connect()` call basis. The default timeout is 10 seconds.
+
+Client level setting:
+```py
+from datetime import timedelta
+
+db = Prisma(
+    connect_timeout=timedelta(seconds=15),
+)
+```
+
+All subsequent calls to `connect()` will now timeout after 15 seconds.
+
+```py
+from datetime import timedelta
+
+db = Prisma()
+await db.connect(timeout=timedelta(seconds=5))
+```
+
+The `db.connect()` call will timeout if it takes longer than 5 seconds.
+
 ## Context Manager
 
 To make running small scripts as easy as possible, Prisma Client Python supports connecting and disconnecting from the database using a [context manager](https://book.pythontips.com/en/latest/context_managers.html).

--- a/src/prisma/generator/templates/client.py.jinja
+++ b/src/prisma/generator/templates/client.py.jinja
@@ -155,7 +155,7 @@ class Prisma:
         elif isinstance(connect_timeout, int):
             message = (
                 'Using integers for connect_timeout argument is deprecated'
-                ' and will be removed in the next release.\n'
+                ' and will be removed in the next major release.\n'
                 'You can disable this warning by passing a datetime.timedelta object instead of an integer. e.g.'
                 'prisma = Prisma(connect_timeout=datetime.timedelta(seconds=10))'
             )
@@ -222,7 +222,7 @@ class Prisma:
         elif isinstance(timeout, int):
             message = (
                 'Using integers for timeout argument is deprecated'
-                ' and will be removed in the next release.\n'
+                ' and will be removed in the next major release.\n'
                 'You can disable this warning by passing a datetime.timedelta object instead of an integer. e.g.'
                 'prisma.connect(timeout=datetime.timedelta(seconds=10))'
             )

--- a/src/prisma/generator/templates/client.py.jinja
+++ b/src/prisma/generator/templates/client.py.jinja
@@ -2,7 +2,7 @@
 {% from '_utils.py.jinja' import is_async, maybe_async_def, maybe_await, methods, operations, recursive_types, active_provider with context %}
 # -- template client.py.jinja --
 from types import TracebackType
-
+import warnings
 from . import types, models, errors, actions
 from .types import DatasourceOverride, HttpConfig
 from ._types import BaseModelT
@@ -36,13 +36,13 @@ class UseClientDefault:
     by typing the parameter with this class rather than using None, for example:
 
     ```py
-    def connect(timeout: Union[int, UseClientDefault] = UseClientDefault()) -> None: ...
+    def connect(timeout: Union[datetime.timedelta, int, UseClientDefault] = UseClientDefault()) -> None: ...
     ```
 
     relays the intention more clearly than:
 
     ```py
-    def connect(timeout: Optional[int] = None) -> None: ...
+    def connect(timeout: Optional[datetime.timedelta, int] = None) -> None: ...
     ```
 
     This solution also allows us to indicate an "unset" state that is uniquely distinct
@@ -136,7 +136,7 @@ class Prisma:
         log_queries: bool = False,
         auto_register: bool = False,
         datasource: Optional[DatasourceOverride] = None,
-        connect_timeout: int = 10,
+        connect_timeout: Optional[Union[datetime.timedelta, int,UseClientDefault]] = _USE_CLIENT_DEFAULT,
         http: Optional[HttpConfig] = None,
     ) -> None:
         {% for model in dmmf.datamodel.models %}
@@ -150,7 +150,19 @@ class Prisma:
         self._active_provider = '{{ active_provider }}'
         self._log_queries = log_queries
         self._datasource = datasource
-        self._connect_timeout = connect_timeout
+        if connect_timeout is None or isinstance(connect_timeout, UseClientDefault):
+            self._connect_timeout = datetime.timedelta(seconds=10)
+        elif isinstance(connect_timeout, int):
+            message = (
+                'Using integers for connect_timeout argument is deprecated'
+                ' and will be removed in the next release.\n'
+                'You can disable this warning by passing a datetime.timedelta object instead of an integer. e.g.'
+                'prisma = Prisma(connect_timeout=datetime.timedelta(seconds=10))'
+            )
+            warnings.warn(message, DeprecationWarning, stacklevel=4)
+            self._connect_timeout = datetime.timedelta(seconds=connect_timeout)
+        else:
+            self._connect_timeout = connect_timeout
         self._http_config: HttpConfig = http or {}
 
         if use_dotenv:
@@ -199,7 +211,7 @@ class Prisma:
 
     {{ maybe_async_def }}connect(
         self,
-        timeout: Union[int, UseClientDefault] = _USE_CLIENT_DEFAULT,
+        timeout: Union[datetime.timedelta, int, UseClientDefault] = _USE_CLIENT_DEFAULT,
     ) -> None:
         """Connect to the Prisma query engine.
 
@@ -207,6 +219,15 @@ class Prisma:
         """
         if isinstance(timeout, UseClientDefault):
             timeout = self._connect_timeout
+        elif isinstance(timeout, int):
+            message = (
+                'Using integers for timeout argument is deprecated'
+                ' and will be removed in the next release.\n'
+                'You can disable this warning by passing a datetime.timedelta object instead of an integer. e.g.'
+                'prisma.connect(timeout=datetime.timedelta(seconds=10))'
+            )
+            warnings.warn(message, DeprecationWarning, stacklevel=4)
+            timeout = datetime.timedelta(seconds=timeout)
 
         if self.__engine is None:
             self.__engine = self._create_engine(dml=SCHEMA)
@@ -218,7 +239,7 @@ class Prisma:
             datasources = [ds]
 
         {{ maybe_await }}self.__engine.connect(
-            timeout=timeout,
+            timeout=int(timeout.total_seconds()),
             datasources=datasources,
         )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping
-
+from datetime import timedelta
 import httpx
 import pytest
 from mock import AsyncMock
@@ -54,7 +54,7 @@ async def test_datasource_overwriting(
     other = Prisma(
         datasource={'url': 'file:./tmp.db'},
     )
-    await other.connect(timeout=1)
+    await other.connect(timeout=timedelta(seconds=1))
 
     user = await other.user.create({'name': 'Robert'})
     assert user.name == 'Robert'
@@ -98,7 +98,7 @@ def test_engine_type() -> None:
 @pytest.mark.asyncio
 async def test_connect_timeout(mocker: MockerFixture) -> None:
     """Setting the timeout on a client and a per-call basis works"""
-    client = Prisma(connect_timeout=7)
+    client = Prisma(connect_timeout=timedelta(seconds=7))
     mocked = mocker.patch.object(
         client._engine_class,
         'connect',
@@ -109,7 +109,7 @@ async def test_connect_timeout(mocker: MockerFixture) -> None:
     mocked.assert_called_once_with(timeout=7, datasources=None)
     mocked.reset_mock()
 
-    await client.connect(timeout=5)
+    await client.connect(timeout=timedelta(seconds=5))
     mocked.assert_called_once_with(timeout=5, datasources=None)
 
 
@@ -163,3 +163,18 @@ def test_old_client_alias() -> None:
     from prisma import Client, Prisma
 
     assert Client == Prisma
+
+
+@pytest.mark.asyncio
+async def test_warn_when_connect_timeout_is_int() -> None:
+    """Ensure that when Prisma(connect_timeout:int), connect_timeout is converted to a timedelta and a warning is emitted"""
+    with pytest.warns(DeprecationWarning):
+        Prisma(connect_timeout=10)
+
+
+@pytest.mark.asyncio
+async def test_warn_when_client_connecting_with_int_timeout() -> None:
+    """Ensure that when calling client.connect(timeout:int), timeout is converted to a timedelta and a warning is emitted"""
+    with pytest.warns(DeprecationWarning):
+        client = Prisma()
+        await client.connect(timeout=10)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -111,6 +111,10 @@ async def test_connect_timeout(mocker: MockerFixture) -> None:
 
     await client.connect(timeout=timedelta(seconds=5))
     mocked.assert_called_once_with(timeout=5, datasources=None)
+    mocked.reset_mock()
+
+    await client.connect(timeout=timedelta(minutes=1, seconds=5))
+    mocked.assert_called_once_with(timeout=65, datasources=None)
 
 
 @pytest.mark.asyncio

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
@@ -30,7 +30,7 @@ from typing_extensions import TypedDict, Literal
 
 # -- template client.py.jinja --
 from types import TracebackType
-
+import warnings
 from . import types, models, errors, actions
 from .types import DatasourceOverride, HttpConfig
 from ._types import BaseModelT
@@ -247,13 +247,13 @@ class UseClientDefault:
     by typing the parameter with this class rather than using None, for example:
 
     ```py
-    def connect(timeout: Union[int, UseClientDefault] = UseClientDefault()) -> None: ...
+    def connect(timeout: Union[datetime.timedelta, int, UseClientDefault] = UseClientDefault()) -> None: ...
     ```
 
     relays the intention more clearly than:
 
     ```py
-    def connect(timeout: Optional[int] = None) -> None: ...
+    def connect(timeout: Optional[datetime.timedelta, int] = None) -> None: ...
     ```
 
     This solution also allows us to indicate an "unset" state that is uniquely distinct
@@ -361,7 +361,7 @@ class Prisma:
         log_queries: bool = False,
         auto_register: bool = False,
         datasource: Optional[DatasourceOverride] = None,
-        connect_timeout: int = 10,
+        connect_timeout: Optional[Union[datetime.timedelta, int,UseClientDefault]] = _USE_CLIENT_DEFAULT,
         http: Optional[HttpConfig] = None,
     ) -> None:
         self.post = actions.PostActions(self, models.Post)
@@ -380,7 +380,19 @@ class Prisma:
         self._active_provider = 'postgresql'
         self._log_queries = log_queries
         self._datasource = datasource
-        self._connect_timeout = connect_timeout
+        if connect_timeout is None or isinstance(connect_timeout, UseClientDefault):
+            self._connect_timeout = datetime.timedelta(seconds=10)
+        elif isinstance(connect_timeout, int):
+            message = (
+                'Using integers for connect_timeout argument is deprecated'
+                ' and will be removed in the next release.\n'
+                'You can disable this warning by passing a datetime.timedelta object instead of an integer. e.g.'
+                'prisma = Prisma(connect_timeout=datetime.timedelta(seconds=10))'
+            )
+            warnings.warn(message, DeprecationWarning, stacklevel=4)
+            self._connect_timeout = datetime.timedelta(seconds=connect_timeout)
+        else:
+            self._connect_timeout = connect_timeout
         self._http_config: HttpConfig = http or {}
 
         if use_dotenv:
@@ -414,7 +426,7 @@ class Prisma:
 
     async def connect(
         self,
-        timeout: Union[int, UseClientDefault] = _USE_CLIENT_DEFAULT,
+        timeout: Union[datetime.timedelta, int, UseClientDefault] = _USE_CLIENT_DEFAULT,
     ) -> None:
         """Connect to the Prisma query engine.
 
@@ -422,6 +434,15 @@ class Prisma:
         """
         if isinstance(timeout, UseClientDefault):
             timeout = self._connect_timeout
+        elif isinstance(timeout, int):
+            message = (
+                'Using integers for timeout argument is deprecated'
+                ' and will be removed in the next release.\n'
+                'You can disable this warning by passing a datetime.timedelta object instead of an integer. e.g.'
+                'prisma.connect(timeout=datetime.timedelta(seconds=10))'
+            )
+            warnings.warn(message, DeprecationWarning, stacklevel=4)
+            timeout = datetime.timedelta(seconds=timeout)
 
         if self.__engine is None:
             self.__engine = self._create_engine(dml=SCHEMA)
@@ -433,7 +454,7 @@ class Prisma:
             datasources = [ds]
 
         await self.__engine.connect(
-            timeout=timeout,
+            timeout=int(timeout.total_seconds()),
             datasources=datasources,
         )
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
@@ -387,7 +387,7 @@ class Prisma:
         elif isinstance(connect_timeout, int):
             message = (
                 'Using integers for connect_timeout argument is deprecated'
-                ' and will be removed in the next release.\n'
+                ' and will be removed in the next major release.\n'
                 'You can disable this warning by passing a datetime.timedelta object instead of an integer. e.g.'
                 'prisma = Prisma(connect_timeout=datetime.timedelta(seconds=10))'
             )
@@ -439,7 +439,7 @@ class Prisma:
         elif isinstance(timeout, int):
             message = (
                 'Using integers for timeout argument is deprecated'
-                ' and will be removed in the next release.\n'
+                ' and will be removed in the next major release.\n'
                 'You can disable this warning by passing a datetime.timedelta object instead of an integer. e.g.'
                 'prisma.connect(timeout=datetime.timedelta(seconds=10))'
             )

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
@@ -30,7 +30,7 @@ from typing_extensions import TypedDict, Literal
 
 # -- template client.py.jinja --
 from types import TracebackType
-
+import warnings
 from . import types, models, errors, actions
 from .types import DatasourceOverride, HttpConfig
 from ._types import BaseModelT
@@ -247,13 +247,13 @@ class UseClientDefault:
     by typing the parameter with this class rather than using None, for example:
 
     ```py
-    def connect(timeout: Union[int, UseClientDefault] = UseClientDefault()) -> None: ...
+    def connect(timeout: Union[datetime.timedelta, int, UseClientDefault] = UseClientDefault()) -> None: ...
     ```
 
     relays the intention more clearly than:
 
     ```py
-    def connect(timeout: Optional[int] = None) -> None: ...
+    def connect(timeout: Optional[datetime.timedelta, int] = None) -> None: ...
     ```
 
     This solution also allows us to indicate an "unset" state that is uniquely distinct
@@ -361,7 +361,7 @@ class Prisma:
         log_queries: bool = False,
         auto_register: bool = False,
         datasource: Optional[DatasourceOverride] = None,
-        connect_timeout: int = 10,
+        connect_timeout: Optional[Union[datetime.timedelta, int,UseClientDefault]] = _USE_CLIENT_DEFAULT,
         http: Optional[HttpConfig] = None,
     ) -> None:
         self.post = actions.PostActions(self, models.Post)
@@ -380,7 +380,19 @@ class Prisma:
         self._active_provider = 'postgresql'
         self._log_queries = log_queries
         self._datasource = datasource
-        self._connect_timeout = connect_timeout
+        if connect_timeout is None or isinstance(connect_timeout, UseClientDefault):
+            self._connect_timeout = datetime.timedelta(seconds=10)
+        elif isinstance(connect_timeout, int):
+            message = (
+                'Using integers for connect_timeout argument is deprecated'
+                ' and will be removed in the next release.\n'
+                'You can disable this warning by passing a datetime.timedelta object instead of an integer. e.g.'
+                'prisma = Prisma(connect_timeout=datetime.timedelta(seconds=10))'
+            )
+            warnings.warn(message, DeprecationWarning, stacklevel=4)
+            self._connect_timeout = datetime.timedelta(seconds=connect_timeout)
+        else:
+            self._connect_timeout = connect_timeout
         self._http_config: HttpConfig = http or {}
 
         if use_dotenv:
@@ -414,7 +426,7 @@ class Prisma:
 
     def connect(
         self,
-        timeout: Union[int, UseClientDefault] = _USE_CLIENT_DEFAULT,
+        timeout: Union[datetime.timedelta, int, UseClientDefault] = _USE_CLIENT_DEFAULT,
     ) -> None:
         """Connect to the Prisma query engine.
 
@@ -422,6 +434,15 @@ class Prisma:
         """
         if isinstance(timeout, UseClientDefault):
             timeout = self._connect_timeout
+        elif isinstance(timeout, int):
+            message = (
+                'Using integers for timeout argument is deprecated'
+                ' and will be removed in the next release.\n'
+                'You can disable this warning by passing a datetime.timedelta object instead of an integer. e.g.'
+                'prisma.connect(timeout=datetime.timedelta(seconds=10))'
+            )
+            warnings.warn(message, DeprecationWarning, stacklevel=4)
+            timeout = datetime.timedelta(seconds=timeout)
 
         if self.__engine is None:
             self.__engine = self._create_engine(dml=SCHEMA)
@@ -433,7 +454,7 @@ class Prisma:
             datasources = [ds]
 
         self.__engine.connect(
-            timeout=timeout,
+            timeout=int(timeout.total_seconds()),
             datasources=datasources,
         )
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
@@ -387,7 +387,7 @@ class Prisma:
         elif isinstance(connect_timeout, int):
             message = (
                 'Using integers for connect_timeout argument is deprecated'
-                ' and will be removed in the next release.\n'
+                ' and will be removed in the next major release.\n'
                 'You can disable this warning by passing a datetime.timedelta object instead of an integer. e.g.'
                 'prisma = Prisma(connect_timeout=datetime.timedelta(seconds=10))'
             )
@@ -439,7 +439,7 @@ class Prisma:
         elif isinstance(timeout, int):
             message = (
                 'Using integers for timeout argument is deprecated'
-                ' and will be removed in the next release.\n'
+                ' and will be removed in the next major release.\n'
                 'You can disable this warning by passing a datetime.timedelta object instead of an integer. e.g.'
                 'prisma.connect(timeout=datetime.timedelta(seconds=10))'
             )


### PR DESCRIPTION
change the type of timeout args  to timedelta
and raise a depreciation warning when provided type is an integer
fixes #167 
## Change Summary

change the type of timeout args in client generation and in `connect` method of client  to timedelta
and raise a depreciation warning when provided type is an integer

## Checklist

- ✅ Unit tests for the changes exist
- ✅ Tests pass without significant drop in coverage
- ✅ Documentation reflects changes where applicable
- ✅Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
