### PR TITLE
fix: use arm64 prisma binaries on arm64 machines

### DIFF
--- a/src/prisma/binaries/platform.py
+++ b/src/prisma/binaries/platform.py
@@ -1,13 +1,22 @@
-import re
-import sys
-import subprocess
 import platform as _platform
+import re
+import subprocess
+import sys
 from functools import lru_cache
 from typing import Tuple
 
 
 def name() -> str:
-    return _platform.system().lower()
+    system = _platform.system().lower()
+    machine = _platform.machine()
+
+    if machine in ("arm64", "aarch64"):
+        return f"{system}-arm64"
+
+    if machine != "x86_64":
+        raise RuntimeError(f"don't know how to fetch binaries for {machine}")
+
+    return system
 
 
 def check_for_extension(file: str) -> str:
@@ -50,7 +59,7 @@ def _get_linux_distro_details() -> Tuple[str, str]:
 @lru_cache(maxsize=None)
 def binary_platform() -> str:
     platform = name()
-    if platform != 'linux':
+    if platform not in ('linux', 'linux-arm64'):
         return platform
 
     distro = linux_distro()
@@ -58,6 +67,9 @@ def binary_platform() -> str:
         return 'linux-musl'
 
     ssl = get_openssl()
+    if platform == "linux-arm64":
+        return f'{platform}-openssl-{ssl}'
+
     return f'{distro}-openssl-{ssl}'
 
 


### PR DESCRIPTION
Fetch arm64 binaries when running on an arm64 machine.

This allows prisma-client-py to work on Linux and macOS machines with arm64 CPUs (it actually already worked on macOS because of Rosetta but this lets it use native binaries.)

Throw a RuntimeError if the machine is not arm64 or x86_64 to avoid downloading binaries with the wrong architecture.

Still WIP because Alpine seems broken, but I'm not 100% sure that Alpine was working to begin with; I'll poke at it more tomorrow.

## Change Summary

Please summarise the changes this pull request is making here.

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
