### PR TITLE
feat(tests): add support for unregistering a client

### DIFF
--- a/src/prisma/testing.py
+++ b/src/prisma/testing.py
@@ -23,3 +23,11 @@ def reset_client(
         yield
     finally:
         _client._registered_client = client
+
+
+def unregister_client() -> None:
+    """Unregister the current client."""
+    if _client._registered_client is None:
+        raise ClientNotRegisteredError()
+
+    _client._registered_client = None

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -43,3 +43,6 @@ def test_unregister_client() -> None:
 
     with pytest.raises(prisma.errors.ClientNotRegisteredError):
         unregister_client()
+
+    # test cleanup
+    register(original)

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,7 +1,7 @@
 import pytest
 import prisma
 from prisma import Prisma, register, get_client
-from prisma.testing import reset_client
+from prisma.testing import reset_client, unregister_client
 
 
 @pytest.mark.prisma
@@ -29,3 +29,17 @@ def test_reset_client() -> None:
         assert get_client() == client
 
     assert get_client() == original
+
+
+@pytest.mark.prisma
+def test_unregister_client() -> None:
+    """Unregistering the client works as expected"""
+    original = get_client()
+    assert isinstance(original, Prisma)
+    unregister_client()
+
+    with pytest.raises(prisma.errors.ClientNotRegisteredError):
+        get_client()
+
+    with pytest.raises(prisma.errors.ClientNotRegisteredError):
+        unregister_client()


### PR DESCRIPTION
## Change Summary

As suggested in https://github.com/RobertCraigie/prisma-client-py/issues/243, this adds a `unregister_client` function that unregisters/deregisters the prisma client.

Closes https://github.com/RobertCraigie/prisma-client-py/issues/243

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass without significant drop in coverage
- [x] Documentation reflects changes where applicable
- [x] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
