### PR TITLE
feat(client): add ForeignKeyViolationError

### DIFF
--- a/src/prisma/engine/utils.py
+++ b/src/prisma/engine/utils.py
@@ -18,6 +18,7 @@ from ..binaries import GLOBAL_TEMP_DIR, ENGINE_VERSION, platform
 log: logging.Logger = logging.getLogger(__name__)
 ERROR_MAPPING: Dict[str, Type[Exception]] = {
     'P2002': prisma_errors.UniqueViolationError,
+    'P2003': prisma_errors.ForeignKeyViolationError,
     'P2009': prisma_errors.FieldNotFoundError,
     'P2010': prisma_errors.RawQueryError,
     'P2012': prisma_errors.MissingRequiredValueError,

--- a/src/prisma/errors.py
+++ b/src/prisma/errors.py
@@ -75,6 +75,10 @@ class UniqueViolationError(DataError):
     pass
 
 
+class ForeignKeyViolationError(DataError):
+    pass
+
+
 class MissingRequiredValueError(DataError):
     pass
 

--- a/src/prisma/errors.py
+++ b/src/prisma/errors.py
@@ -5,6 +5,7 @@ __all__ = (
     'PrismaError',
     'DataError',
     'UniqueViolationError',
+    'ForeignKeyViolationError',
     'MissingRequiredValueError',
     'RawQueryError',
     'TableNotFoundError',

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,7 +1,7 @@
 import pytest
 
 from prisma import Prisma
-from prisma.errors import FieldNotFoundError
+from prisma.errors import FieldNotFoundError, ForeignKeyViolationError
 
 
 @pytest.mark.asyncio
@@ -30,4 +30,17 @@ async def test_field_not_found_error(client: Prisma) -> None:
                     },
                 },
             },
+        )
+
+
+@pytest.mark.asyncio
+async def test_foreign_key_violation_error(client: Prisma) -> None:
+    """The ForeignKeyViolationError is raised when a foreign key is invalid."""
+    with pytest.raises(ForeignKeyViolationError):
+        await client.post.create(
+            data={
+                'title': 'foo',
+                'published': True,
+                'author_id': 'cjld2cjxh0000qzrmn831i7rn',
+            }
         )

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -36,7 +36,7 @@ async def test_field_not_found_error(client: Prisma) -> None:
 @pytest.mark.asyncio
 async def test_foreign_key_violation_error(client: Prisma) -> None:
     """The ForeignKeyViolationError is raised when a foreign key is invalid."""
-    with pytest.raises(ForeignKeyViolationError):
+    with pytest.raises(ForeignKeyViolationError, match='foreign key'):
         await client.post.create(
             data={
                 'title': 'foo',


### PR DESCRIPTION
## Change Summary

Add `ForeignKeyViolationError` to the client error map.

Closes https://github.com/RobertCraigie/prisma-client-py/issues/351

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass without significant drop in coverage
- [x] Documentation reflects changes where applicable
- [x] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
