### PR TITLE
feat(cli): warn when recursive type depth not set in prism schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ datasource db {
 
 // generator
 generator client {
-  provider = "prisma-client-py"
+  provider             = "prisma-client-py"
+  recursive_type_depth = 5
 }
 
 // data models

--- a/docs/getting_started/setup.md
+++ b/docs/getting_started/setup.md
@@ -16,8 +16,9 @@ pip install prisma
 
 ```prisma
 generator client {
-  provider  = "prisma-client-py"
-  interface = "asyncio"
+  provider             = "prisma-client-py"
+  interface            = "asyncio"
+  recursive_type_depth = 5
 }
 ```
 
@@ -47,8 +48,9 @@ if __name__ == '__main__':
 
 ```prisma
 generator client {
-  provider  = "prisma-client-py"
-  interface = "sync"
+  provider             = "prisma-client-py"
+  interface            = "sync"
+  recursive_type_depth = 5
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,7 +85,8 @@ datasource db {
 
 // generator
 generator client {
-  provider = "prisma-client-py"
+  provider             = "prisma-client-py"
+  recursive_type_depth = 5
 }
 
 // data models
@@ -311,7 +312,7 @@ Supported editors / extensions:
 
 - VSCode with [pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) v2021.9.4 or higher
 - Sublime Text with [LSP-Pyright](https://github.com/sublimelsp/LSP-pyright) v1.1.196 or higher
-- PyCharm [2022.1 EAP 3](https://youtrack.jetbrains.com/articles/PY-A-233537928/PyCharm-2022.1-EAP-3-(221.4994.44-build)-Release-Notes) added support for completing `TypedDict`
+- PyCharm [2022.1 EAP 3](https://youtrack.jetbrains.com/articles/PY-A-233537928/PyCharm-2022.1-EAP-3-(221.4994.44-build)-Release-Notes) added support for completing `TypedDict`s
     - This does not yet work for Prisma Client Python unfortunately, see [this issue](https://youtrack.jetbrains.com/issue/PY-54151/TypedDict-completion-at-callee-does-not-work-for-methods)
 - Any editor that supports the Language Server Protocol and has an extension supporting Pyright v1.1.196 or higher
     - vim and neovim with [coc.nvim](https://github.com/fannheyward/coc-pyright)

--- a/docs/src_examples/advanced.schema.prisma
+++ b/docs/src_examples/advanced.schema.prisma
@@ -5,7 +5,8 @@ datasource db {
 }
 
 generator db {
-  provider = "prisma-client-py"
+  provider             = "prisma-client-py"
+  recursive_type_depth = 5
 }
 
 model Post {

--- a/docs/src_examples/async/index.schema.prisma
+++ b/docs/src_examples/async/index.schema.prisma
@@ -5,8 +5,9 @@ datasource db {
 }
 
 generator db {
-  provider  = "prisma-client-py"
-  interface = "asyncio"
+  provider             = "prisma-client-py"
+  interface            = "asyncio"
+  recursive_type_depth = 5
 }
 
 model Post {

--- a/docs/src_examples/basic.schema.prisma
+++ b/docs/src_examples/basic.schema.prisma
@@ -4,7 +4,8 @@ datasource db {
 }
 
 generator py {
-  provider = "prisma-client-py"
+  provider             = "prisma-client-py"
+  recursive_type_depth = 5
 }
 
 model User {

--- a/docs/src_examples/sync/index.schema.prisma
+++ b/docs/src_examples/sync/index.schema.prisma
@@ -5,8 +5,9 @@ datasource db {
 }
 
 generator db {
-  provider  = "prisma-client-py"
-  interface = "sync"
+  provider             = "prisma-client-py"
+  interface            = "sync"
+  recursive_type_depth = 5
 }
 
 model Post {

--- a/examples/discord-message-counter/schema.prisma
+++ b/examples/discord-message-counter/schema.prisma
@@ -4,8 +4,9 @@ datasource db {
 }
 
 generator db {
-  provider  = "prisma-client-py"
-  interface = "asyncio"
+  provider             = "prisma-client-py"
+  interface            = "asyncio"
+  recursive_type_depth = 5
 }
 
 model Channel {

--- a/examples/flask-url-shortener/schema.prisma
+++ b/examples/flask-url-shortener/schema.prisma
@@ -4,8 +4,9 @@ datasource db {
 }
 
 generator db {
-  provider  = "prisma-client-py"
-  interface = "sync"
+  provider             = "prisma-client-py"
+  interface            = "sync"
+  recursive_type_depth = 5
 }
 
 model Url {

--- a/examples/kivy-basic/schema.prisma
+++ b/examples/kivy-basic/schema.prisma
@@ -4,8 +4,9 @@ datasource db {
 }
 
 generator client {
-  provider  = "prisma-client-py"
-  interface = "sync"
+  provider             = "prisma-client-py"
+  interface            = "sync"
+  recursive_type_depth = 5
 }
 
 model Customer {

--- a/src/prisma/generator/models.py
+++ b/src/prisma/generator/models.py
@@ -83,10 +83,10 @@ FILTER_TYPES = [
     'Json',
     'Decimal',
 ]
-RECURSIVE_TYPE_DEPTH_WARNING = """
-Some types are disabled by default due to being incompatible with Mypy, it is highly recommended
-to use Pyright instead and configure Prisma Python to use recursive types to re-enable certain types:
+RECURSIVE_TYPE_DEPTH_WARNING = """Some types are disabled by default due to being incompatible with Mypy, it is highly recommended
+to use Pyright instead and configure Prisma Python to use recursive types to re-enable certain types:"""
 
+RECURSIVE_TYPE_DEPTH_WARNING_DESC = """
 generator client {
   provider             = "prisma-client-py"
   recursive_type_depth = -1
@@ -100,7 +100,6 @@ generator client {
 }
 
 For more information see: https://prisma-client-py.readthedocs.io/en/stable/reference/limitations/#default-type-limitations
-
 """
 
 FAKER: Faker = Faker()
@@ -207,10 +206,11 @@ def _pathlib_serializer(path: Path) -> str:
 def _recursive_type_depth_factory() -> int:
     click.echo(
         click.style(
-            RECURSIVE_TYPE_DEPTH_WARNING,
+            f'\n{RECURSIVE_TYPE_DEPTH_WARNING}',
             fg='yellow',
         )
     )
+    click.echo(f'{RECURSIVE_TYPE_DEPTH_WARNING_DESC}\n')
     return 5
 
 

--- a/src/prisma/generator/models.py
+++ b/src/prisma/generator/models.py
@@ -84,7 +84,7 @@ FILTER_TYPES = [
     'Decimal',
 ]
 RECURSIVE_TYPE_DEPTH_WARNING = """Some types are disabled by default due to being incompatible with Mypy, it is highly recommended
-to use Pyright instead and configure Prisma Python to use recursive types to re-enable certain types:"""
+to use Pyright instead and configure Prisma Python to use recursive types. To re-enable certain types:"""
 
 RECURSIVE_TYPE_DEPTH_WARNING_DESC = """
 generator client {

--- a/src/prisma/generator/models.py
+++ b/src/prisma/generator/models.py
@@ -204,6 +204,16 @@ def _pathlib_serializer(path: Path) -> str:
     return str(path.absolute())
 
 
+def _recursive_type_depth_factory() -> int:
+    click.echo(
+        click.style(
+            RECURSIVE_TYPE_DEPTH_WARNING,
+            fg='yellow',
+        )
+    )
+    return 5
+
+
 class BaseModel(PydanticBaseModel):
     class Config:
         arbitrary_types_allowed: bool = True
@@ -391,7 +401,9 @@ class Config(BaseSettings):
 
     interface: InterfaceChoices = InterfaceChoices.asyncio
     partial_type_generator: Optional[Module] = None
-    recursive_type_depth: Optional[int] = None
+    recursive_type_depth: int = FieldInfo(
+        default_factory=_recursive_type_depth_factory
+    )
     engine_type: EngineType = FieldInfo(default=EngineType.binary)
 
     # this should be a list of experimental features
@@ -481,15 +493,7 @@ class Config(BaseSettings):
 
     @validator('recursive_type_depth', always=True, allow_reuse=True)
     @classmethod
-    def recursive_type_depth_validator(cls, value: Optional[int]) -> int:
-        if value is None:
-            click.echo(
-                click.style(
-                    RECURSIVE_TYPE_DEPTH_WARNING,
-                    fg='yellow',
-                )
-            )
-            return 5
+    def recursive_type_depth_validator(cls, value: int) -> int:
         if value < -1 or value in {0, 1}:
             raise ValueError('Value must equal -1 or be greater than 1.')
         return value

--- a/src/prisma/generator/models.py
+++ b/src/prisma/generator/models.py
@@ -32,7 +32,6 @@ from pydantic import (
     BaseSettings,
     Extra,
     Field as FieldInfo,
-    validator,
 )
 from pydantic.fields import PrivateAttr
 from pydantic.generics import GenericModel as PydanticGenericModel

--- a/tests/test_generation/test_models.py
+++ b/tests/test_generation/test_models.py
@@ -32,3 +32,21 @@ def test_recursive_type_depth() -> None:
     for value in [-1, 2, 3, 10, 99]:
         config = Config(recursive_type_depth=value)
         assert config.recursive_type_depth == value
+
+
+def test_default_recursive_type_depth(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Warn when recursive type depth is not set:
+
+    https://github.com/RobertCraigie/prisma-client-py/issues/252
+
+    Ensure that we provide advice on what value to use.
+    Also ensure that it defaults to 5.
+    """
+    c = Config()
+    captured = capsys.readouterr()
+    assert 'it is highly recommended to use Pyright' in captured.out.replace(
+        '\n', ' '
+    )
+    assert c.recursive_type_depth == 5

--- a/tests/test_generation/test_models.py
+++ b/tests/test_generation/test_models.py
@@ -41,8 +41,9 @@ def test_default_recursive_type_depth(
 
     https://github.com/RobertCraigie/prisma-client-py/issues/252
 
-    Ensure that we provide advice on what value to use.
-    Also ensure that it defaults to 5.
+    Ensure that we provide advice on what value to use and that it defaults to 5.
+
+    Also validate that when a type depth is provided, no warning is shown.
     """
     c = Config()
     captured = capsys.readouterr()
@@ -50,3 +51,19 @@ def test_default_recursive_type_depth(
         '\n', ' '
     )
     assert c.recursive_type_depth == 5
+
+    c = Config(recursive_type_depth=5)
+    captured = capsys.readouterr()
+    assert (
+        'it is highly recommended to use Pyright'
+        not in captured.out.replace('\n', ' ')
+    )
+    assert c.recursive_type_depth == 5
+
+    c = Config(recursive_type_depth=2)
+    captured = capsys.readouterr()
+    assert (
+        'it is highly recommended to use Pyright'
+        not in captured.out.replace('\n', ' ')
+    )
+    assert c.recursive_type_depth == 2


### PR DESCRIPTION
## Change Summary

Warn users when they don't set recursive type depth in the prism schema. The warning should tell users that they can set it to -1 for use with Pyright.

Closes https://github.com/RobertCraigie/prisma-client-py/issues/252

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass without significant drop in coverage
- [x] Documentation reflects changes where applicable
- [x] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
