### PR TITLE
feat(client): support ANY queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ users = await db.user.find_many(
 ```py
 posts = await db.post.find_many(
     where={
-        'OR': [
+        'ANY': [
             {'title': {'contains': 'prisma'}},
             {'content': {'contains': 'prisma'}},
         ]

--- a/docs/index.md
+++ b/docs/index.md
@@ -243,7 +243,7 @@ users = await db.user.find_many(
 ```py
 posts = await db.post.find_many(
     where={
-        'OR': [
+        'ANY': [
             {'title': {'contains': 'prisma'}},
             {'content': {'contains': 'prisma'}},
         ]

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -505,7 +505,7 @@ The following query will return the first post where the title contains the word
 ```py
 post = await db.post.find_first(
     where={
-        'OR': [
+        'ANY': [
             {
                 'title': {
                     'contains': 'prisma',

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -473,7 +473,7 @@ user = await db.user.find_first(
 
 ### Combining arguments
 
-All of the above mentioned filters can be combined with other filters using `AND`, `NOT` and `OR`.
+All of the above mentioned filters can be combined with other filters using `AND`, `NOT` and `ANY`.
 
 #### AND
 
@@ -498,7 +498,7 @@ post = await db.post.find_first(
 )
 ```
 
-#### OR
+#### ANY
 
 The following query will return the first post where the title contains the word `prisma` or is published.
 

--- a/src/prisma/_constants.py
+++ b/src/prisma/_constants.py
@@ -11,4 +11,5 @@ QUERY_BUILDER_ALIASES: Dict[str, str] = {
     'order_by': 'orderBy',
     'not_in': 'notIn',
     'is_not': 'isNot',
+    'ANY': 'OR',
 }

--- a/src/prisma/generator/templates/types.py.jinja
+++ b/src/prisma/generator/templates/types.py.jinja
@@ -637,7 +637,7 @@ class {{ current }}(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['{{ next }}', List['{{ next }}']]
     # but this causes mypy to hang :/
     AND: List['{{ next }}']
-    # OR is deprecated for ANY in https://github.com/RobertCraigie/prisma-client-py/issues/293
+    # `OR` is deprecated and will be removed in a future release
     OR: List['{{ next }}']
     ANY: List['{{ next }}']
     NOT: List['{{ next }}']
@@ -657,7 +657,7 @@ class {{ current }}(TypedDict, total=False):
 
     {% if next != '' %}
     AND: List['{{ next }}']
-    # OR is deprecated for ANY in https://github.com/RobertCraigie/prisma-client-py/issues/293
+    # `OR` is deprecated and will be removed in a future release
     OR: List['{{ next }}']
     ANY: List['{{ next }}']
     NOT: List['{{ next }}']

--- a/src/prisma/generator/templates/types.py.jinja
+++ b/src/prisma/generator/templates/types.py.jinja
@@ -637,10 +637,8 @@ class {{ current }}(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['{{ next }}', List['{{ next }}']]
     # but this causes mypy to hang :/
     AND: List['{{ next }}']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['{{ next }}']
-    ANY: List['{{ next }}']
     NOT: List['{{ next }}']
+    ANY: List['{{ next }}']
     {% endif %}
 {% endcall %}
 
@@ -657,10 +655,8 @@ class {{ current }}(TypedDict, total=False):
 
     {% if next != '' %}
     AND: List['{{ next }}']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['{{ next }}']
-    ANY: List['{{ next }}']
     NOT: List['{{ next }}']
+    ANY: List['{{ next }}']
     {% endif %}
 {% endcall %}
 

--- a/src/prisma/generator/templates/types.py.jinja
+++ b/src/prisma/generator/templates/types.py.jinja
@@ -637,7 +637,9 @@ class {{ current }}(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['{{ next }}', List['{{ next }}']]
     # but this causes mypy to hang :/
     AND: List['{{ next }}']
+    # OR is deprecated for ANY in https://github.com/RobertCraigie/prisma-client-py/issues/293
     OR: List['{{ next }}']
+    ANY: List['{{ next }}']
     NOT: List['{{ next }}']
     {% endif %}
 {% endcall %}
@@ -655,7 +657,9 @@ class {{ current }}(TypedDict, total=False):
 
     {% if next != '' %}
     AND: List['{{ next }}']
+    # OR is deprecated for ANY in https://github.com/RobertCraigie/prisma-client-py/issues/293
     OR: List['{{ next }}']
+    ANY: List['{{ next }}']
     NOT: List['{{ next }}']
     {% endif %}
 {% endcall %}

--- a/tests/test_delete_many.py
+++ b/tests/test_delete_many.py
@@ -17,3 +17,15 @@ async def test_delete_many(client: Prisma) -> None:
 
     for post in posts:
         assert await client.post.find_unique(where={'id': post.id}) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_many_where(client: Prisma) -> None:
+    """delete_many with a where clause"""
+    await client.post.create({'title': 'Foo post', 'published': False})
+    await client.post.create({'title': 'Bar post', 'published': False})
+
+    count = await client.post.delete_many(
+        where={'ANY': [{'title': 'Foo post'}, {'title': 'Bar post'}]}
+    )
+    assert count == 2

--- a/tests/test_find_first.py
+++ b/tests/test_find_first.py
@@ -138,7 +138,7 @@ async def test_find_first(client: Prisma) -> None:
             'views': {
                 'gt': 100,
             },
-            'OR': [
+            'ANY': [
                 {
                     'published': False,
                 },
@@ -149,7 +149,7 @@ async def test_find_first(client: Prisma) -> None:
 
     post = await client.post.find_first(
         where={
-            'OR': [
+            'ANY': [
                 {
                     'views': {
                         'gt': 100,
@@ -166,7 +166,7 @@ async def test_find_first(client: Prisma) -> None:
 
     post = await client.post.find_first(
         where={
-            'OR': [
+            'ANY': [
                 {
                     'views': {
                         'gt': 100,
@@ -284,37 +284,6 @@ async def test_filtering_and_ordering_one_to_many_relation(
     )
     assert user is not None
     assert user.name == 'Tegan'
-
-
-@pytest.mark.asyncio
-async def test_list_wrapper_query_transformation_deprecated(
-    client: Prisma,
-) -> None:
-    """Queries wrapped within a list transform global aliases
-
-    This can be removed when 'OR' support is dropped.
-    """
-    query: UserWhereInput = {
-        'OR': [
-            {'name': {'startswith': '40'}},
-            {'name': {'contains': ', 40'}},
-            {'name': {'contains': 'house'}},
-        ]
-    }
-
-    await client.user.create({'name': 'Robert house'})
-    found = await client.user.find_first(
-        where=query, order={'created_at': 'asc'}
-    )
-    assert found is not None
-    assert found.name == 'Robert house'
-
-    await client.user.create({'name': '40 robert'})
-    found = await client.user.find_first(
-        skip=1, where=query, order={'created_at': 'asc'}
-    )
-    assert found is not None
-    assert found.name == '40 robert'
 
 
 @pytest.mark.asyncio

--- a/tests/test_find_many.py
+++ b/tests/test_find_many.py
@@ -14,8 +14,14 @@ async def test_find_many(client: Prisma) -> None:
     assert len(found) == 1
     assert found[0].id == posts[0].id
 
+    # OR is deprecated and will be removed in a future release
     posts = await client.post.find_many(
         where={'OR': [{'title': 'Test post 1'}, {'title': 'Test post 2'}]}
+    )
+    assert len(posts) == 2
+
+    posts = await client.post.find_many(
+        where={'ANY': [{'title': 'Test post 1'}, {'title': 'Test post 2'}]}
     )
     assert len(posts) == 2
 

--- a/tests/test_find_many.py
+++ b/tests/test_find_many.py
@@ -14,12 +14,6 @@ async def test_find_many(client: Prisma) -> None:
     assert len(found) == 1
     assert found[0].id == posts[0].id
 
-    # OR is deprecated and will be removed in a future release
-    posts = await client.post.find_many(
-        where={'OR': [{'title': 'Test post 1'}, {'title': 'Test post 2'}]}
-    )
-    assert len(posts) == 2
-
     posts = await client.post.find_many(
         where={'ANY': [{'title': 'Test post 1'}, {'title': 'Test post 2'}]}
     )

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[types.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[types.py].raw
@@ -1897,7 +1897,9 @@ class PostWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['PostWhereInputRecursive1', List['PostWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['PostWhereInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['PostWhereInputRecursive1']
+    ANY: List['PostWhereInputRecursive1']
     NOT: List['PostWhereInputRecursive1']
 
 
@@ -1914,7 +1916,9 @@ class PostWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['PostWhereInputRecursive2', List['PostWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['PostWhereInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['PostWhereInputRecursive2']
+    ANY: List['PostWhereInputRecursive2']
     NOT: List['PostWhereInputRecursive2']
 
 
@@ -1945,7 +1949,9 @@ class PostScalarWhereWithAggregatesInput(TypedDict, total=False):
     author_id: Union[int, 'types.IntWithAggregatesFilter']
 
     AND: List['PostScalarWhereWithAggregatesInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['PostScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['PostScalarWhereWithAggregatesInputRecursive1']
     NOT: List['PostScalarWhereWithAggregatesInputRecursive1']
 
 
@@ -1959,7 +1965,9 @@ class PostScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     author_id: Union[int, 'types.IntWithAggregatesFilter']
 
     AND: List['PostScalarWhereWithAggregatesInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['PostScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['PostScalarWhereWithAggregatesInputRecursive2']
     NOT: List['PostScalarWhereWithAggregatesInputRecursive2']
 
 
@@ -3116,7 +3124,9 @@ class UserWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['UserWhereInputRecursive1', List['UserWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['UserWhereInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['UserWhereInputRecursive1']
+    ANY: List['UserWhereInputRecursive1']
     NOT: List['UserWhereInputRecursive1']
 
 
@@ -3139,7 +3149,9 @@ class UserWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['UserWhereInputRecursive2', List['UserWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['UserWhereInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['UserWhereInputRecursive2']
+    ANY: List['UserWhereInputRecursive2']
     NOT: List['UserWhereInputRecursive2']
 
 
@@ -3182,7 +3194,9 @@ class UserScalarWhereWithAggregatesInput(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['UserScalarWhereWithAggregatesInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['UserScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['UserScalarWhereWithAggregatesInputRecursive1']
     NOT: List['UserScalarWhereWithAggregatesInputRecursive1']
 
 
@@ -3202,7 +3216,9 @@ class UserScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['UserScalarWhereWithAggregatesInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['UserScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['UserScalarWhereWithAggregatesInputRecursive2']
     NOT: List['UserScalarWhereWithAggregatesInputRecursive2']
 
 
@@ -4397,7 +4413,9 @@ class MWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['MWhereInputRecursive1', List['MWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['MWhereInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['MWhereInputRecursive1']
+    ANY: List['MWhereInputRecursive1']
     NOT: List['MWhereInputRecursive1']
 
 
@@ -4419,7 +4437,9 @@ class MWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['MWhereInputRecursive2', List['MWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['MWhereInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['MWhereInputRecursive2']
+    ANY: List['MWhereInputRecursive2']
     NOT: List['MWhereInputRecursive2']
 
 
@@ -4460,7 +4480,9 @@ class MScalarWhereWithAggregatesInput(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['MScalarWhereWithAggregatesInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['MScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['MScalarWhereWithAggregatesInputRecursive1']
     NOT: List['MScalarWhereWithAggregatesInputRecursive1']
 
 
@@ -4479,7 +4501,9 @@ class MScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['MScalarWhereWithAggregatesInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['MScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['MScalarWhereWithAggregatesInputRecursive2']
     NOT: List['MScalarWhereWithAggregatesInputRecursive2']
 
 
@@ -5693,7 +5717,9 @@ class NWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['NWhereInputRecursive1', List['NWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['NWhereInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['NWhereInputRecursive1']
+    ANY: List['NWhereInputRecursive1']
     NOT: List['NWhereInputRecursive1']
 
 
@@ -5717,7 +5743,9 @@ class NWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['NWhereInputRecursive2', List['NWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['NWhereInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['NWhereInputRecursive2']
+    ANY: List['NWhereInputRecursive2']
     NOT: List['NWhereInputRecursive2']
 
 
@@ -5762,7 +5790,9 @@ class NScalarWhereWithAggregatesInput(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['NScalarWhereWithAggregatesInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['NScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['NScalarWhereWithAggregatesInputRecursive1']
     NOT: List['NScalarWhereWithAggregatesInputRecursive1']
 
 
@@ -5783,7 +5813,9 @@ class NScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['NScalarWhereWithAggregatesInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['NScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['NScalarWhereWithAggregatesInputRecursive2']
     NOT: List['NScalarWhereWithAggregatesInputRecursive2']
 
 
@@ -6987,7 +7019,9 @@ class OneOptionalWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['OneOptionalWhereInputRecursive1', List['OneOptionalWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['OneOptionalWhereInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['OneOptionalWhereInputRecursive1']
+    ANY: List['OneOptionalWhereInputRecursive1']
     NOT: List['OneOptionalWhereInputRecursive1']
 
 
@@ -7009,7 +7043,9 @@ class OneOptionalWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['OneOptionalWhereInputRecursive2', List['OneOptionalWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['OneOptionalWhereInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['OneOptionalWhereInputRecursive2']
+    ANY: List['OneOptionalWhereInputRecursive2']
     NOT: List['OneOptionalWhereInputRecursive2']
 
 
@@ -7050,7 +7086,9 @@ class OneOptionalScalarWhereWithAggregatesInput(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['OneOptionalScalarWhereWithAggregatesInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['OneOptionalScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['OneOptionalScalarWhereWithAggregatesInputRecursive1']
     NOT: List['OneOptionalScalarWhereWithAggregatesInputRecursive1']
 
 
@@ -7069,7 +7107,9 @@ class OneOptionalScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['OneOptionalScalarWhereWithAggregatesInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['OneOptionalScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['OneOptionalScalarWhereWithAggregatesInputRecursive2']
     NOT: List['OneOptionalScalarWhereWithAggregatesInputRecursive2']
 
 
@@ -8267,7 +8307,9 @@ class ManyRequiredWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['ManyRequiredWhereInputRecursive1', List['ManyRequiredWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['ManyRequiredWhereInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['ManyRequiredWhereInputRecursive1']
+    ANY: List['ManyRequiredWhereInputRecursive1']
     NOT: List['ManyRequiredWhereInputRecursive1']
 
 
@@ -8290,7 +8332,9 @@ class ManyRequiredWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['ManyRequiredWhereInputRecursive2', List['ManyRequiredWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['ManyRequiredWhereInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['ManyRequiredWhereInputRecursive2']
+    ANY: List['ManyRequiredWhereInputRecursive2']
     NOT: List['ManyRequiredWhereInputRecursive2']
 
 
@@ -8333,7 +8377,9 @@ class ManyRequiredScalarWhereWithAggregatesInput(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['ManyRequiredScalarWhereWithAggregatesInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['ManyRequiredScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['ManyRequiredScalarWhereWithAggregatesInputRecursive1']
     NOT: List['ManyRequiredScalarWhereWithAggregatesInputRecursive1']
 
 
@@ -8353,7 +8399,9 @@ class ManyRequiredScalarWhereWithAggregatesInputRecursive1(TypedDict, total=Fals
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['ManyRequiredScalarWhereWithAggregatesInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['ManyRequiredScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['ManyRequiredScalarWhereWithAggregatesInputRecursive2']
     NOT: List['ManyRequiredScalarWhereWithAggregatesInputRecursive2']
 
 
@@ -9533,7 +9581,9 @@ class ListsWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['ListsWhereInputRecursive1', List['ListsWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['ListsWhereInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['ListsWhereInputRecursive1']
+    ANY: List['ListsWhereInputRecursive1']
     NOT: List['ListsWhereInputRecursive1']
 
 
@@ -9553,7 +9603,9 @@ class ListsWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['ListsWhereInputRecursive2', List['ListsWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['ListsWhereInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['ListsWhereInputRecursive2']
+    ANY: List['ListsWhereInputRecursive2']
     NOT: List['ListsWhereInputRecursive2']
 
 
@@ -9591,7 +9643,9 @@ class ListsScalarWhereWithAggregatesInput(TypedDict, total=False):
     decimals: Union[decimal.Decimal, 'types.DecimalWithAggregatesFilter']
 
     AND: List['ListsScalarWhereWithAggregatesInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['ListsScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['ListsScalarWhereWithAggregatesInputRecursive1']
     NOT: List['ListsScalarWhereWithAggregatesInputRecursive1']
 
 
@@ -9609,7 +9663,9 @@ class ListsScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     decimals: Union[decimal.Decimal, 'types.DecimalWithAggregatesFilter']
 
     AND: List['ListsScalarWhereWithAggregatesInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['ListsScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['ListsScalarWhereWithAggregatesInputRecursive2']
     NOT: List['ListsScalarWhereWithAggregatesInputRecursive2']
 
 
@@ -10766,7 +10822,9 @@ class AWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['AWhereInputRecursive1', List['AWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['AWhereInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['AWhereInputRecursive1']
+    ANY: List['AWhereInputRecursive1']
     NOT: List['AWhereInputRecursive1']
 
 
@@ -10785,7 +10843,9 @@ class AWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['AWhereInputRecursive2', List['AWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['AWhereInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['AWhereInputRecursive2']
+    ANY: List['AWhereInputRecursive2']
     NOT: List['AWhereInputRecursive2']
 
 
@@ -10821,7 +10881,9 @@ class AScalarWhereWithAggregatesInput(TypedDict, total=False):
     enum: 'enums.ABeautifulEnum'
 
     AND: List['AScalarWhereWithAggregatesInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['AScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['AScalarWhereWithAggregatesInputRecursive1']
     NOT: List['AScalarWhereWithAggregatesInputRecursive1']
 
 
@@ -10838,7 +10900,9 @@ class AScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     enum: 'enums.ABeautifulEnum'
 
     AND: List['AScalarWhereWithAggregatesInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['AScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['AScalarWhereWithAggregatesInputRecursive2']
     NOT: List['AScalarWhereWithAggregatesInputRecursive2']
 
 
@@ -11938,7 +12002,9 @@ class BWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['BWhereInputRecursive1', List['BWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['BWhereInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['BWhereInputRecursive1']
+    ANY: List['BWhereInputRecursive1']
     NOT: List['BWhereInputRecursive1']
 
 
@@ -11953,7 +12019,9 @@ class BWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['BWhereInputRecursive2', List['BWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['BWhereInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['BWhereInputRecursive2']
+    ANY: List['BWhereInputRecursive2']
     NOT: List['BWhereInputRecursive2']
 
 
@@ -11981,7 +12049,9 @@ class BScalarWhereWithAggregatesInput(TypedDict, total=False):
     numFloat: Union[decimal.Decimal, 'types.DecimalWithAggregatesFilter']
 
     AND: List['BScalarWhereWithAggregatesInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['BScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['BScalarWhereWithAggregatesInputRecursive1']
     NOT: List['BScalarWhereWithAggregatesInputRecursive1']
 
 
@@ -11994,7 +12064,9 @@ class BScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     numFloat: Union[decimal.Decimal, 'types.DecimalWithAggregatesFilter']
 
     AND: List['BScalarWhereWithAggregatesInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['BScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['BScalarWhereWithAggregatesInputRecursive2']
     NOT: List['BScalarWhereWithAggregatesInputRecursive2']
 
 
@@ -13049,7 +13121,9 @@ class CWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['CWhereInputRecursive1', List['CWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['CWhereInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['CWhereInputRecursive1']
+    ANY: List['CWhereInputRecursive1']
     NOT: List['CWhereInputRecursive1']
 
 
@@ -13065,7 +13139,9 @@ class CWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['CWhereInputRecursive2', List['CWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['CWhereInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['CWhereInputRecursive2']
+    ANY: List['CWhereInputRecursive2']
     NOT: List['CWhereInputRecursive2']
 
 
@@ -13095,7 +13171,9 @@ class CScalarWhereWithAggregatesInput(TypedDict, total=False):
     uuid: Union[str, 'types.StringWithAggregatesFilter']
 
     AND: List['CScalarWhereWithAggregatesInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['CScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['CScalarWhereWithAggregatesInputRecursive1']
     NOT: List['CScalarWhereWithAggregatesInputRecursive1']
 
 
@@ -13109,7 +13187,9 @@ class CScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     uuid: Union[str, 'types.StringWithAggregatesFilter']
 
     AND: List['CScalarWhereWithAggregatesInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['CScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['CScalarWhereWithAggregatesInputRecursive2']
     NOT: List['CScalarWhereWithAggregatesInputRecursive2']
 
 
@@ -14158,7 +14238,9 @@ class DWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['DWhereInputRecursive1', List['DWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['DWhereInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['DWhereInputRecursive1']
+    ANY: List['DWhereInputRecursive1']
     NOT: List['DWhereInputRecursive1']
 
 
@@ -14174,7 +14256,9 @@ class DWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['DWhereInputRecursive2', List['DWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['DWhereInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['DWhereInputRecursive2']
+    ANY: List['DWhereInputRecursive2']
     NOT: List['DWhereInputRecursive2']
 
 
@@ -14204,7 +14288,9 @@ class DScalarWhereWithAggregatesInput(TypedDict, total=False):
     binary: Union['fields.Base64', 'types.BytesWithAggregatesFilter']
 
     AND: List['DScalarWhereWithAggregatesInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['DScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['DScalarWhereWithAggregatesInputRecursive1']
     NOT: List['DScalarWhereWithAggregatesInputRecursive1']
 
 
@@ -14218,7 +14304,9 @@ class DScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     binary: Union['fields.Base64', 'types.BytesWithAggregatesFilter']
 
     AND: List['DScalarWhereWithAggregatesInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['DScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['DScalarWhereWithAggregatesInputRecursive2']
     NOT: List['DScalarWhereWithAggregatesInputRecursive2']
 
 
@@ -15239,7 +15327,9 @@ class EWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['EWhereInputRecursive1', List['EWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['EWhereInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['EWhereInputRecursive1']
+    ANY: List['EWhereInputRecursive1']
     NOT: List['EWhereInputRecursive1']
 
 
@@ -15253,7 +15343,9 @@ class EWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['EWhereInputRecursive2', List['EWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['EWhereInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['EWhereInputRecursive2']
+    ANY: List['EWhereInputRecursive2']
     NOT: List['EWhereInputRecursive2']
 
 
@@ -15279,7 +15371,9 @@ class EScalarWhereWithAggregatesInput(TypedDict, total=False):
     ts: Union[datetime.datetime, 'types.DateTimeWithAggregatesFilter']
 
     AND: List['EScalarWhereWithAggregatesInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['EScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['EScalarWhereWithAggregatesInputRecursive1']
     NOT: List['EScalarWhereWithAggregatesInputRecursive1']
 
 
@@ -15291,7 +15385,9 @@ class EScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     ts: Union[datetime.datetime, 'types.DateTimeWithAggregatesFilter']
 
     AND: List['EScalarWhereWithAggregatesInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['EScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['EScalarWhereWithAggregatesInputRecursive2']
     NOT: List['EScalarWhereWithAggregatesInputRecursive2']
 
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[types.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[types.py].raw
@@ -1897,10 +1897,8 @@ class PostWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['PostWhereInputRecursive1', List['PostWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['PostWhereInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['PostWhereInputRecursive1']
-    ANY: List['PostWhereInputRecursive1']
     NOT: List['PostWhereInputRecursive1']
+    ANY: List['PostWhereInputRecursive1']
 
 
 class PostWhereInputRecursive1(TypedDict, total=False):
@@ -1916,10 +1914,8 @@ class PostWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['PostWhereInputRecursive2', List['PostWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['PostWhereInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['PostWhereInputRecursive2']
-    ANY: List['PostWhereInputRecursive2']
     NOT: List['PostWhereInputRecursive2']
+    ANY: List['PostWhereInputRecursive2']
 
 
 class PostWhereInputRecursive2(TypedDict, total=False):
@@ -1949,10 +1945,8 @@ class PostScalarWhereWithAggregatesInput(TypedDict, total=False):
     author_id: Union[int, 'types.IntWithAggregatesFilter']
 
     AND: List['PostScalarWhereWithAggregatesInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['PostScalarWhereWithAggregatesInputRecursive1']
-    ANY: List['PostScalarWhereWithAggregatesInputRecursive1']
     NOT: List['PostScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['PostScalarWhereWithAggregatesInputRecursive1']
 
 
 class PostScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
@@ -1965,10 +1959,8 @@ class PostScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     author_id: Union[int, 'types.IntWithAggregatesFilter']
 
     AND: List['PostScalarWhereWithAggregatesInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['PostScalarWhereWithAggregatesInputRecursive2']
-    ANY: List['PostScalarWhereWithAggregatesInputRecursive2']
     NOT: List['PostScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['PostScalarWhereWithAggregatesInputRecursive2']
 
 
 class PostScalarWhereWithAggregatesInputRecursive2(TypedDict, total=False):
@@ -3124,10 +3116,8 @@ class UserWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['UserWhereInputRecursive1', List['UserWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['UserWhereInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['UserWhereInputRecursive1']
-    ANY: List['UserWhereInputRecursive1']
     NOT: List['UserWhereInputRecursive1']
+    ANY: List['UserWhereInputRecursive1']
 
 
 class UserWhereInputRecursive1(TypedDict, total=False):
@@ -3149,10 +3139,8 @@ class UserWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['UserWhereInputRecursive2', List['UserWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['UserWhereInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['UserWhereInputRecursive2']
-    ANY: List['UserWhereInputRecursive2']
     NOT: List['UserWhereInputRecursive2']
+    ANY: List['UserWhereInputRecursive2']
 
 
 class UserWhereInputRecursive2(TypedDict, total=False):
@@ -3194,10 +3182,8 @@ class UserScalarWhereWithAggregatesInput(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['UserScalarWhereWithAggregatesInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['UserScalarWhereWithAggregatesInputRecursive1']
-    ANY: List['UserScalarWhereWithAggregatesInputRecursive1']
     NOT: List['UserScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['UserScalarWhereWithAggregatesInputRecursive1']
 
 
 class UserScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
@@ -3216,10 +3202,8 @@ class UserScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['UserScalarWhereWithAggregatesInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['UserScalarWhereWithAggregatesInputRecursive2']
-    ANY: List['UserScalarWhereWithAggregatesInputRecursive2']
     NOT: List['UserScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['UserScalarWhereWithAggregatesInputRecursive2']
 
 
 class UserScalarWhereWithAggregatesInputRecursive2(TypedDict, total=False):
@@ -4413,10 +4397,8 @@ class MWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['MWhereInputRecursive1', List['MWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['MWhereInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['MWhereInputRecursive1']
-    ANY: List['MWhereInputRecursive1']
     NOT: List['MWhereInputRecursive1']
+    ANY: List['MWhereInputRecursive1']
 
 
 class MWhereInputRecursive1(TypedDict, total=False):
@@ -4437,10 +4419,8 @@ class MWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['MWhereInputRecursive2', List['MWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['MWhereInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['MWhereInputRecursive2']
-    ANY: List['MWhereInputRecursive2']
     NOT: List['MWhereInputRecursive2']
+    ANY: List['MWhereInputRecursive2']
 
 
 class MWhereInputRecursive2(TypedDict, total=False):
@@ -4480,10 +4460,8 @@ class MScalarWhereWithAggregatesInput(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['MScalarWhereWithAggregatesInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['MScalarWhereWithAggregatesInputRecursive1']
-    ANY: List['MScalarWhereWithAggregatesInputRecursive1']
     NOT: List['MScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['MScalarWhereWithAggregatesInputRecursive1']
 
 
 class MScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
@@ -4501,10 +4479,8 @@ class MScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['MScalarWhereWithAggregatesInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['MScalarWhereWithAggregatesInputRecursive2']
-    ANY: List['MScalarWhereWithAggregatesInputRecursive2']
     NOT: List['MScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['MScalarWhereWithAggregatesInputRecursive2']
 
 
 class MScalarWhereWithAggregatesInputRecursive2(TypedDict, total=False):
@@ -5717,10 +5693,8 @@ class NWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['NWhereInputRecursive1', List['NWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['NWhereInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['NWhereInputRecursive1']
-    ANY: List['NWhereInputRecursive1']
     NOT: List['NWhereInputRecursive1']
+    ANY: List['NWhereInputRecursive1']
 
 
 class NWhereInputRecursive1(TypedDict, total=False):
@@ -5743,10 +5717,8 @@ class NWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['NWhereInputRecursive2', List['NWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['NWhereInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['NWhereInputRecursive2']
-    ANY: List['NWhereInputRecursive2']
     NOT: List['NWhereInputRecursive2']
+    ANY: List['NWhereInputRecursive2']
 
 
 class NWhereInputRecursive2(TypedDict, total=False):
@@ -5790,10 +5762,8 @@ class NScalarWhereWithAggregatesInput(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['NScalarWhereWithAggregatesInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['NScalarWhereWithAggregatesInputRecursive1']
-    ANY: List['NScalarWhereWithAggregatesInputRecursive1']
     NOT: List['NScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['NScalarWhereWithAggregatesInputRecursive1']
 
 
 class NScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
@@ -5813,10 +5783,8 @@ class NScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['NScalarWhereWithAggregatesInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['NScalarWhereWithAggregatesInputRecursive2']
-    ANY: List['NScalarWhereWithAggregatesInputRecursive2']
     NOT: List['NScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['NScalarWhereWithAggregatesInputRecursive2']
 
 
 class NScalarWhereWithAggregatesInputRecursive2(TypedDict, total=False):
@@ -7019,10 +6987,8 @@ class OneOptionalWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['OneOptionalWhereInputRecursive1', List['OneOptionalWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['OneOptionalWhereInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['OneOptionalWhereInputRecursive1']
-    ANY: List['OneOptionalWhereInputRecursive1']
     NOT: List['OneOptionalWhereInputRecursive1']
+    ANY: List['OneOptionalWhereInputRecursive1']
 
 
 class OneOptionalWhereInputRecursive1(TypedDict, total=False):
@@ -7043,10 +7009,8 @@ class OneOptionalWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['OneOptionalWhereInputRecursive2', List['OneOptionalWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['OneOptionalWhereInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['OneOptionalWhereInputRecursive2']
-    ANY: List['OneOptionalWhereInputRecursive2']
     NOT: List['OneOptionalWhereInputRecursive2']
+    ANY: List['OneOptionalWhereInputRecursive2']
 
 
 class OneOptionalWhereInputRecursive2(TypedDict, total=False):
@@ -7086,10 +7050,8 @@ class OneOptionalScalarWhereWithAggregatesInput(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['OneOptionalScalarWhereWithAggregatesInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['OneOptionalScalarWhereWithAggregatesInputRecursive1']
-    ANY: List['OneOptionalScalarWhereWithAggregatesInputRecursive1']
     NOT: List['OneOptionalScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['OneOptionalScalarWhereWithAggregatesInputRecursive1']
 
 
 class OneOptionalScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
@@ -7107,10 +7069,8 @@ class OneOptionalScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['OneOptionalScalarWhereWithAggregatesInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['OneOptionalScalarWhereWithAggregatesInputRecursive2']
-    ANY: List['OneOptionalScalarWhereWithAggregatesInputRecursive2']
     NOT: List['OneOptionalScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['OneOptionalScalarWhereWithAggregatesInputRecursive2']
 
 
 class OneOptionalScalarWhereWithAggregatesInputRecursive2(TypedDict, total=False):
@@ -8307,10 +8267,8 @@ class ManyRequiredWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['ManyRequiredWhereInputRecursive1', List['ManyRequiredWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['ManyRequiredWhereInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['ManyRequiredWhereInputRecursive1']
-    ANY: List['ManyRequiredWhereInputRecursive1']
     NOT: List['ManyRequiredWhereInputRecursive1']
+    ANY: List['ManyRequiredWhereInputRecursive1']
 
 
 class ManyRequiredWhereInputRecursive1(TypedDict, total=False):
@@ -8332,10 +8290,8 @@ class ManyRequiredWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['ManyRequiredWhereInputRecursive2', List['ManyRequiredWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['ManyRequiredWhereInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['ManyRequiredWhereInputRecursive2']
-    ANY: List['ManyRequiredWhereInputRecursive2']
     NOT: List['ManyRequiredWhereInputRecursive2']
+    ANY: List['ManyRequiredWhereInputRecursive2']
 
 
 class ManyRequiredWhereInputRecursive2(TypedDict, total=False):
@@ -8377,10 +8333,8 @@ class ManyRequiredScalarWhereWithAggregatesInput(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['ManyRequiredScalarWhereWithAggregatesInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['ManyRequiredScalarWhereWithAggregatesInputRecursive1']
-    ANY: List['ManyRequiredScalarWhereWithAggregatesInputRecursive1']
     NOT: List['ManyRequiredScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['ManyRequiredScalarWhereWithAggregatesInputRecursive1']
 
 
 class ManyRequiredScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
@@ -8399,10 +8353,8 @@ class ManyRequiredScalarWhereWithAggregatesInputRecursive1(TypedDict, total=Fals
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['ManyRequiredScalarWhereWithAggregatesInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['ManyRequiredScalarWhereWithAggregatesInputRecursive2']
-    ANY: List['ManyRequiredScalarWhereWithAggregatesInputRecursive2']
     NOT: List['ManyRequiredScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['ManyRequiredScalarWhereWithAggregatesInputRecursive2']
 
 
 class ManyRequiredScalarWhereWithAggregatesInputRecursive2(TypedDict, total=False):
@@ -9581,10 +9533,8 @@ class ListsWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['ListsWhereInputRecursive1', List['ListsWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['ListsWhereInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['ListsWhereInputRecursive1']
-    ANY: List['ListsWhereInputRecursive1']
     NOT: List['ListsWhereInputRecursive1']
+    ANY: List['ListsWhereInputRecursive1']
 
 
 class ListsWhereInputRecursive1(TypedDict, total=False):
@@ -9603,10 +9553,8 @@ class ListsWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['ListsWhereInputRecursive2', List['ListsWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['ListsWhereInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['ListsWhereInputRecursive2']
-    ANY: List['ListsWhereInputRecursive2']
     NOT: List['ListsWhereInputRecursive2']
+    ANY: List['ListsWhereInputRecursive2']
 
 
 class ListsWhereInputRecursive2(TypedDict, total=False):
@@ -9643,10 +9591,8 @@ class ListsScalarWhereWithAggregatesInput(TypedDict, total=False):
     decimals: Union[decimal.Decimal, 'types.DecimalWithAggregatesFilter']
 
     AND: List['ListsScalarWhereWithAggregatesInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['ListsScalarWhereWithAggregatesInputRecursive1']
-    ANY: List['ListsScalarWhereWithAggregatesInputRecursive1']
     NOT: List['ListsScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['ListsScalarWhereWithAggregatesInputRecursive1']
 
 
 class ListsScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
@@ -9663,10 +9609,8 @@ class ListsScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     decimals: Union[decimal.Decimal, 'types.DecimalWithAggregatesFilter']
 
     AND: List['ListsScalarWhereWithAggregatesInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['ListsScalarWhereWithAggregatesInputRecursive2']
-    ANY: List['ListsScalarWhereWithAggregatesInputRecursive2']
     NOT: List['ListsScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['ListsScalarWhereWithAggregatesInputRecursive2']
 
 
 class ListsScalarWhereWithAggregatesInputRecursive2(TypedDict, total=False):
@@ -10822,10 +10766,8 @@ class AWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['AWhereInputRecursive1', List['AWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['AWhereInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['AWhereInputRecursive1']
-    ANY: List['AWhereInputRecursive1']
     NOT: List['AWhereInputRecursive1']
+    ANY: List['AWhereInputRecursive1']
 
 
 class AWhereInputRecursive1(TypedDict, total=False):
@@ -10843,10 +10785,8 @@ class AWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['AWhereInputRecursive2', List['AWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['AWhereInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['AWhereInputRecursive2']
-    ANY: List['AWhereInputRecursive2']
     NOT: List['AWhereInputRecursive2']
+    ANY: List['AWhereInputRecursive2']
 
 
 class AWhereInputRecursive2(TypedDict, total=False):
@@ -10881,10 +10821,8 @@ class AScalarWhereWithAggregatesInput(TypedDict, total=False):
     enum: 'enums.ABeautifulEnum'
 
     AND: List['AScalarWhereWithAggregatesInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['AScalarWhereWithAggregatesInputRecursive1']
-    ANY: List['AScalarWhereWithAggregatesInputRecursive1']
     NOT: List['AScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['AScalarWhereWithAggregatesInputRecursive1']
 
 
 class AScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
@@ -10900,10 +10838,8 @@ class AScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     enum: 'enums.ABeautifulEnum'
 
     AND: List['AScalarWhereWithAggregatesInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['AScalarWhereWithAggregatesInputRecursive2']
-    ANY: List['AScalarWhereWithAggregatesInputRecursive2']
     NOT: List['AScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['AScalarWhereWithAggregatesInputRecursive2']
 
 
 class AScalarWhereWithAggregatesInputRecursive2(TypedDict, total=False):
@@ -12002,10 +11938,8 @@ class BWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['BWhereInputRecursive1', List['BWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['BWhereInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['BWhereInputRecursive1']
-    ANY: List['BWhereInputRecursive1']
     NOT: List['BWhereInputRecursive1']
+    ANY: List['BWhereInputRecursive1']
 
 
 class BWhereInputRecursive1(TypedDict, total=False):
@@ -12019,10 +11953,8 @@ class BWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['BWhereInputRecursive2', List['BWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['BWhereInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['BWhereInputRecursive2']
-    ANY: List['BWhereInputRecursive2']
     NOT: List['BWhereInputRecursive2']
+    ANY: List['BWhereInputRecursive2']
 
 
 class BWhereInputRecursive2(TypedDict, total=False):
@@ -12049,10 +11981,8 @@ class BScalarWhereWithAggregatesInput(TypedDict, total=False):
     numFloat: Union[decimal.Decimal, 'types.DecimalWithAggregatesFilter']
 
     AND: List['BScalarWhereWithAggregatesInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['BScalarWhereWithAggregatesInputRecursive1']
-    ANY: List['BScalarWhereWithAggregatesInputRecursive1']
     NOT: List['BScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['BScalarWhereWithAggregatesInputRecursive1']
 
 
 class BScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
@@ -12064,10 +11994,8 @@ class BScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     numFloat: Union[decimal.Decimal, 'types.DecimalWithAggregatesFilter']
 
     AND: List['BScalarWhereWithAggregatesInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['BScalarWhereWithAggregatesInputRecursive2']
-    ANY: List['BScalarWhereWithAggregatesInputRecursive2']
     NOT: List['BScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['BScalarWhereWithAggregatesInputRecursive2']
 
 
 class BScalarWhereWithAggregatesInputRecursive2(TypedDict, total=False):
@@ -13121,10 +13049,8 @@ class CWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['CWhereInputRecursive1', List['CWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['CWhereInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['CWhereInputRecursive1']
-    ANY: List['CWhereInputRecursive1']
     NOT: List['CWhereInputRecursive1']
+    ANY: List['CWhereInputRecursive1']
 
 
 class CWhereInputRecursive1(TypedDict, total=False):
@@ -13139,10 +13065,8 @@ class CWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['CWhereInputRecursive2', List['CWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['CWhereInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['CWhereInputRecursive2']
-    ANY: List['CWhereInputRecursive2']
     NOT: List['CWhereInputRecursive2']
+    ANY: List['CWhereInputRecursive2']
 
 
 class CWhereInputRecursive2(TypedDict, total=False):
@@ -13171,10 +13095,8 @@ class CScalarWhereWithAggregatesInput(TypedDict, total=False):
     uuid: Union[str, 'types.StringWithAggregatesFilter']
 
     AND: List['CScalarWhereWithAggregatesInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['CScalarWhereWithAggregatesInputRecursive1']
-    ANY: List['CScalarWhereWithAggregatesInputRecursive1']
     NOT: List['CScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['CScalarWhereWithAggregatesInputRecursive1']
 
 
 class CScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
@@ -13187,10 +13109,8 @@ class CScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     uuid: Union[str, 'types.StringWithAggregatesFilter']
 
     AND: List['CScalarWhereWithAggregatesInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['CScalarWhereWithAggregatesInputRecursive2']
-    ANY: List['CScalarWhereWithAggregatesInputRecursive2']
     NOT: List['CScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['CScalarWhereWithAggregatesInputRecursive2']
 
 
 class CScalarWhereWithAggregatesInputRecursive2(TypedDict, total=False):
@@ -14238,10 +14158,8 @@ class DWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['DWhereInputRecursive1', List['DWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['DWhereInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['DWhereInputRecursive1']
-    ANY: List['DWhereInputRecursive1']
     NOT: List['DWhereInputRecursive1']
+    ANY: List['DWhereInputRecursive1']
 
 
 class DWhereInputRecursive1(TypedDict, total=False):
@@ -14256,10 +14174,8 @@ class DWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['DWhereInputRecursive2', List['DWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['DWhereInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['DWhereInputRecursive2']
-    ANY: List['DWhereInputRecursive2']
     NOT: List['DWhereInputRecursive2']
+    ANY: List['DWhereInputRecursive2']
 
 
 class DWhereInputRecursive2(TypedDict, total=False):
@@ -14288,10 +14204,8 @@ class DScalarWhereWithAggregatesInput(TypedDict, total=False):
     binary: Union['fields.Base64', 'types.BytesWithAggregatesFilter']
 
     AND: List['DScalarWhereWithAggregatesInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['DScalarWhereWithAggregatesInputRecursive1']
-    ANY: List['DScalarWhereWithAggregatesInputRecursive1']
     NOT: List['DScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['DScalarWhereWithAggregatesInputRecursive1']
 
 
 class DScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
@@ -14304,10 +14218,8 @@ class DScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     binary: Union['fields.Base64', 'types.BytesWithAggregatesFilter']
 
     AND: List['DScalarWhereWithAggregatesInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['DScalarWhereWithAggregatesInputRecursive2']
-    ANY: List['DScalarWhereWithAggregatesInputRecursive2']
     NOT: List['DScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['DScalarWhereWithAggregatesInputRecursive2']
 
 
 class DScalarWhereWithAggregatesInputRecursive2(TypedDict, total=False):
@@ -15327,10 +15239,8 @@ class EWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['EWhereInputRecursive1', List['EWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['EWhereInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['EWhereInputRecursive1']
-    ANY: List['EWhereInputRecursive1']
     NOT: List['EWhereInputRecursive1']
+    ANY: List['EWhereInputRecursive1']
 
 
 class EWhereInputRecursive1(TypedDict, total=False):
@@ -15343,10 +15253,8 @@ class EWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['EWhereInputRecursive2', List['EWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['EWhereInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['EWhereInputRecursive2']
-    ANY: List['EWhereInputRecursive2']
     NOT: List['EWhereInputRecursive2']
+    ANY: List['EWhereInputRecursive2']
 
 
 class EWhereInputRecursive2(TypedDict, total=False):
@@ -15371,10 +15279,8 @@ class EScalarWhereWithAggregatesInput(TypedDict, total=False):
     ts: Union[datetime.datetime, 'types.DateTimeWithAggregatesFilter']
 
     AND: List['EScalarWhereWithAggregatesInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['EScalarWhereWithAggregatesInputRecursive1']
-    ANY: List['EScalarWhereWithAggregatesInputRecursive1']
     NOT: List['EScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['EScalarWhereWithAggregatesInputRecursive1']
 
 
 class EScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
@@ -15385,10 +15291,8 @@ class EScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     ts: Union[datetime.datetime, 'types.DateTimeWithAggregatesFilter']
 
     AND: List['EScalarWhereWithAggregatesInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['EScalarWhereWithAggregatesInputRecursive2']
-    ANY: List['EScalarWhereWithAggregatesInputRecursive2']
     NOT: List['EScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['EScalarWhereWithAggregatesInputRecursive2']
 
 
 class EScalarWhereWithAggregatesInputRecursive2(TypedDict, total=False):

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[types.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[types.py].raw
@@ -1897,7 +1897,9 @@ class PostWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['PostWhereInputRecursive1', List['PostWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['PostWhereInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['PostWhereInputRecursive1']
+    ANY: List['PostWhereInputRecursive1']
     NOT: List['PostWhereInputRecursive1']
 
 
@@ -1914,7 +1916,9 @@ class PostWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['PostWhereInputRecursive2', List['PostWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['PostWhereInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['PostWhereInputRecursive2']
+    ANY: List['PostWhereInputRecursive2']
     NOT: List['PostWhereInputRecursive2']
 
 
@@ -1945,7 +1949,9 @@ class PostScalarWhereWithAggregatesInput(TypedDict, total=False):
     author_id: Union[int, 'types.IntWithAggregatesFilter']
 
     AND: List['PostScalarWhereWithAggregatesInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['PostScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['PostScalarWhereWithAggregatesInputRecursive1']
     NOT: List['PostScalarWhereWithAggregatesInputRecursive1']
 
 
@@ -1959,7 +1965,9 @@ class PostScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     author_id: Union[int, 'types.IntWithAggregatesFilter']
 
     AND: List['PostScalarWhereWithAggregatesInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['PostScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['PostScalarWhereWithAggregatesInputRecursive2']
     NOT: List['PostScalarWhereWithAggregatesInputRecursive2']
 
 
@@ -3116,7 +3124,9 @@ class UserWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['UserWhereInputRecursive1', List['UserWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['UserWhereInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['UserWhereInputRecursive1']
+    ANY: List['UserWhereInputRecursive1']
     NOT: List['UserWhereInputRecursive1']
 
 
@@ -3139,7 +3149,9 @@ class UserWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['UserWhereInputRecursive2', List['UserWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['UserWhereInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['UserWhereInputRecursive2']
+    ANY: List['UserWhereInputRecursive2']
     NOT: List['UserWhereInputRecursive2']
 
 
@@ -3182,7 +3194,9 @@ class UserScalarWhereWithAggregatesInput(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['UserScalarWhereWithAggregatesInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['UserScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['UserScalarWhereWithAggregatesInputRecursive1']
     NOT: List['UserScalarWhereWithAggregatesInputRecursive1']
 
 
@@ -3202,7 +3216,9 @@ class UserScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['UserScalarWhereWithAggregatesInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['UserScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['UserScalarWhereWithAggregatesInputRecursive2']
     NOT: List['UserScalarWhereWithAggregatesInputRecursive2']
 
 
@@ -4397,7 +4413,9 @@ class MWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['MWhereInputRecursive1', List['MWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['MWhereInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['MWhereInputRecursive1']
+    ANY: List['MWhereInputRecursive1']
     NOT: List['MWhereInputRecursive1']
 
 
@@ -4419,7 +4437,9 @@ class MWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['MWhereInputRecursive2', List['MWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['MWhereInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['MWhereInputRecursive2']
+    ANY: List['MWhereInputRecursive2']
     NOT: List['MWhereInputRecursive2']
 
 
@@ -4460,7 +4480,9 @@ class MScalarWhereWithAggregatesInput(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['MScalarWhereWithAggregatesInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['MScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['MScalarWhereWithAggregatesInputRecursive1']
     NOT: List['MScalarWhereWithAggregatesInputRecursive1']
 
 
@@ -4479,7 +4501,9 @@ class MScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['MScalarWhereWithAggregatesInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['MScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['MScalarWhereWithAggregatesInputRecursive2']
     NOT: List['MScalarWhereWithAggregatesInputRecursive2']
 
 
@@ -5693,7 +5717,9 @@ class NWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['NWhereInputRecursive1', List['NWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['NWhereInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['NWhereInputRecursive1']
+    ANY: List['NWhereInputRecursive1']
     NOT: List['NWhereInputRecursive1']
 
 
@@ -5717,7 +5743,9 @@ class NWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['NWhereInputRecursive2', List['NWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['NWhereInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['NWhereInputRecursive2']
+    ANY: List['NWhereInputRecursive2']
     NOT: List['NWhereInputRecursive2']
 
 
@@ -5762,7 +5790,9 @@ class NScalarWhereWithAggregatesInput(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['NScalarWhereWithAggregatesInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['NScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['NScalarWhereWithAggregatesInputRecursive1']
     NOT: List['NScalarWhereWithAggregatesInputRecursive1']
 
 
@@ -5783,7 +5813,9 @@ class NScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['NScalarWhereWithAggregatesInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['NScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['NScalarWhereWithAggregatesInputRecursive2']
     NOT: List['NScalarWhereWithAggregatesInputRecursive2']
 
 
@@ -6987,7 +7019,9 @@ class OneOptionalWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['OneOptionalWhereInputRecursive1', List['OneOptionalWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['OneOptionalWhereInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['OneOptionalWhereInputRecursive1']
+    ANY: List['OneOptionalWhereInputRecursive1']
     NOT: List['OneOptionalWhereInputRecursive1']
 
 
@@ -7009,7 +7043,9 @@ class OneOptionalWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['OneOptionalWhereInputRecursive2', List['OneOptionalWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['OneOptionalWhereInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['OneOptionalWhereInputRecursive2']
+    ANY: List['OneOptionalWhereInputRecursive2']
     NOT: List['OneOptionalWhereInputRecursive2']
 
 
@@ -7050,7 +7086,9 @@ class OneOptionalScalarWhereWithAggregatesInput(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['OneOptionalScalarWhereWithAggregatesInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['OneOptionalScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['OneOptionalScalarWhereWithAggregatesInputRecursive1']
     NOT: List['OneOptionalScalarWhereWithAggregatesInputRecursive1']
 
 
@@ -7069,7 +7107,9 @@ class OneOptionalScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['OneOptionalScalarWhereWithAggregatesInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['OneOptionalScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['OneOptionalScalarWhereWithAggregatesInputRecursive2']
     NOT: List['OneOptionalScalarWhereWithAggregatesInputRecursive2']
 
 
@@ -8267,7 +8307,9 @@ class ManyRequiredWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['ManyRequiredWhereInputRecursive1', List['ManyRequiredWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['ManyRequiredWhereInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['ManyRequiredWhereInputRecursive1']
+    ANY: List['ManyRequiredWhereInputRecursive1']
     NOT: List['ManyRequiredWhereInputRecursive1']
 
 
@@ -8290,7 +8332,9 @@ class ManyRequiredWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['ManyRequiredWhereInputRecursive2', List['ManyRequiredWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['ManyRequiredWhereInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['ManyRequiredWhereInputRecursive2']
+    ANY: List['ManyRequiredWhereInputRecursive2']
     NOT: List['ManyRequiredWhereInputRecursive2']
 
 
@@ -8333,7 +8377,9 @@ class ManyRequiredScalarWhereWithAggregatesInput(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['ManyRequiredScalarWhereWithAggregatesInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['ManyRequiredScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['ManyRequiredScalarWhereWithAggregatesInputRecursive1']
     NOT: List['ManyRequiredScalarWhereWithAggregatesInputRecursive1']
 
 
@@ -8353,7 +8399,9 @@ class ManyRequiredScalarWhereWithAggregatesInputRecursive1(TypedDict, total=Fals
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['ManyRequiredScalarWhereWithAggregatesInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['ManyRequiredScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['ManyRequiredScalarWhereWithAggregatesInputRecursive2']
     NOT: List['ManyRequiredScalarWhereWithAggregatesInputRecursive2']
 
 
@@ -9533,7 +9581,9 @@ class ListsWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['ListsWhereInputRecursive1', List['ListsWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['ListsWhereInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['ListsWhereInputRecursive1']
+    ANY: List['ListsWhereInputRecursive1']
     NOT: List['ListsWhereInputRecursive1']
 
 
@@ -9553,7 +9603,9 @@ class ListsWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['ListsWhereInputRecursive2', List['ListsWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['ListsWhereInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['ListsWhereInputRecursive2']
+    ANY: List['ListsWhereInputRecursive2']
     NOT: List['ListsWhereInputRecursive2']
 
 
@@ -9591,7 +9643,9 @@ class ListsScalarWhereWithAggregatesInput(TypedDict, total=False):
     decimals: Union[decimal.Decimal, 'types.DecimalWithAggregatesFilter']
 
     AND: List['ListsScalarWhereWithAggregatesInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['ListsScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['ListsScalarWhereWithAggregatesInputRecursive1']
     NOT: List['ListsScalarWhereWithAggregatesInputRecursive1']
 
 
@@ -9609,7 +9663,9 @@ class ListsScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     decimals: Union[decimal.Decimal, 'types.DecimalWithAggregatesFilter']
 
     AND: List['ListsScalarWhereWithAggregatesInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['ListsScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['ListsScalarWhereWithAggregatesInputRecursive2']
     NOT: List['ListsScalarWhereWithAggregatesInputRecursive2']
 
 
@@ -10766,7 +10822,9 @@ class AWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['AWhereInputRecursive1', List['AWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['AWhereInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['AWhereInputRecursive1']
+    ANY: List['AWhereInputRecursive1']
     NOT: List['AWhereInputRecursive1']
 
 
@@ -10785,7 +10843,9 @@ class AWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['AWhereInputRecursive2', List['AWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['AWhereInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['AWhereInputRecursive2']
+    ANY: List['AWhereInputRecursive2']
     NOT: List['AWhereInputRecursive2']
 
 
@@ -10821,7 +10881,9 @@ class AScalarWhereWithAggregatesInput(TypedDict, total=False):
     enum: 'enums.ABeautifulEnum'
 
     AND: List['AScalarWhereWithAggregatesInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['AScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['AScalarWhereWithAggregatesInputRecursive1']
     NOT: List['AScalarWhereWithAggregatesInputRecursive1']
 
 
@@ -10838,7 +10900,9 @@ class AScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     enum: 'enums.ABeautifulEnum'
 
     AND: List['AScalarWhereWithAggregatesInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['AScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['AScalarWhereWithAggregatesInputRecursive2']
     NOT: List['AScalarWhereWithAggregatesInputRecursive2']
 
 
@@ -11938,7 +12002,9 @@ class BWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['BWhereInputRecursive1', List['BWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['BWhereInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['BWhereInputRecursive1']
+    ANY: List['BWhereInputRecursive1']
     NOT: List['BWhereInputRecursive1']
 
 
@@ -11953,7 +12019,9 @@ class BWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['BWhereInputRecursive2', List['BWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['BWhereInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['BWhereInputRecursive2']
+    ANY: List['BWhereInputRecursive2']
     NOT: List['BWhereInputRecursive2']
 
 
@@ -11981,7 +12049,9 @@ class BScalarWhereWithAggregatesInput(TypedDict, total=False):
     numFloat: Union[decimal.Decimal, 'types.DecimalWithAggregatesFilter']
 
     AND: List['BScalarWhereWithAggregatesInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['BScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['BScalarWhereWithAggregatesInputRecursive1']
     NOT: List['BScalarWhereWithAggregatesInputRecursive1']
 
 
@@ -11994,7 +12064,9 @@ class BScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     numFloat: Union[decimal.Decimal, 'types.DecimalWithAggregatesFilter']
 
     AND: List['BScalarWhereWithAggregatesInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['BScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['BScalarWhereWithAggregatesInputRecursive2']
     NOT: List['BScalarWhereWithAggregatesInputRecursive2']
 
 
@@ -13049,7 +13121,9 @@ class CWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['CWhereInputRecursive1', List['CWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['CWhereInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['CWhereInputRecursive1']
+    ANY: List['CWhereInputRecursive1']
     NOT: List['CWhereInputRecursive1']
 
 
@@ -13065,7 +13139,9 @@ class CWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['CWhereInputRecursive2', List['CWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['CWhereInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['CWhereInputRecursive2']
+    ANY: List['CWhereInputRecursive2']
     NOT: List['CWhereInputRecursive2']
 
 
@@ -13095,7 +13171,9 @@ class CScalarWhereWithAggregatesInput(TypedDict, total=False):
     uuid: Union[str, 'types.StringWithAggregatesFilter']
 
     AND: List['CScalarWhereWithAggregatesInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['CScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['CScalarWhereWithAggregatesInputRecursive1']
     NOT: List['CScalarWhereWithAggregatesInputRecursive1']
 
 
@@ -13109,7 +13187,9 @@ class CScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     uuid: Union[str, 'types.StringWithAggregatesFilter']
 
     AND: List['CScalarWhereWithAggregatesInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['CScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['CScalarWhereWithAggregatesInputRecursive2']
     NOT: List['CScalarWhereWithAggregatesInputRecursive2']
 
 
@@ -14158,7 +14238,9 @@ class DWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['DWhereInputRecursive1', List['DWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['DWhereInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['DWhereInputRecursive1']
+    ANY: List['DWhereInputRecursive1']
     NOT: List['DWhereInputRecursive1']
 
 
@@ -14174,7 +14256,9 @@ class DWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['DWhereInputRecursive2', List['DWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['DWhereInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['DWhereInputRecursive2']
+    ANY: List['DWhereInputRecursive2']
     NOT: List['DWhereInputRecursive2']
 
 
@@ -14204,7 +14288,9 @@ class DScalarWhereWithAggregatesInput(TypedDict, total=False):
     binary: Union['fields.Base64', 'types.BytesWithAggregatesFilter']
 
     AND: List['DScalarWhereWithAggregatesInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['DScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['DScalarWhereWithAggregatesInputRecursive1']
     NOT: List['DScalarWhereWithAggregatesInputRecursive1']
 
 
@@ -14218,7 +14304,9 @@ class DScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     binary: Union['fields.Base64', 'types.BytesWithAggregatesFilter']
 
     AND: List['DScalarWhereWithAggregatesInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['DScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['DScalarWhereWithAggregatesInputRecursive2']
     NOT: List['DScalarWhereWithAggregatesInputRecursive2']
 
 
@@ -15239,7 +15327,9 @@ class EWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['EWhereInputRecursive1', List['EWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['EWhereInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['EWhereInputRecursive1']
+    ANY: List['EWhereInputRecursive1']
     NOT: List['EWhereInputRecursive1']
 
 
@@ -15253,7 +15343,9 @@ class EWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['EWhereInputRecursive2', List['EWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['EWhereInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['EWhereInputRecursive2']
+    ANY: List['EWhereInputRecursive2']
     NOT: List['EWhereInputRecursive2']
 
 
@@ -15279,7 +15371,9 @@ class EScalarWhereWithAggregatesInput(TypedDict, total=False):
     ts: Union[datetime.datetime, 'types.DateTimeWithAggregatesFilter']
 
     AND: List['EScalarWhereWithAggregatesInputRecursive1']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['EScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['EScalarWhereWithAggregatesInputRecursive1']
     NOT: List['EScalarWhereWithAggregatesInputRecursive1']
 
 
@@ -15291,7 +15385,9 @@ class EScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     ts: Union[datetime.datetime, 'types.DateTimeWithAggregatesFilter']
 
     AND: List['EScalarWhereWithAggregatesInputRecursive2']
+    # `OR` is deprecated and will be removed in a future release
     OR: List['EScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['EScalarWhereWithAggregatesInputRecursive2']
     NOT: List['EScalarWhereWithAggregatesInputRecursive2']
 
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[types.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[types.py].raw
@@ -1897,10 +1897,8 @@ class PostWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['PostWhereInputRecursive1', List['PostWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['PostWhereInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['PostWhereInputRecursive1']
-    ANY: List['PostWhereInputRecursive1']
     NOT: List['PostWhereInputRecursive1']
+    ANY: List['PostWhereInputRecursive1']
 
 
 class PostWhereInputRecursive1(TypedDict, total=False):
@@ -1916,10 +1914,8 @@ class PostWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['PostWhereInputRecursive2', List['PostWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['PostWhereInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['PostWhereInputRecursive2']
-    ANY: List['PostWhereInputRecursive2']
     NOT: List['PostWhereInputRecursive2']
+    ANY: List['PostWhereInputRecursive2']
 
 
 class PostWhereInputRecursive2(TypedDict, total=False):
@@ -1949,10 +1945,8 @@ class PostScalarWhereWithAggregatesInput(TypedDict, total=False):
     author_id: Union[int, 'types.IntWithAggregatesFilter']
 
     AND: List['PostScalarWhereWithAggregatesInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['PostScalarWhereWithAggregatesInputRecursive1']
-    ANY: List['PostScalarWhereWithAggregatesInputRecursive1']
     NOT: List['PostScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['PostScalarWhereWithAggregatesInputRecursive1']
 
 
 class PostScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
@@ -1965,10 +1959,8 @@ class PostScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     author_id: Union[int, 'types.IntWithAggregatesFilter']
 
     AND: List['PostScalarWhereWithAggregatesInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['PostScalarWhereWithAggregatesInputRecursive2']
-    ANY: List['PostScalarWhereWithAggregatesInputRecursive2']
     NOT: List['PostScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['PostScalarWhereWithAggregatesInputRecursive2']
 
 
 class PostScalarWhereWithAggregatesInputRecursive2(TypedDict, total=False):
@@ -3124,10 +3116,8 @@ class UserWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['UserWhereInputRecursive1', List['UserWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['UserWhereInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['UserWhereInputRecursive1']
-    ANY: List['UserWhereInputRecursive1']
     NOT: List['UserWhereInputRecursive1']
+    ANY: List['UserWhereInputRecursive1']
 
 
 class UserWhereInputRecursive1(TypedDict, total=False):
@@ -3149,10 +3139,8 @@ class UserWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['UserWhereInputRecursive2', List['UserWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['UserWhereInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['UserWhereInputRecursive2']
-    ANY: List['UserWhereInputRecursive2']
     NOT: List['UserWhereInputRecursive2']
+    ANY: List['UserWhereInputRecursive2']
 
 
 class UserWhereInputRecursive2(TypedDict, total=False):
@@ -3194,10 +3182,8 @@ class UserScalarWhereWithAggregatesInput(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['UserScalarWhereWithAggregatesInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['UserScalarWhereWithAggregatesInputRecursive1']
-    ANY: List['UserScalarWhereWithAggregatesInputRecursive1']
     NOT: List['UserScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['UserScalarWhereWithAggregatesInputRecursive1']
 
 
 class UserScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
@@ -3216,10 +3202,8 @@ class UserScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['UserScalarWhereWithAggregatesInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['UserScalarWhereWithAggregatesInputRecursive2']
-    ANY: List['UserScalarWhereWithAggregatesInputRecursive2']
     NOT: List['UserScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['UserScalarWhereWithAggregatesInputRecursive2']
 
 
 class UserScalarWhereWithAggregatesInputRecursive2(TypedDict, total=False):
@@ -4413,10 +4397,8 @@ class MWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['MWhereInputRecursive1', List['MWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['MWhereInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['MWhereInputRecursive1']
-    ANY: List['MWhereInputRecursive1']
     NOT: List['MWhereInputRecursive1']
+    ANY: List['MWhereInputRecursive1']
 
 
 class MWhereInputRecursive1(TypedDict, total=False):
@@ -4437,10 +4419,8 @@ class MWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['MWhereInputRecursive2', List['MWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['MWhereInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['MWhereInputRecursive2']
-    ANY: List['MWhereInputRecursive2']
     NOT: List['MWhereInputRecursive2']
+    ANY: List['MWhereInputRecursive2']
 
 
 class MWhereInputRecursive2(TypedDict, total=False):
@@ -4480,10 +4460,8 @@ class MScalarWhereWithAggregatesInput(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['MScalarWhereWithAggregatesInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['MScalarWhereWithAggregatesInputRecursive1']
-    ANY: List['MScalarWhereWithAggregatesInputRecursive1']
     NOT: List['MScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['MScalarWhereWithAggregatesInputRecursive1']
 
 
 class MScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
@@ -4501,10 +4479,8 @@ class MScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['MScalarWhereWithAggregatesInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['MScalarWhereWithAggregatesInputRecursive2']
-    ANY: List['MScalarWhereWithAggregatesInputRecursive2']
     NOT: List['MScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['MScalarWhereWithAggregatesInputRecursive2']
 
 
 class MScalarWhereWithAggregatesInputRecursive2(TypedDict, total=False):
@@ -5717,10 +5693,8 @@ class NWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['NWhereInputRecursive1', List['NWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['NWhereInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['NWhereInputRecursive1']
-    ANY: List['NWhereInputRecursive1']
     NOT: List['NWhereInputRecursive1']
+    ANY: List['NWhereInputRecursive1']
 
 
 class NWhereInputRecursive1(TypedDict, total=False):
@@ -5743,10 +5717,8 @@ class NWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['NWhereInputRecursive2', List['NWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['NWhereInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['NWhereInputRecursive2']
-    ANY: List['NWhereInputRecursive2']
     NOT: List['NWhereInputRecursive2']
+    ANY: List['NWhereInputRecursive2']
 
 
 class NWhereInputRecursive2(TypedDict, total=False):
@@ -5790,10 +5762,8 @@ class NScalarWhereWithAggregatesInput(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['NScalarWhereWithAggregatesInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['NScalarWhereWithAggregatesInputRecursive1']
-    ANY: List['NScalarWhereWithAggregatesInputRecursive1']
     NOT: List['NScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['NScalarWhereWithAggregatesInputRecursive1']
 
 
 class NScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
@@ -5813,10 +5783,8 @@ class NScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['NScalarWhereWithAggregatesInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['NScalarWhereWithAggregatesInputRecursive2']
-    ANY: List['NScalarWhereWithAggregatesInputRecursive2']
     NOT: List['NScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['NScalarWhereWithAggregatesInputRecursive2']
 
 
 class NScalarWhereWithAggregatesInputRecursive2(TypedDict, total=False):
@@ -7019,10 +6987,8 @@ class OneOptionalWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['OneOptionalWhereInputRecursive1', List['OneOptionalWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['OneOptionalWhereInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['OneOptionalWhereInputRecursive1']
-    ANY: List['OneOptionalWhereInputRecursive1']
     NOT: List['OneOptionalWhereInputRecursive1']
+    ANY: List['OneOptionalWhereInputRecursive1']
 
 
 class OneOptionalWhereInputRecursive1(TypedDict, total=False):
@@ -7043,10 +7009,8 @@ class OneOptionalWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['OneOptionalWhereInputRecursive2', List['OneOptionalWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['OneOptionalWhereInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['OneOptionalWhereInputRecursive2']
-    ANY: List['OneOptionalWhereInputRecursive2']
     NOT: List['OneOptionalWhereInputRecursive2']
+    ANY: List['OneOptionalWhereInputRecursive2']
 
 
 class OneOptionalWhereInputRecursive2(TypedDict, total=False):
@@ -7086,10 +7050,8 @@ class OneOptionalScalarWhereWithAggregatesInput(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['OneOptionalScalarWhereWithAggregatesInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['OneOptionalScalarWhereWithAggregatesInputRecursive1']
-    ANY: List['OneOptionalScalarWhereWithAggregatesInputRecursive1']
     NOT: List['OneOptionalScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['OneOptionalScalarWhereWithAggregatesInputRecursive1']
 
 
 class OneOptionalScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
@@ -7107,10 +7069,8 @@ class OneOptionalScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['OneOptionalScalarWhereWithAggregatesInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['OneOptionalScalarWhereWithAggregatesInputRecursive2']
-    ANY: List['OneOptionalScalarWhereWithAggregatesInputRecursive2']
     NOT: List['OneOptionalScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['OneOptionalScalarWhereWithAggregatesInputRecursive2']
 
 
 class OneOptionalScalarWhereWithAggregatesInputRecursive2(TypedDict, total=False):
@@ -8307,10 +8267,8 @@ class ManyRequiredWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['ManyRequiredWhereInputRecursive1', List['ManyRequiredWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['ManyRequiredWhereInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['ManyRequiredWhereInputRecursive1']
-    ANY: List['ManyRequiredWhereInputRecursive1']
     NOT: List['ManyRequiredWhereInputRecursive1']
+    ANY: List['ManyRequiredWhereInputRecursive1']
 
 
 class ManyRequiredWhereInputRecursive1(TypedDict, total=False):
@@ -8332,10 +8290,8 @@ class ManyRequiredWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['ManyRequiredWhereInputRecursive2', List['ManyRequiredWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['ManyRequiredWhereInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['ManyRequiredWhereInputRecursive2']
-    ANY: List['ManyRequiredWhereInputRecursive2']
     NOT: List['ManyRequiredWhereInputRecursive2']
+    ANY: List['ManyRequiredWhereInputRecursive2']
 
 
 class ManyRequiredWhereInputRecursive2(TypedDict, total=False):
@@ -8377,10 +8333,8 @@ class ManyRequiredScalarWhereWithAggregatesInput(TypedDict, total=False):
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['ManyRequiredScalarWhereWithAggregatesInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['ManyRequiredScalarWhereWithAggregatesInputRecursive1']
-    ANY: List['ManyRequiredScalarWhereWithAggregatesInputRecursive1']
     NOT: List['ManyRequiredScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['ManyRequiredScalarWhereWithAggregatesInputRecursive1']
 
 
 class ManyRequiredScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
@@ -8399,10 +8353,8 @@ class ManyRequiredScalarWhereWithAggregatesInputRecursive1(TypedDict, total=Fals
     optional_boolean: Union[bool, 'types.BooleanWithAggregatesFilter']
 
     AND: List['ManyRequiredScalarWhereWithAggregatesInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['ManyRequiredScalarWhereWithAggregatesInputRecursive2']
-    ANY: List['ManyRequiredScalarWhereWithAggregatesInputRecursive2']
     NOT: List['ManyRequiredScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['ManyRequiredScalarWhereWithAggregatesInputRecursive2']
 
 
 class ManyRequiredScalarWhereWithAggregatesInputRecursive2(TypedDict, total=False):
@@ -9581,10 +9533,8 @@ class ListsWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['ListsWhereInputRecursive1', List['ListsWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['ListsWhereInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['ListsWhereInputRecursive1']
-    ANY: List['ListsWhereInputRecursive1']
     NOT: List['ListsWhereInputRecursive1']
+    ANY: List['ListsWhereInputRecursive1']
 
 
 class ListsWhereInputRecursive1(TypedDict, total=False):
@@ -9603,10 +9553,8 @@ class ListsWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['ListsWhereInputRecursive2', List['ListsWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['ListsWhereInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['ListsWhereInputRecursive2']
-    ANY: List['ListsWhereInputRecursive2']
     NOT: List['ListsWhereInputRecursive2']
+    ANY: List['ListsWhereInputRecursive2']
 
 
 class ListsWhereInputRecursive2(TypedDict, total=False):
@@ -9643,10 +9591,8 @@ class ListsScalarWhereWithAggregatesInput(TypedDict, total=False):
     decimals: Union[decimal.Decimal, 'types.DecimalWithAggregatesFilter']
 
     AND: List['ListsScalarWhereWithAggregatesInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['ListsScalarWhereWithAggregatesInputRecursive1']
-    ANY: List['ListsScalarWhereWithAggregatesInputRecursive1']
     NOT: List['ListsScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['ListsScalarWhereWithAggregatesInputRecursive1']
 
 
 class ListsScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
@@ -9663,10 +9609,8 @@ class ListsScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     decimals: Union[decimal.Decimal, 'types.DecimalWithAggregatesFilter']
 
     AND: List['ListsScalarWhereWithAggregatesInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['ListsScalarWhereWithAggregatesInputRecursive2']
-    ANY: List['ListsScalarWhereWithAggregatesInputRecursive2']
     NOT: List['ListsScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['ListsScalarWhereWithAggregatesInputRecursive2']
 
 
 class ListsScalarWhereWithAggregatesInputRecursive2(TypedDict, total=False):
@@ -10822,10 +10766,8 @@ class AWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['AWhereInputRecursive1', List['AWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['AWhereInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['AWhereInputRecursive1']
-    ANY: List['AWhereInputRecursive1']
     NOT: List['AWhereInputRecursive1']
+    ANY: List['AWhereInputRecursive1']
 
 
 class AWhereInputRecursive1(TypedDict, total=False):
@@ -10843,10 +10785,8 @@ class AWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['AWhereInputRecursive2', List['AWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['AWhereInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['AWhereInputRecursive2']
-    ANY: List['AWhereInputRecursive2']
     NOT: List['AWhereInputRecursive2']
+    ANY: List['AWhereInputRecursive2']
 
 
 class AWhereInputRecursive2(TypedDict, total=False):
@@ -10881,10 +10821,8 @@ class AScalarWhereWithAggregatesInput(TypedDict, total=False):
     enum: 'enums.ABeautifulEnum'
 
     AND: List['AScalarWhereWithAggregatesInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['AScalarWhereWithAggregatesInputRecursive1']
-    ANY: List['AScalarWhereWithAggregatesInputRecursive1']
     NOT: List['AScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['AScalarWhereWithAggregatesInputRecursive1']
 
 
 class AScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
@@ -10900,10 +10838,8 @@ class AScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     enum: 'enums.ABeautifulEnum'
 
     AND: List['AScalarWhereWithAggregatesInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['AScalarWhereWithAggregatesInputRecursive2']
-    ANY: List['AScalarWhereWithAggregatesInputRecursive2']
     NOT: List['AScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['AScalarWhereWithAggregatesInputRecursive2']
 
 
 class AScalarWhereWithAggregatesInputRecursive2(TypedDict, total=False):
@@ -12002,10 +11938,8 @@ class BWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['BWhereInputRecursive1', List['BWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['BWhereInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['BWhereInputRecursive1']
-    ANY: List['BWhereInputRecursive1']
     NOT: List['BWhereInputRecursive1']
+    ANY: List['BWhereInputRecursive1']
 
 
 class BWhereInputRecursive1(TypedDict, total=False):
@@ -12019,10 +11953,8 @@ class BWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['BWhereInputRecursive2', List['BWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['BWhereInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['BWhereInputRecursive2']
-    ANY: List['BWhereInputRecursive2']
     NOT: List['BWhereInputRecursive2']
+    ANY: List['BWhereInputRecursive2']
 
 
 class BWhereInputRecursive2(TypedDict, total=False):
@@ -12049,10 +11981,8 @@ class BScalarWhereWithAggregatesInput(TypedDict, total=False):
     numFloat: Union[decimal.Decimal, 'types.DecimalWithAggregatesFilter']
 
     AND: List['BScalarWhereWithAggregatesInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['BScalarWhereWithAggregatesInputRecursive1']
-    ANY: List['BScalarWhereWithAggregatesInputRecursive1']
     NOT: List['BScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['BScalarWhereWithAggregatesInputRecursive1']
 
 
 class BScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
@@ -12064,10 +11994,8 @@ class BScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     numFloat: Union[decimal.Decimal, 'types.DecimalWithAggregatesFilter']
 
     AND: List['BScalarWhereWithAggregatesInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['BScalarWhereWithAggregatesInputRecursive2']
-    ANY: List['BScalarWhereWithAggregatesInputRecursive2']
     NOT: List['BScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['BScalarWhereWithAggregatesInputRecursive2']
 
 
 class BScalarWhereWithAggregatesInputRecursive2(TypedDict, total=False):
@@ -13121,10 +13049,8 @@ class CWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['CWhereInputRecursive1', List['CWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['CWhereInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['CWhereInputRecursive1']
-    ANY: List['CWhereInputRecursive1']
     NOT: List['CWhereInputRecursive1']
+    ANY: List['CWhereInputRecursive1']
 
 
 class CWhereInputRecursive1(TypedDict, total=False):
@@ -13139,10 +13065,8 @@ class CWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['CWhereInputRecursive2', List['CWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['CWhereInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['CWhereInputRecursive2']
-    ANY: List['CWhereInputRecursive2']
     NOT: List['CWhereInputRecursive2']
+    ANY: List['CWhereInputRecursive2']
 
 
 class CWhereInputRecursive2(TypedDict, total=False):
@@ -13171,10 +13095,8 @@ class CScalarWhereWithAggregatesInput(TypedDict, total=False):
     uuid: Union[str, 'types.StringWithAggregatesFilter']
 
     AND: List['CScalarWhereWithAggregatesInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['CScalarWhereWithAggregatesInputRecursive1']
-    ANY: List['CScalarWhereWithAggregatesInputRecursive1']
     NOT: List['CScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['CScalarWhereWithAggregatesInputRecursive1']
 
 
 class CScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
@@ -13187,10 +13109,8 @@ class CScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     uuid: Union[str, 'types.StringWithAggregatesFilter']
 
     AND: List['CScalarWhereWithAggregatesInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['CScalarWhereWithAggregatesInputRecursive2']
-    ANY: List['CScalarWhereWithAggregatesInputRecursive2']
     NOT: List['CScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['CScalarWhereWithAggregatesInputRecursive2']
 
 
 class CScalarWhereWithAggregatesInputRecursive2(TypedDict, total=False):
@@ -14238,10 +14158,8 @@ class DWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['DWhereInputRecursive1', List['DWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['DWhereInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['DWhereInputRecursive1']
-    ANY: List['DWhereInputRecursive1']
     NOT: List['DWhereInputRecursive1']
+    ANY: List['DWhereInputRecursive1']
 
 
 class DWhereInputRecursive1(TypedDict, total=False):
@@ -14256,10 +14174,8 @@ class DWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['DWhereInputRecursive2', List['DWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['DWhereInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['DWhereInputRecursive2']
-    ANY: List['DWhereInputRecursive2']
     NOT: List['DWhereInputRecursive2']
+    ANY: List['DWhereInputRecursive2']
 
 
 class DWhereInputRecursive2(TypedDict, total=False):
@@ -14288,10 +14204,8 @@ class DScalarWhereWithAggregatesInput(TypedDict, total=False):
     binary: Union['fields.Base64', 'types.BytesWithAggregatesFilter']
 
     AND: List['DScalarWhereWithAggregatesInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['DScalarWhereWithAggregatesInputRecursive1']
-    ANY: List['DScalarWhereWithAggregatesInputRecursive1']
     NOT: List['DScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['DScalarWhereWithAggregatesInputRecursive1']
 
 
 class DScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
@@ -14304,10 +14218,8 @@ class DScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     binary: Union['fields.Base64', 'types.BytesWithAggregatesFilter']
 
     AND: List['DScalarWhereWithAggregatesInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['DScalarWhereWithAggregatesInputRecursive2']
-    ANY: List['DScalarWhereWithAggregatesInputRecursive2']
     NOT: List['DScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['DScalarWhereWithAggregatesInputRecursive2']
 
 
 class DScalarWhereWithAggregatesInputRecursive2(TypedDict, total=False):
@@ -15327,10 +15239,8 @@ class EWhereInput(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['EWhereInputRecursive1', List['EWhereInputRecursive1']]
     # but this causes mypy to hang :/
     AND: List['EWhereInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['EWhereInputRecursive1']
-    ANY: List['EWhereInputRecursive1']
     NOT: List['EWhereInputRecursive1']
+    ANY: List['EWhereInputRecursive1']
 
 
 class EWhereInputRecursive1(TypedDict, total=False):
@@ -15343,10 +15253,8 @@ class EWhereInputRecursive1(TypedDict, total=False):
     # should be noted that AND and NOT should be Union['EWhereInputRecursive2', List['EWhereInputRecursive2']]
     # but this causes mypy to hang :/
     AND: List['EWhereInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['EWhereInputRecursive2']
-    ANY: List['EWhereInputRecursive2']
     NOT: List['EWhereInputRecursive2']
+    ANY: List['EWhereInputRecursive2']
 
 
 class EWhereInputRecursive2(TypedDict, total=False):
@@ -15371,10 +15279,8 @@ class EScalarWhereWithAggregatesInput(TypedDict, total=False):
     ts: Union[datetime.datetime, 'types.DateTimeWithAggregatesFilter']
 
     AND: List['EScalarWhereWithAggregatesInputRecursive1']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['EScalarWhereWithAggregatesInputRecursive1']
-    ANY: List['EScalarWhereWithAggregatesInputRecursive1']
     NOT: List['EScalarWhereWithAggregatesInputRecursive1']
+    ANY: List['EScalarWhereWithAggregatesInputRecursive1']
 
 
 class EScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
@@ -15385,10 +15291,8 @@ class EScalarWhereWithAggregatesInputRecursive1(TypedDict, total=False):
     ts: Union[datetime.datetime, 'types.DateTimeWithAggregatesFilter']
 
     AND: List['EScalarWhereWithAggregatesInputRecursive2']
-    # `OR` is deprecated and will be removed in a future release
-    OR: List['EScalarWhereWithAggregatesInputRecursive2']
-    ANY: List['EScalarWhereWithAggregatesInputRecursive2']
     NOT: List['EScalarWhereWithAggregatesInputRecursive2']
+    ANY: List['EScalarWhereWithAggregatesInputRecursive2']
 
 
 class EScalarWhereWithAggregatesInputRecursive2(TypedDict, total=False):

--- a/tests/test_group_by.py
+++ b/tests/test_group_by.py
@@ -1,3 +1,4 @@
+from typing import Literal
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -287,7 +288,7 @@ async def test_having_aggregation_nested(
         by=['country'],
         count=True,
         having={
-            'OR': [
+            'ANY': [
                 {
                     'views': {
                         '_avg': {
@@ -311,7 +312,7 @@ async def test_having_aggregation_nested(
         by=['country'],
         count=True,
         having={
-            'OR': [
+            'ANY': [
                 {
                     'views': {
                         '_avg': {
@@ -335,7 +336,7 @@ async def test_having_aggregation_nested(
         by=['country'],
         count=True,
         having={
-            'OR': [
+            'ANY': [
                 {
                     'views': {
                         '_avg': {

--- a/tests/test_group_by.py
+++ b/tests/test_group_by.py
@@ -1,4 +1,3 @@
-from typing import Literal
 import pytest
 from syrupy.assertion import SnapshotAssertion
 

--- a/tests/test_include.py
+++ b/tests/test_include.py
@@ -164,7 +164,7 @@ async def test_find_unique_include_nested_where_or(
         where={'id': user_id},
         include={
             'posts': {
-                'where': {'OR': [{'published': True}, {'id': posts[0].id}]}
+                'where': {'ANY': [{'published': True}, {'id': posts[0].id}]}
             }
         },
     )


### PR DESCRIPTION
## Change Summary

In case the outcome of  https://github.com/RobertCraigie/prisma-client-py/issues/293 is to officially support `ANY` queries, this PR attempts attempts to add support for it. 

Unfortunately I was unable to support both `OR` and `ANY`, due to `mypy` issues. I was unable to resolve them, so have opted to just replace `OR` with `ANY`. This is certainly not ideal, but this is where it stands for now.

The `mypy` error encountered was:
```
ERROR: InvocationError for command /tmp/tox/prisma-client-py/mypy/bin/coverage run -m mypy --show-traceback --namespace-packages 
```

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass without significant drop in coverage
- [x] Documentation reflects changes where applicable
- [x] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
