### PR TITLE
fix(client): override the default SQLite relative file path

### DIFF
--- a/src/prisma/generator/models.py
+++ b/src/prisma/generator/models.py
@@ -304,7 +304,7 @@ class GenericData(GenericModel, Generic[ConfigT]):
     version: str
     generator: 'Generator[ConfigT]'
     dmmf: 'DMMF' = FieldInfo(alias='dmmf')
-    schema_path: str = FieldInfo(alias='schemaPath')
+    schema_path: Path = FieldInfo(alias='schemaPath')
     datasources: List['Datasource'] = FieldInfo(alias='datasources')
     other_generators: List['Generator[_ModelAllowAll]'] = FieldInfo(
         alias='otherGenerators'
@@ -394,6 +394,19 @@ class ValueFromEnvVar(BaseModel):
 class OptionalValueFromEnvVar(BaseModel):
     value: Optional[str]
     from_env_var: Optional[str] = FieldInfo(alias='fromEnvVar')
+
+    def resolve(self) -> str:
+        value = self.value
+        if value is not None:
+            return value
+
+        env_var = self.from_env_var
+        assert env_var is not None, 'from_env_var should not be None'
+        value = os.environ.get(env_var)
+        if value is None:
+            raise RuntimeError(f'Environment variable not found: {env_var}')
+
+        return value
 
 
 class Config(BaseSettings):

--- a/src/prisma/generator/templates/client.py.jinja
+++ b/src/prisma/generator/templates/client.py.jinja
@@ -1,6 +1,7 @@
 {% include '_header.py.jinja' %}
 {% from '_utils.py.jinja' import is_async, maybe_async_def, maybe_await, methods, operations, recursive_types, active_provider with context %}
 # -- template client.py.jinja --
+from pathlib import Path
 from types import TracebackType
 
 from . import types, models, errors, actions
@@ -8,11 +9,12 @@ from .types import DatasourceOverride, HttpConfig
 from ._types import BaseModelT
 from .engine import AbstractEngine, QueryEngine
 from .builder import QueryBuilder
-from .generator.models import EngineType
+from .generator.models import EngineType, OptionalValueFromEnvVar
 
 
 __all__ = (
     'ENGINE_TYPE',
+    'SCHEMA_PATH',
     'Batch',
     'Prisma',
     'Client',
@@ -24,6 +26,7 @@ __all__ = (
 SCHEMA = '''
 {{ datamodel }}
 '''
+SCHEMA_PATH = Path('{{ schema_path }}')
 
 ENGINE_TYPE: EngineType = EngineType.{{ generator.config.engine_type }}
 
@@ -216,6 +219,12 @@ class Prisma:
             ds = self._datasource.copy()
             ds.setdefault('name', '{{ datasources[0].name }}')
             datasources = [ds]
+        {% if active_provider == 'sqlite' %}
+        else:
+            # Override the default SQLite path to protect against
+            # https://github.com/RobertCraigie/prisma-client-py/issues/409
+            datasources = [self._make_sqlite_datasource()]
+        {% endif %}
 
         {{ maybe_await }}self.__engine.connect(
             timeout=timeout,
@@ -332,6 +341,29 @@ class Prisma:
         if engine is None:
             raise errors.ClientNotConnectedError()
         return engine
+
+    def _make_sqlite_datasource(self) -> DatasourceOverride:
+        return {
+            'name': '{{ datasources[0].name }}',
+            'url': self._make_sqlite_url(self._default_datasource['url']),
+        }
+
+    def _make_sqlite_url(self, url: str, *, relative_to: Path = SCHEMA_PATH.parent) -> str:
+        url_path = url.lstrip('file:').lstrip('sqlite:')
+        if url_path == url:
+            return url
+
+        if Path(url_path).is_absolute():
+            return url
+
+        return f'file:{relative_to.joinpath(url_path).resolve()}'
+
+    @property
+    def _default_datasource(self) -> DatasourceOverride:
+        return {
+            'name': '{{ datasources[0].name }}',
+            'url': OptionalValueFromEnvVar(**{{ datasources[0].url.dict(by_alias=True) }}).resolve(),
+        }
 
 
 # TODO: this should return the results as well

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
@@ -31,6 +31,7 @@ from typing_extensions import TypedDict, Literal
 
 LiteralString = str
 # -- template client.py.jinja --
+from pathlib import Path
 from types import TracebackType
 
 from . import types, models, errors, actions
@@ -38,11 +39,12 @@ from .types import DatasourceOverride, HttpConfig
 from ._types import BaseModelT
 from .engine import AbstractEngine, QueryEngine
 from .builder import QueryBuilder
-from .generator.models import EngineType
+from .generator.models import EngineType, OptionalValueFromEnvVar
 
 
 __all__ = (
     'ENGINE_TYPE',
+    'SCHEMA_PATH',
     'Batch',
     'Prisma',
     'Client',
@@ -237,6 +239,7 @@ model E {
 }
 
 '''
+SCHEMA_PATH = Path('<absolute-schema-path>')
 
 ENGINE_TYPE: EngineType = EngineType.binary
 
@@ -543,6 +546,29 @@ class Prisma:
         if engine is None:
             raise errors.ClientNotConnectedError()
         return engine
+
+    def _make_sqlite_datasource(self) -> DatasourceOverride:
+        return {
+            'name': 'db',
+            'url': self._make_sqlite_url(self._default_datasource['url']),
+        }
+
+    def _make_sqlite_url(self, url: str, *, relative_to: Path = SCHEMA_PATH.parent) -> str:
+        url_path = url.lstrip('file:').lstrip('sqlite:')
+        if url_path == url:
+            return url
+
+        if Path(url_path).is_absolute():
+            return url
+
+        return f'file:{relative_to.joinpath(url_path).resolve()}'
+
+    @property
+    def _default_datasource(self) -> DatasourceOverride:
+        return {
+            'name': 'db',
+            'url': OptionalValueFromEnvVar(**{'value': None, 'fromEnvVar': 'DB_URL'}).resolve(),
+        }
 
 
 # TODO: this should return the results as well

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
@@ -31,6 +31,7 @@ from typing_extensions import TypedDict, Literal
 
 LiteralString = str
 # -- template client.py.jinja --
+from pathlib import Path
 from types import TracebackType
 
 from . import types, models, errors, actions
@@ -38,11 +39,12 @@ from .types import DatasourceOverride, HttpConfig
 from ._types import BaseModelT
 from .engine import AbstractEngine, QueryEngine
 from .builder import QueryBuilder
-from .generator.models import EngineType
+from .generator.models import EngineType, OptionalValueFromEnvVar
 
 
 __all__ = (
     'ENGINE_TYPE',
+    'SCHEMA_PATH',
     'Batch',
     'Prisma',
     'Client',
@@ -237,6 +239,7 @@ model E {
 }
 
 '''
+SCHEMA_PATH = Path('<absolute-schema-path>')
 
 ENGINE_TYPE: EngineType = EngineType.binary
 
@@ -542,6 +545,29 @@ class Prisma:
         if engine is None:
             raise errors.ClientNotConnectedError()
         return engine
+
+    def _make_sqlite_datasource(self) -> DatasourceOverride:
+        return {
+            'name': 'db',
+            'url': self._make_sqlite_url(self._default_datasource['url']),
+        }
+
+    def _make_sqlite_url(self, url: str, *, relative_to: Path = SCHEMA_PATH.parent) -> str:
+        url_path = url.lstrip('file:').lstrip('sqlite:')
+        if url_path == url:
+            return url
+
+        if Path(url_path).is_absolute():
+            return url
+
+        return f'file:{relative_to.joinpath(url_path).resolve()}'
+
+    @property
+    def _default_datasource(self) -> DatasourceOverride:
+        return {
+            'name': 'db',
+            'url': OptionalValueFromEnvVar(**{'value': None, 'fromEnvVar': 'DB_URL'}).resolve(),
+        }
 
 
 # TODO: this should return the results as well

--- a/tests/test_generation/exhaustive/test_exhaustive.py
+++ b/tests/test_generation/exhaustive/test_exhaustive.py
@@ -87,7 +87,7 @@ def schema_path_matcher(
 def test_sync(snapshot: SnapshotAssertion, file: str) -> None:
     """Ensure synchronous client files match"""
     assert SYNC_ROOTDIR.joinpath(file).absolute().read_text() == snapshot(
-        matcher=schema_path_matcher(THIS_DIR / 'sync.schema.prisma')
+        matcher=schema_path_matcher(THIS_DIR / 'sync.schema.prisma')  # type: ignore
     )
 
 
@@ -95,7 +95,7 @@ def test_sync(snapshot: SnapshotAssertion, file: str) -> None:
 def test_async(snapshot: SnapshotAssertion, file: str) -> None:
     """Ensure asynchronous client files match"""
     assert ASYNC_ROOTDIR.joinpath(file).absolute().read_text() == snapshot(
-        matcher=schema_path_matcher(THIS_DIR / 'async.schema.prisma')
+        matcher=schema_path_matcher(THIS_DIR / 'async.schema.prisma')  # type: ignore
     )
 
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,7 +1,6 @@
 import pytest
 from _pytest.capture import CaptureFixture
 
-import prisma
 from prisma import Prisma
 from prisma.models import User
 
@@ -36,9 +35,8 @@ async def test_logs_sql_queries(testdir: Testdir) -> None:
     with testdir.redirect_stdout_to_file() as file:
         await client.connect()
 
-        # implementation detail of this test
-        with pytest.raises(prisma.errors.TableNotFoundError):
-            await client.user.find_unique(where={'id': 'jsdhsjd'})
+        user = await client.user.find_unique(where={'id': 'jsdhsjd'})
+        assert user is None
 
         await client.disconnect()
 


### PR DESCRIPTION
## Change Summary

closes #400 
closes #409

This PR overrides the default SQLite URL to use a path relative to the Prisma Schema file instead of the working directory. This is a breaking change but is required in order to maintain consistency between the CLI and the Client.

This PR also exports a new constant, `SCHEMA_PATH` which points to the location of the schema file used to generate the client.

```py
from prisma import SCHEMA_PATH

print(SCHEMA_PATH)  # Path('/absolute/path/prisma/schema.prisma')
```

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [x] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
