### PR TITLE
feat(typing): annotate raw queries with LiteralString

### DIFF
--- a/src/prisma/generator/templates/_header.py.jinja
+++ b/src/prisma/generator/templates/_header.py.jinja
@@ -25,6 +25,11 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal, LiteralString
+from typing_extensions import TypedDict, Literal
 
+{% if recursive_types %}
+from typing_extensions import LiteralString
+{% else %}
+LiteralString = str
+{% endif %}
 

--- a/src/prisma/generator/templates/_header.py.jinja
+++ b/src/prisma/generator/templates/_header.py.jinja
@@ -25,6 +25,6 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal
+from typing_extensions import TypedDict, Literal, LiteralString
 
 

--- a/src/prisma/generator/templates/_header.py.jinja
+++ b/src/prisma/generator/templates/_header.py.jinja
@@ -27,6 +27,8 @@ from typing import (
 )
 from typing_extensions import TypedDict, Literal
 
+{% from '_utils.py.jinja' import recursive_types with context %}
+
 {% if recursive_types %}
 from typing_extensions import LiteralString
 {% else %}

--- a/src/prisma/generator/templates/actions.py.jinja
+++ b/src/prisma/generator/templates/actions.py.jinja
@@ -92,7 +92,7 @@ class {{ model.name }}Actions:
 
     {{ maybe_async_def }}query_first(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> Optional[{{ ModelType }}]:
         """Execute a raw SQL query, returning the first result

--- a/src/prisma/generator/templates/actions.py.jinja
+++ b/src/prisma/generator/templates/actions.py.jinja
@@ -54,7 +54,7 @@ class {{ model.name }}Actions:
     {% if active_provider != 'mongodb' %}
     {{ maybe_async_def }}query_raw(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> List[{{ ModelType }}]:
         """Execute a raw SQL query

--- a/src/prisma/generator/templates/client.py.jinja
+++ b/src/prisma/generator/templates/client.py.jinja
@@ -234,7 +234,7 @@ class Prisma:
             self.__engine = None
 
     {% if active_provider != 'mongodb' %}
-    {{ maybe_async_def }}execute_raw(self, query: str, *args: Any) -> int:
+    {{ maybe_async_def }}execute_raw(self, query: LiteralString, *args: Any) -> int:
         resp = {{ maybe_await }}self._execute(
             operation='{{ operations.execute_raw }}',
             method='{{ methods.execute_raw }}',
@@ -246,15 +246,15 @@ class Prisma:
         return int(resp['data']['result'])
 
     @overload
-    {{ maybe_async_def }}query_first(self, query: str, *args: Any) -> Any:
+    {{ maybe_async_def }}query_first(self, query: LiteralString, *args: Any) -> Any:
         ...
 
     @overload
-    {{ maybe_async_def }}query_first(self, query: str, *args: Any, model: Type[BaseModelT]) -> Optional[BaseModelT]:
+    {{ maybe_async_def }}query_first(self, query: LiteralString, *args: Any, model: Type[BaseModelT]) -> Optional[BaseModelT]:
         ...
 
     {{ maybe_async_def }}query_first(
-        self, query: str, *args: Any, model: Optional[Type[BaseModelT]] = None
+        self, query: LiteralString, *args: Any, model: Optional[Type[BaseModelT]] = None
     ) -> Union[Optional[BaseModelT], Any]:
         if model is not None:
             results = {{ maybe_await }}self.query_raw(query, *args, model=model)

--- a/src/prisma/generator/templates/client.py.jinja
+++ b/src/prisma/generator/templates/client.py.jinja
@@ -267,15 +267,15 @@ class Prisma:
         return results[0]
 
     @overload
-    {{ maybe_async_def }}query_raw(self, query: str, *args: Any) -> Any:
+    {{ maybe_async_def }}query_raw(self, query: LiteralString, *args: Any) -> Any:
         ...
 
     @overload
-    {{ maybe_async_def }}query_raw(self, query: str, *args: Any, model: Type[BaseModelT]) -> List[BaseModelT]:
+    {{ maybe_async_def }}query_raw(self, query: LiteralString, *args: Any, model: Type[BaseModelT]) -> List[BaseModelT]:
         ...
 
     {{ maybe_async_def }}query_raw(
-        self, query: str, *args: Any, model: Optional[Type[BaseModelT]] = None
+        self, query: LiteralString, *args: Any, model: Optional[Type[BaseModelT]] = None
     ) -> Union[List[BaseModelT], Any]:
         resp = {{ maybe_await }}self._execute(
             operation='{{ operations.query_raw }}',

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[actions.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[actions.py].raw
@@ -26,8 +26,9 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal, LiteralString
+from typing_extensions import TypedDict, Literal
 
+LiteralString = str
 # -- template actions.py.jinja --
 import warnings
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[actions.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[actions.py].raw
@@ -28,6 +28,7 @@ from typing import (
 )
 from typing_extensions import TypedDict, Literal
 
+
 LiteralString = str
 # -- template actions.py.jinja --
 import warnings

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[actions.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[actions.py].raw
@@ -26,7 +26,7 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal
+from typing_extensions import TypedDict, Literal, LiteralString
 
 # -- template actions.py.jinja --
 import warnings
@@ -51,7 +51,7 @@ class PostActions:
 
     async def query_raw(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> List['models.Post']:
         """Execute a raw SQL query
@@ -970,7 +970,7 @@ class UserActions:
 
     async def query_raw(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> List['models.User']:
         """Execute a raw SQL query
@@ -1909,7 +1909,7 @@ class MActions:
 
     async def query_raw(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> List['models.M']:
         """Execute a raw SQL query
@@ -2843,7 +2843,7 @@ class NActions:
 
     async def query_raw(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> List['models.N']:
         """Execute a raw SQL query
@@ -3782,7 +3782,7 @@ class OneOptionalActions:
 
     async def query_raw(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> List['models.OneOptional']:
         """Execute a raw SQL query
@@ -4716,7 +4716,7 @@ class ManyRequiredActions:
 
     async def query_raw(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> List['models.ManyRequired']:
         """Execute a raw SQL query
@@ -5650,7 +5650,7 @@ class ListsActions:
 
     async def query_raw(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> List['models.Lists']:
         """Execute a raw SQL query
@@ -6559,7 +6559,7 @@ class AActions:
 
     async def query_raw(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> List['models.A']:
         """Execute a raw SQL query
@@ -7486,7 +7486,7 @@ class BActions:
 
     async def query_raw(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> List['models.B']:
         """Execute a raw SQL query
@@ -8415,7 +8415,7 @@ class CActions:
 
     async def query_raw(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> List['models.C']:
         """Execute a raw SQL query
@@ -9346,7 +9346,7 @@ class DActions:
 
     async def query_raw(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> List['models.D']:
         """Execute a raw SQL query
@@ -10280,7 +10280,7 @@ class EActions:
 
     async def query_raw(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> List['models.E']:
         """Execute a raw SQL query

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[actions.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[actions.py].raw
@@ -89,7 +89,7 @@ class PostActions:
 
     async def query_first(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> Optional['models.Post']:
         """Execute a raw SQL query, returning the first result
@@ -1008,7 +1008,7 @@ class UserActions:
 
     async def query_first(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> Optional['models.User']:
         """Execute a raw SQL query, returning the first result
@@ -1947,7 +1947,7 @@ class MActions:
 
     async def query_first(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> Optional['models.M']:
         """Execute a raw SQL query, returning the first result
@@ -2881,7 +2881,7 @@ class NActions:
 
     async def query_first(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> Optional['models.N']:
         """Execute a raw SQL query, returning the first result
@@ -3820,7 +3820,7 @@ class OneOptionalActions:
 
     async def query_first(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> Optional['models.OneOptional']:
         """Execute a raw SQL query, returning the first result
@@ -4754,7 +4754,7 @@ class ManyRequiredActions:
 
     async def query_first(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> Optional['models.ManyRequired']:
         """Execute a raw SQL query, returning the first result
@@ -5688,7 +5688,7 @@ class ListsActions:
 
     async def query_first(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> Optional['models.Lists']:
         """Execute a raw SQL query, returning the first result
@@ -6597,7 +6597,7 @@ class AActions:
 
     async def query_first(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> Optional['models.A']:
         """Execute a raw SQL query, returning the first result
@@ -7524,7 +7524,7 @@ class BActions:
 
     async def query_first(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> Optional['models.B']:
         """Execute a raw SQL query, returning the first result
@@ -8453,7 +8453,7 @@ class CActions:
 
     async def query_first(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> Optional['models.C']:
         """Execute a raw SQL query, returning the first result
@@ -9384,7 +9384,7 @@ class DActions:
 
     async def query_first(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> Optional['models.D']:
         """Execute a raw SQL query, returning the first result
@@ -10318,7 +10318,7 @@ class EActions:
 
     async def query_first(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> Optional['models.E']:
         """Execute a raw SQL query, returning the first result

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[builder.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[builder.py].raw
@@ -28,6 +28,7 @@ from typing import (
 )
 from typing_extensions import TypedDict, Literal
 
+
 LiteralString = str
 # -- template builder.py.jinja --
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[builder.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[builder.py].raw
@@ -26,7 +26,7 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal
+from typing_extensions import TypedDict, Literal, LiteralString
 
 # -- template builder.py.jinja --
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[builder.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[builder.py].raw
@@ -26,8 +26,9 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal, LiteralString
+from typing_extensions import TypedDict, Literal
 
+LiteralString = str
 # -- template builder.py.jinja --
 
 # TODO: the QueryBuilder should validate and add type information context.

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
@@ -444,7 +444,7 @@ class Prisma:
             await self.__engine.aclose()
             self.__engine = None
 
-    async def execute_raw(self, query: str, *args: Any) -> int:
+    async def execute_raw(self, query: LiteralString, *args: Any) -> int:
         resp = await self._execute(
             operation='mutation',
             method='executeRaw',
@@ -456,15 +456,15 @@ class Prisma:
         return int(resp['data']['result'])
 
     @overload
-    async def query_first(self, query: str, *args: Any) -> Any:
+    async def query_first(self, query: LiteralString, *args: Any) -> Any:
         ...
 
     @overload
-    async def query_first(self, query: str, *args: Any, model: Type[BaseModelT]) -> Optional[BaseModelT]:
+    async def query_first(self, query: LiteralString, *args: Any, model: Type[BaseModelT]) -> Optional[BaseModelT]:
         ...
 
     async def query_first(
-        self, query: str, *args: Any, model: Optional[Type[BaseModelT]] = None
+        self, query: LiteralString, *args: Any, model: Optional[Type[BaseModelT]] = None
     ) -> Union[Optional[BaseModelT], Any]:
         if model is not None:
             results = await self.query_raw(query, *args, model=model)

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
@@ -26,7 +26,7 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal
+from typing_extensions import TypedDict, Literal, LiteralString
 
 # -- template client.py.jinja --
 from types import TracebackType
@@ -477,15 +477,15 @@ class Prisma:
         return results[0]
 
     @overload
-    async def query_raw(self, query: str, *args: Any) -> Any:
+    async def query_raw(self, query: LiteralString, *args: Any) -> Any:
         ...
 
     @overload
-    async def query_raw(self, query: str, *args: Any, model: Type[BaseModelT]) -> List[BaseModelT]:
+    async def query_raw(self, query: LiteralString, *args: Any, model: Type[BaseModelT]) -> List[BaseModelT]:
         ...
 
     async def query_raw(
-        self, query: str, *args: Any, model: Optional[Type[BaseModelT]] = None
+        self, query: LiteralString, *args: Any, model: Optional[Type[BaseModelT]] = None
     ) -> Union[List[BaseModelT], Any]:
         resp = await self._execute(
             operation='mutation',

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
@@ -28,6 +28,7 @@ from typing import (
 )
 from typing_extensions import TypedDict, Literal
 
+
 LiteralString = str
 # -- template client.py.jinja --
 from types import TracebackType

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
@@ -26,8 +26,9 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal, LiteralString
+from typing_extensions import TypedDict, Literal
 
+LiteralString = str
 # -- template client.py.jinja --
 from types import TracebackType
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[engineabstract.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[engineabstract.py].raw
@@ -26,8 +26,9 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal, LiteralString
+from typing_extensions import TypedDict, Literal
 
+LiteralString = str
 # -- template engine/abstract.py.jinja --
 from abc import ABC, abstractmethod
 from ..types import DatasourceOverride

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[engineabstract.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[engineabstract.py].raw
@@ -28,6 +28,7 @@ from typing import (
 )
 from typing_extensions import TypedDict, Literal
 
+
 LiteralString = str
 # -- template engine/abstract.py.jinja --
 from abc import ABC, abstractmethod

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[engineabstract.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[engineabstract.py].raw
@@ -26,7 +26,7 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal
+from typing_extensions import TypedDict, Literal, LiteralString
 
 # -- template engine/abstract.py.jinja --
 from abc import ABC, abstractmethod

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enginehttp.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enginehttp.py].raw
@@ -26,7 +26,7 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal
+from typing_extensions import TypedDict, Literal, LiteralString
 
 # -- template engine/http.py.jinja --
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enginehttp.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enginehttp.py].raw
@@ -28,6 +28,7 @@ from typing import (
 )
 from typing_extensions import TypedDict, Literal
 
+
 LiteralString = str
 # -- template engine/http.py.jinja --
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enginehttp.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enginehttp.py].raw
@@ -26,8 +26,9 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal, LiteralString
+from typing_extensions import TypedDict, Literal
 
+LiteralString = str
 # -- template engine/http.py.jinja --
 
 import logging

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enginequery.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enginequery.py].raw
@@ -26,8 +26,9 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal, LiteralString
+from typing_extensions import TypedDict, Literal
 
+LiteralString = str
 # -- template engine/query.py.jinja --
 
 import os

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enginequery.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enginequery.py].raw
@@ -28,6 +28,7 @@ from typing import (
 )
 from typing_extensions import TypedDict, Literal
 
+
 LiteralString = str
 # -- template engine/query.py.jinja --
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enginequery.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enginequery.py].raw
@@ -26,7 +26,7 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal
+from typing_extensions import TypedDict, Literal, LiteralString
 
 # -- template engine/query.py.jinja --
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enums.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enums.py].raw
@@ -28,6 +28,7 @@ from typing import (
 )
 from typing_extensions import TypedDict, Literal
 
+
 LiteralString = str
 # -- template enums.py.jinja --
 from enum import Enum

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enums.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enums.py].raw
@@ -26,8 +26,9 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal, LiteralString
+from typing_extensions import TypedDict, Literal
 
+LiteralString = str
 # -- template enums.py.jinja --
 from enum import Enum
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enums.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enums.py].raw
@@ -26,7 +26,7 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal
+from typing_extensions import TypedDict, Literal, LiteralString
 
 # -- template enums.py.jinja --
 from enum import Enum

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[fields.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[fields.py].raw
@@ -28,6 +28,7 @@ from typing import (
 )
 from typing_extensions import TypedDict, Literal
 
+
 LiteralString = str
 # -- template fields.py.jinja --
 import base64

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[fields.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[fields.py].raw
@@ -26,7 +26,7 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal
+from typing_extensions import TypedDict, Literal, LiteralString
 
 # -- template fields.py.jinja --
 import base64

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[fields.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[fields.py].raw
@@ -26,8 +26,9 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal, LiteralString
+from typing_extensions import TypedDict, Literal
 
+LiteralString = str
 # -- template fields.py.jinja --
 import base64
 from pydantic import Json as _PydanticJson

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[http.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[http.py].raw
@@ -28,6 +28,7 @@ from typing import (
 )
 from typing_extensions import TypedDict, Literal
 
+
 LiteralString = str
 # -- template http.py.jinja --
 from ._async_http import (

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[http.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[http.py].raw
@@ -26,7 +26,7 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal
+from typing_extensions import TypedDict, Literal, LiteralString
 
 # -- template http.py.jinja --
 from ._async_http import (

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[http.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[http.py].raw
@@ -26,8 +26,9 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal, LiteralString
+from typing_extensions import TypedDict, Literal
 
+LiteralString = str
 # -- template http.py.jinja --
 from ._async_http import (
     HTTP as HTTP,

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[models.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[models.py].raw
@@ -28,6 +28,7 @@ from typing import (
 )
 from typing_extensions import TypedDict, Literal
 
+
 LiteralString = str
 # -- template models.py.jinja --
 import os

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[models.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[models.py].raw
@@ -26,7 +26,7 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal
+from typing_extensions import TypedDict, Literal, LiteralString
 
 # -- template models.py.jinja --
 import os

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[models.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[models.py].raw
@@ -26,8 +26,9 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal, LiteralString
+from typing_extensions import TypedDict, Literal
 
+LiteralString = str
 # -- template models.py.jinja --
 import os
 import logging

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[partials.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[partials.py].raw
@@ -26,7 +26,7 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal
+from typing_extensions import TypedDict, Literal, LiteralString
 
 # -- template partials.py.jinja --
 from pydantic import BaseModel, Field, validator

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[partials.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[partials.py].raw
@@ -26,8 +26,9 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal, LiteralString
+from typing_extensions import TypedDict, Literal
 
+LiteralString = str
 # -- template partials.py.jinja --
 from pydantic import BaseModel, Field, validator
 from . import types, models, fields, enums

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[partials.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[partials.py].raw
@@ -28,6 +28,7 @@ from typing import (
 )
 from typing_extensions import TypedDict, Literal
 
+
 LiteralString = str
 # -- template partials.py.jinja --
 from pydantic import BaseModel, Field, validator

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[types.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[types.py].raw
@@ -26,7 +26,7 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal
+from typing_extensions import TypedDict, Literal, LiteralString
 
 # -- template types.py.jinja --
 from typing import TypeVar

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[types.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[types.py].raw
@@ -28,6 +28,7 @@ from typing import (
 )
 from typing_extensions import TypedDict, Literal
 
+
 LiteralString = str
 # -- template types.py.jinja --
 from typing import TypeVar

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[types.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[types.py].raw
@@ -26,8 +26,9 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal, LiteralString
+from typing_extensions import TypedDict, Literal
 
+LiteralString = str
 # -- template types.py.jinja --
 from typing import TypeVar
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[actions.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[actions.py].raw
@@ -26,8 +26,9 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal, LiteralString
+from typing_extensions import TypedDict, Literal
 
+LiteralString = str
 # -- template actions.py.jinja --
 import warnings
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[actions.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[actions.py].raw
@@ -28,6 +28,7 @@ from typing import (
 )
 from typing_extensions import TypedDict, Literal
 
+
 LiteralString = str
 # -- template actions.py.jinja --
 import warnings

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[actions.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[actions.py].raw
@@ -26,7 +26,7 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal
+from typing_extensions import TypedDict, Literal, LiteralString
 
 # -- template actions.py.jinja --
 import warnings
@@ -51,7 +51,7 @@ class PostActions:
 
     def query_raw(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> List['models.Post']:
         """Execute a raw SQL query
@@ -970,7 +970,7 @@ class UserActions:
 
     def query_raw(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> List['models.User']:
         """Execute a raw SQL query
@@ -1909,7 +1909,7 @@ class MActions:
 
     def query_raw(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> List['models.M']:
         """Execute a raw SQL query
@@ -2843,7 +2843,7 @@ class NActions:
 
     def query_raw(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> List['models.N']:
         """Execute a raw SQL query
@@ -3782,7 +3782,7 @@ class OneOptionalActions:
 
     def query_raw(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> List['models.OneOptional']:
         """Execute a raw SQL query
@@ -4716,7 +4716,7 @@ class ManyRequiredActions:
 
     def query_raw(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> List['models.ManyRequired']:
         """Execute a raw SQL query
@@ -5650,7 +5650,7 @@ class ListsActions:
 
     def query_raw(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> List['models.Lists']:
         """Execute a raw SQL query
@@ -6559,7 +6559,7 @@ class AActions:
 
     def query_raw(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> List['models.A']:
         """Execute a raw SQL query
@@ -7486,7 +7486,7 @@ class BActions:
 
     def query_raw(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> List['models.B']:
         """Execute a raw SQL query
@@ -8415,7 +8415,7 @@ class CActions:
 
     def query_raw(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> List['models.C']:
         """Execute a raw SQL query
@@ -9346,7 +9346,7 @@ class DActions:
 
     def query_raw(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> List['models.D']:
         """Execute a raw SQL query
@@ -10280,7 +10280,7 @@ class EActions:
 
     def query_raw(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> List['models.E']:
         """Execute a raw SQL query

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[actions.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[actions.py].raw
@@ -89,7 +89,7 @@ class PostActions:
 
     def query_first(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> Optional['models.Post']:
         """Execute a raw SQL query, returning the first result
@@ -1008,7 +1008,7 @@ class UserActions:
 
     def query_first(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> Optional['models.User']:
         """Execute a raw SQL query, returning the first result
@@ -1947,7 +1947,7 @@ class MActions:
 
     def query_first(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> Optional['models.M']:
         """Execute a raw SQL query, returning the first result
@@ -2881,7 +2881,7 @@ class NActions:
 
     def query_first(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> Optional['models.N']:
         """Execute a raw SQL query, returning the first result
@@ -3820,7 +3820,7 @@ class OneOptionalActions:
 
     def query_first(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> Optional['models.OneOptional']:
         """Execute a raw SQL query, returning the first result
@@ -4754,7 +4754,7 @@ class ManyRequiredActions:
 
     def query_first(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> Optional['models.ManyRequired']:
         """Execute a raw SQL query, returning the first result
@@ -5688,7 +5688,7 @@ class ListsActions:
 
     def query_first(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> Optional['models.Lists']:
         """Execute a raw SQL query, returning the first result
@@ -6597,7 +6597,7 @@ class AActions:
 
     def query_first(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> Optional['models.A']:
         """Execute a raw SQL query, returning the first result
@@ -7524,7 +7524,7 @@ class BActions:
 
     def query_first(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> Optional['models.B']:
         """Execute a raw SQL query, returning the first result
@@ -8453,7 +8453,7 @@ class CActions:
 
     def query_first(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> Optional['models.C']:
         """Execute a raw SQL query, returning the first result
@@ -9384,7 +9384,7 @@ class DActions:
 
     def query_first(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> Optional['models.D']:
         """Execute a raw SQL query, returning the first result
@@ -10318,7 +10318,7 @@ class EActions:
 
     def query_first(
         self,
-        query: str,
+        query: LiteralString,
         *args: Any,
     ) -> Optional['models.E']:
         """Execute a raw SQL query, returning the first result

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[builder.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[builder.py].raw
@@ -28,6 +28,7 @@ from typing import (
 )
 from typing_extensions import TypedDict, Literal
 
+
 LiteralString = str
 # -- template builder.py.jinja --
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[builder.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[builder.py].raw
@@ -26,7 +26,7 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal
+from typing_extensions import TypedDict, Literal, LiteralString
 
 # -- template builder.py.jinja --
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[builder.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[builder.py].raw
@@ -26,8 +26,9 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal, LiteralString
+from typing_extensions import TypedDict, Literal
 
+LiteralString = str
 # -- template builder.py.jinja --
 
 # TODO: the QueryBuilder should validate and add type information context.

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
@@ -26,7 +26,7 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal
+from typing_extensions import TypedDict, Literal, LiteralString
 
 # -- template client.py.jinja --
 from types import TracebackType
@@ -476,15 +476,15 @@ class Prisma:
         return results[0]
 
     @overload
-    def query_raw(self, query: str, *args: Any) -> Any:
+    def query_raw(self, query: LiteralString, *args: Any) -> Any:
         ...
 
     @overload
-    def query_raw(self, query: str, *args: Any, model: Type[BaseModelT]) -> List[BaseModelT]:
+    def query_raw(self, query: LiteralString, *args: Any, model: Type[BaseModelT]) -> List[BaseModelT]:
         ...
 
     def query_raw(
-        self, query: str, *args: Any, model: Optional[Type[BaseModelT]] = None
+        self, query: LiteralString, *args: Any, model: Optional[Type[BaseModelT]] = None
     ) -> Union[List[BaseModelT], Any]:
         resp = self._execute(
             operation='mutation',

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
@@ -28,6 +28,7 @@ from typing import (
 )
 from typing_extensions import TypedDict, Literal
 
+
 LiteralString = str
 # -- template client.py.jinja --
 from types import TracebackType

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
@@ -26,8 +26,9 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal, LiteralString
+from typing_extensions import TypedDict, Literal
 
+LiteralString = str
 # -- template client.py.jinja --
 from types import TracebackType
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
@@ -443,7 +443,7 @@ class Prisma:
             self.__engine.stop()
             self.__engine = None
 
-    def execute_raw(self, query: str, *args: Any) -> int:
+    def execute_raw(self, query: LiteralString, *args: Any) -> int:
         resp = self._execute(
             operation='mutation',
             method='executeRaw',
@@ -455,15 +455,15 @@ class Prisma:
         return int(resp['data']['result'])
 
     @overload
-    def query_first(self, query: str, *args: Any) -> Any:
+    def query_first(self, query: LiteralString, *args: Any) -> Any:
         ...
 
     @overload
-    def query_first(self, query: str, *args: Any, model: Type[BaseModelT]) -> Optional[BaseModelT]:
+    def query_first(self, query: LiteralString, *args: Any, model: Type[BaseModelT]) -> Optional[BaseModelT]:
         ...
 
     def query_first(
-        self, query: str, *args: Any, model: Optional[Type[BaseModelT]] = None
+        self, query: LiteralString, *args: Any, model: Optional[Type[BaseModelT]] = None
     ) -> Union[Optional[BaseModelT], Any]:
         if model is not None:
             results = self.query_raw(query, *args, model=model)

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[engineabstract.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[engineabstract.py].raw
@@ -26,8 +26,9 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal, LiteralString
+from typing_extensions import TypedDict, Literal
 
+LiteralString = str
 # -- template engine/abstract.py.jinja --
 from abc import ABC, abstractmethod
 from ..types import DatasourceOverride

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[engineabstract.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[engineabstract.py].raw
@@ -28,6 +28,7 @@ from typing import (
 )
 from typing_extensions import TypedDict, Literal
 
+
 LiteralString = str
 # -- template engine/abstract.py.jinja --
 from abc import ABC, abstractmethod

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[engineabstract.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[engineabstract.py].raw
@@ -26,7 +26,7 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal
+from typing_extensions import TypedDict, Literal, LiteralString
 
 # -- template engine/abstract.py.jinja --
 from abc import ABC, abstractmethod

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enginehttp.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enginehttp.py].raw
@@ -26,7 +26,7 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal
+from typing_extensions import TypedDict, Literal, LiteralString
 
 # -- template engine/http.py.jinja --
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enginehttp.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enginehttp.py].raw
@@ -28,6 +28,7 @@ from typing import (
 )
 from typing_extensions import TypedDict, Literal
 
+
 LiteralString = str
 # -- template engine/http.py.jinja --
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enginehttp.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enginehttp.py].raw
@@ -26,8 +26,9 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal, LiteralString
+from typing_extensions import TypedDict, Literal
 
+LiteralString = str
 # -- template engine/http.py.jinja --
 
 import logging

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enginequery.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enginequery.py].raw
@@ -26,8 +26,9 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal, LiteralString
+from typing_extensions import TypedDict, Literal
 
+LiteralString = str
 # -- template engine/query.py.jinja --
 
 import os

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enginequery.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enginequery.py].raw
@@ -28,6 +28,7 @@ from typing import (
 )
 from typing_extensions import TypedDict, Literal
 
+
 LiteralString = str
 # -- template engine/query.py.jinja --
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enginequery.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enginequery.py].raw
@@ -26,7 +26,7 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal
+from typing_extensions import TypedDict, Literal, LiteralString
 
 # -- template engine/query.py.jinja --
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enums.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enums.py].raw
@@ -28,6 +28,7 @@ from typing import (
 )
 from typing_extensions import TypedDict, Literal
 
+
 LiteralString = str
 # -- template enums.py.jinja --
 from enum import Enum

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enums.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enums.py].raw
@@ -26,8 +26,9 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal, LiteralString
+from typing_extensions import TypedDict, Literal
 
+LiteralString = str
 # -- template enums.py.jinja --
 from enum import Enum
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enums.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enums.py].raw
@@ -26,7 +26,7 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal
+from typing_extensions import TypedDict, Literal, LiteralString
 
 # -- template enums.py.jinja --
 from enum import Enum

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[fields.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[fields.py].raw
@@ -28,6 +28,7 @@ from typing import (
 )
 from typing_extensions import TypedDict, Literal
 
+
 LiteralString = str
 # -- template fields.py.jinja --
 import base64

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[fields.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[fields.py].raw
@@ -26,7 +26,7 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal
+from typing_extensions import TypedDict, Literal, LiteralString
 
 # -- template fields.py.jinja --
 import base64

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[fields.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[fields.py].raw
@@ -26,8 +26,9 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal, LiteralString
+from typing_extensions import TypedDict, Literal
 
+LiteralString = str
 # -- template fields.py.jinja --
 import base64
 from pydantic import Json as _PydanticJson

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[http.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[http.py].raw
@@ -28,6 +28,7 @@ from typing import (
 )
 from typing_extensions import TypedDict, Literal
 
+
 LiteralString = str
 # -- template http.py.jinja --
 from ._sync_http import (

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[http.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[http.py].raw
@@ -26,8 +26,9 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal, LiteralString
+from typing_extensions import TypedDict, Literal
 
+LiteralString = str
 # -- template http.py.jinja --
 from ._sync_http import (
     HTTP as HTTP,

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[http.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[http.py].raw
@@ -26,7 +26,7 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal
+from typing_extensions import TypedDict, Literal, LiteralString
 
 # -- template http.py.jinja --
 from ._sync_http import (

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[models.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[models.py].raw
@@ -28,6 +28,7 @@ from typing import (
 )
 from typing_extensions import TypedDict, Literal
 
+
 LiteralString = str
 # -- template models.py.jinja --
 import os

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[models.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[models.py].raw
@@ -26,7 +26,7 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal
+from typing_extensions import TypedDict, Literal, LiteralString
 
 # -- template models.py.jinja --
 import os

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[models.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[models.py].raw
@@ -26,8 +26,9 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal, LiteralString
+from typing_extensions import TypedDict, Literal
 
+LiteralString = str
 # -- template models.py.jinja --
 import os
 import logging

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[partials.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[partials.py].raw
@@ -26,7 +26,7 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal
+from typing_extensions import TypedDict, Literal, LiteralString
 
 # -- template partials.py.jinja --
 from pydantic import BaseModel, Field, validator

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[partials.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[partials.py].raw
@@ -26,8 +26,9 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal, LiteralString
+from typing_extensions import TypedDict, Literal
 
+LiteralString = str
 # -- template partials.py.jinja --
 from pydantic import BaseModel, Field, validator
 from . import types, models, fields, enums

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[partials.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[partials.py].raw
@@ -28,6 +28,7 @@ from typing import (
 )
 from typing_extensions import TypedDict, Literal
 
+
 LiteralString = str
 # -- template partials.py.jinja --
 from pydantic import BaseModel, Field, validator

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[types.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[types.py].raw
@@ -26,7 +26,7 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal
+from typing_extensions import TypedDict, Literal, LiteralString
 
 # -- template types.py.jinja --
 from typing import TypeVar

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[types.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[types.py].raw
@@ -28,6 +28,7 @@ from typing import (
 )
 from typing_extensions import TypedDict, Literal
 
+
 LiteralString = str
 # -- template types.py.jinja --
 from typing import TypeVar

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[types.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[types.py].raw
@@ -26,8 +26,9 @@ from typing import (
     overload,
     cast,
 )
-from typing_extensions import TypedDict, Literal, LiteralString
+from typing_extensions import TypedDict, Literal
 
+LiteralString = str
 # -- template types.py.jinja --
 from typing import TypeVar
 

--- a/tox.ini
+++ b/tox.ini
@@ -112,7 +112,7 @@ deps =
     {[testenv]deps}
     interrogate==1.5.0
     blue==0.7.0
-    mypy==0.910
+    mypy==0.950
     pyright==1.1.239
     slotscheck==0.14.0
 
@@ -128,7 +128,7 @@ commands =
 # mypy is in it's own testenv due to the ridiculous amount of time it takes to run
 deps =
     {[testenv]deps}
-    mypy==0.930
+    mypy==0.950
     types-mock
 
 commands =

--- a/typesafety/pyright/execute_raw.py
+++ b/typesafety/pyright/execute_raw.py
@@ -1,0 +1,11 @@
+from prisma import Prisma
+
+
+async def main(client: Prisma) -> None:
+    query = 'safe StringLiteral query'
+    await client.execute_raw(query)
+
+    query = str('unsafe str query')
+    await client.execute_raw(
+        query  # E: Argument of type "str" cannot be assigned to parameter "query" of type "LiteralString" in function "execute_raw"
+    )

--- a/typesafety/pyright/query_first.py
+++ b/typesafety/pyright/query_first.py
@@ -13,3 +13,12 @@ async def main(client: Prisma) -> None:
 
     result = await client.query_first('')
     reveal_type(result)  # T: Any
+
+    query = 'safe StringLiteral query'
+    await client.query_first(query, model=User)
+
+    query = str('unsafe str query')
+    await client.query_first(
+        query,  # E: Argument of type "str" cannot be assigned to parameter "query" of type "LiteralString" in function "query_first"
+        model=User,
+    )

--- a/typesafety/pyright/query_raw.py
+++ b/typesafety/pyright/query_raw.py
@@ -12,3 +12,11 @@ async def main(client: Prisma) -> None:
 
     result = await client.query_raw('')
     reveal_type(result)  # T: Any
+
+    query = 'safe StringLiteral query'
+    await client.query_raw(query, model=User)
+
+    query = str('unsafe str query')
+    await client.query_raw(
+        query, model=User
+    )   # E: Argument of type "str" cannot be assigned to parameter "query" of type "LiteralString" in function "query_raw"

--- a/typesafety/pyright/query_raw.py
+++ b/typesafety/pyright/query_raw.py
@@ -18,5 +18,6 @@ async def main(client: Prisma) -> None:
 
     query = str('unsafe str query')
     await client.query_raw(
-        query, model=User
-    )   # E: Argument of type "str" cannot be assigned to parameter "query" of type "LiteralString" in function "query_raw"
+        query,  # E: Argument of type "str" cannot be assigned to parameter "query" of type "LiteralString" in function "query_raw"
+        model=User,
+    )


### PR DESCRIPTION
## Change Summary
In preparation for PEP 675, this PR changes the type annotation for `query_raw`, `query_first`, and `execute_raw` to be `LiteralString`.

For backwards compatibility with `mypy`, `LiteralString` is aliased as `str` until `mypy` supports `LiteralString`. This was slated to be in mypy 0.950, but apparently was not included in the release (https://github.com/python/typeshed/pull/7725#issuecomment-1111183994)

Addresses https://github.com/RobertCraigie/prisma-client-py/issues/285

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass without significant drop in coverage
- [x] Documentation reflects changes where applicable
- [x] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
