### PR TITLE
fix(partials): support combining exclude and exclude_relational_fields

### DIFF
--- a/src/prisma/generator/templates/models.py.jinja
+++ b/src/prisma/generator/templates/models.py.jinja
@@ -126,8 +126,11 @@ class {{ model.name }}(BaseModel):
         if name in _created_partial_types:
             raise ValueError(f'Partial type "{name}" has already been created.')
 
-        if include is not None and exclude is not None:
-            raise TypeError(f'Exclude and include are mutually exclusive.')
+        if include is not None:
+            if exclude is not None:
+                raise TypeError('Exclude and include are mutually exclusive.')
+            if exclude_relational_fields is True:
+                raise TypeError('Include and exclude_relational_fields=True are mutually exclusive.')
 
         if required and optional:
             shared = set(required) & set(optional)
@@ -172,7 +175,7 @@ class {{ model.name }}(BaseModel):
             if exclude_relational_fields:
                 fields = {
                     key: data
-                    for key, data in _{{ model.name }}_fields.items()
+                    for key, data in fields.items()
                     if key not in _{{ model.name }}_relational_fields
                 }
             {% endif %}

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[models.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[models.py].raw
@@ -150,8 +150,11 @@ class Post(BaseModel):
         if name in _created_partial_types:
             raise ValueError(f'Partial type "{name}" has already been created.')
 
-        if include is not None and exclude is not None:
-            raise TypeError(f'Exclude and include are mutually exclusive.')
+        if include is not None:
+            if exclude is not None:
+                raise TypeError('Exclude and include are mutually exclusive.')
+            if exclude_relational_fields is True:
+                raise TypeError('Include and exclude_relational_fields=True are mutually exclusive.')
 
         if required and optional:
             shared = set(required) & set(optional)
@@ -195,7 +198,7 @@ class Post(BaseModel):
             if exclude_relational_fields:
                 fields = {
                     key: data
-                    for key, data in _Post_fields.items()
+                    for key, data in fields.items()
                     if key not in _Post_relational_fields
                 }
 
@@ -290,8 +293,11 @@ class User(BaseModel):
         if name in _created_partial_types:
             raise ValueError(f'Partial type "{name}" has already been created.')
 
-        if include is not None and exclude is not None:
-            raise TypeError(f'Exclude and include are mutually exclusive.')
+        if include is not None:
+            if exclude is not None:
+                raise TypeError('Exclude and include are mutually exclusive.')
+            if exclude_relational_fields is True:
+                raise TypeError('Include and exclude_relational_fields=True are mutually exclusive.')
 
         if required and optional:
             shared = set(required) & set(optional)
@@ -335,7 +341,7 @@ class User(BaseModel):
             if exclude_relational_fields:
                 fields = {
                     key: data
-                    for key, data in _User_fields.items()
+                    for key, data in fields.items()
                     if key not in _User_relational_fields
                 }
 
@@ -426,8 +432,11 @@ class M(BaseModel):
         if name in _created_partial_types:
             raise ValueError(f'Partial type "{name}" has already been created.')
 
-        if include is not None and exclude is not None:
-            raise TypeError(f'Exclude and include are mutually exclusive.')
+        if include is not None:
+            if exclude is not None:
+                raise TypeError('Exclude and include are mutually exclusive.')
+            if exclude_relational_fields is True:
+                raise TypeError('Include and exclude_relational_fields=True are mutually exclusive.')
 
         if required and optional:
             shared = set(required) & set(optional)
@@ -471,7 +480,7 @@ class M(BaseModel):
             if exclude_relational_fields:
                 fields = {
                     key: data
-                    for key, data in _M_fields.items()
+                    for key, data in fields.items()
                     if key not in _M_relational_fields
                 }
 
@@ -564,8 +573,11 @@ class N(BaseModel):
         if name in _created_partial_types:
             raise ValueError(f'Partial type "{name}" has already been created.')
 
-        if include is not None and exclude is not None:
-            raise TypeError(f'Exclude and include are mutually exclusive.')
+        if include is not None:
+            if exclude is not None:
+                raise TypeError('Exclude and include are mutually exclusive.')
+            if exclude_relational_fields is True:
+                raise TypeError('Include and exclude_relational_fields=True are mutually exclusive.')
 
         if required and optional:
             shared = set(required) & set(optional)
@@ -609,7 +621,7 @@ class N(BaseModel):
             if exclude_relational_fields:
                 fields = {
                     key: data
-                    for key, data in _N_fields.items()
+                    for key, data in fields.items()
                     if key not in _N_relational_fields
                 }
 
@@ -700,8 +712,11 @@ class OneOptional(BaseModel):
         if name in _created_partial_types:
             raise ValueError(f'Partial type "{name}" has already been created.')
 
-        if include is not None and exclude is not None:
-            raise TypeError(f'Exclude and include are mutually exclusive.')
+        if include is not None:
+            if exclude is not None:
+                raise TypeError('Exclude and include are mutually exclusive.')
+            if exclude_relational_fields is True:
+                raise TypeError('Include and exclude_relational_fields=True are mutually exclusive.')
 
         if required and optional:
             shared = set(required) & set(optional)
@@ -745,7 +760,7 @@ class OneOptional(BaseModel):
             if exclude_relational_fields:
                 fields = {
                     key: data
-                    for key, data in _OneOptional_fields.items()
+                    for key, data in fields.items()
                     if key not in _OneOptional_relational_fields
                 }
 
@@ -837,8 +852,11 @@ class ManyRequired(BaseModel):
         if name in _created_partial_types:
             raise ValueError(f'Partial type "{name}" has already been created.')
 
-        if include is not None and exclude is not None:
-            raise TypeError(f'Exclude and include are mutually exclusive.')
+        if include is not None:
+            if exclude is not None:
+                raise TypeError('Exclude and include are mutually exclusive.')
+            if exclude_relational_fields is True:
+                raise TypeError('Include and exclude_relational_fields=True are mutually exclusive.')
 
         if required and optional:
             shared = set(required) & set(optional)
@@ -882,7 +900,7 @@ class ManyRequired(BaseModel):
             if exclude_relational_fields:
                 fields = {
                     key: data
-                    for key, data in _ManyRequired_fields.items()
+                    for key, data in fields.items()
                     if key not in _ManyRequired_relational_fields
                 }
 
@@ -971,8 +989,11 @@ class Lists(BaseModel):
         if name in _created_partial_types:
             raise ValueError(f'Partial type "{name}" has already been created.')
 
-        if include is not None and exclude is not None:
-            raise TypeError(f'Exclude and include are mutually exclusive.')
+        if include is not None:
+            if exclude is not None:
+                raise TypeError('Exclude and include are mutually exclusive.')
+            if exclude_relational_fields is True:
+                raise TypeError('Include and exclude_relational_fields=True are mutually exclusive.')
 
         if required and optional:
             shared = set(required) & set(optional)
@@ -1084,8 +1105,11 @@ class A(BaseModel):
         if name in _created_partial_types:
             raise ValueError(f'Partial type "{name}" has already been created.')
 
-        if include is not None and exclude is not None:
-            raise TypeError(f'Exclude and include are mutually exclusive.')
+        if include is not None:
+            if exclude is not None:
+                raise TypeError('Exclude and include are mutually exclusive.')
+            if exclude_relational_fields is True:
+                raise TypeError('Include and exclude_relational_fields=True are mutually exclusive.')
 
         if required and optional:
             shared = set(required) & set(optional)
@@ -1189,8 +1213,11 @@ class B(BaseModel):
         if name in _created_partial_types:
             raise ValueError(f'Partial type "{name}" has already been created.')
 
-        if include is not None and exclude is not None:
-            raise TypeError(f'Exclude and include are mutually exclusive.')
+        if include is not None:
+            if exclude is not None:
+                raise TypeError('Exclude and include are mutually exclusive.')
+            if exclude_relational_fields is True:
+                raise TypeError('Include and exclude_relational_fields=True are mutually exclusive.')
 
         if required and optional:
             shared = set(required) & set(optional)
@@ -1295,8 +1322,11 @@ class C(BaseModel):
         if name in _created_partial_types:
             raise ValueError(f'Partial type "{name}" has already been created.')
 
-        if include is not None and exclude is not None:
-            raise TypeError(f'Exclude and include are mutually exclusive.')
+        if include is not None:
+            if exclude is not None:
+                raise TypeError('Exclude and include are mutually exclusive.')
+            if exclude_relational_fields is True:
+                raise TypeError('Include and exclude_relational_fields=True are mutually exclusive.')
 
         if required and optional:
             shared = set(required) & set(optional)
@@ -1401,8 +1431,11 @@ class D(BaseModel):
         if name in _created_partial_types:
             raise ValueError(f'Partial type "{name}" has already been created.')
 
-        if include is not None and exclude is not None:
-            raise TypeError(f'Exclude and include are mutually exclusive.')
+        if include is not None:
+            if exclude is not None:
+                raise TypeError('Exclude and include are mutually exclusive.')
+            if exclude_relational_fields is True:
+                raise TypeError('Include and exclude_relational_fields=True are mutually exclusive.')
 
         if required and optional:
             shared = set(required) & set(optional)
@@ -1509,8 +1542,11 @@ class E(BaseModel):
         if name in _created_partial_types:
             raise ValueError(f'Partial type "{name}" has already been created.')
 
-        if include is not None and exclude is not None:
-            raise TypeError(f'Exclude and include are mutually exclusive.')
+        if include is not None:
+            if exclude is not None:
+                raise TypeError('Exclude and include are mutually exclusive.')
+            if exclude_relational_fields is True:
+                raise TypeError('Include and exclude_relational_fields=True are mutually exclusive.')
 
         if required and optional:
             shared = set(required) & set(optional)

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[models.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[models.py].raw
@@ -150,8 +150,11 @@ class Post(BaseModel):
         if name in _created_partial_types:
             raise ValueError(f'Partial type "{name}" has already been created.')
 
-        if include is not None and exclude is not None:
-            raise TypeError(f'Exclude and include are mutually exclusive.')
+        if include is not None:
+            if exclude is not None:
+                raise TypeError('Exclude and include are mutually exclusive.')
+            if exclude_relational_fields is True:
+                raise TypeError('Include and exclude_relational_fields=True are mutually exclusive.')
 
         if required and optional:
             shared = set(required) & set(optional)
@@ -195,7 +198,7 @@ class Post(BaseModel):
             if exclude_relational_fields:
                 fields = {
                     key: data
-                    for key, data in _Post_fields.items()
+                    for key, data in fields.items()
                     if key not in _Post_relational_fields
                 }
 
@@ -290,8 +293,11 @@ class User(BaseModel):
         if name in _created_partial_types:
             raise ValueError(f'Partial type "{name}" has already been created.')
 
-        if include is not None and exclude is not None:
-            raise TypeError(f'Exclude and include are mutually exclusive.')
+        if include is not None:
+            if exclude is not None:
+                raise TypeError('Exclude and include are mutually exclusive.')
+            if exclude_relational_fields is True:
+                raise TypeError('Include and exclude_relational_fields=True are mutually exclusive.')
 
         if required and optional:
             shared = set(required) & set(optional)
@@ -335,7 +341,7 @@ class User(BaseModel):
             if exclude_relational_fields:
                 fields = {
                     key: data
-                    for key, data in _User_fields.items()
+                    for key, data in fields.items()
                     if key not in _User_relational_fields
                 }
 
@@ -426,8 +432,11 @@ class M(BaseModel):
         if name in _created_partial_types:
             raise ValueError(f'Partial type "{name}" has already been created.')
 
-        if include is not None and exclude is not None:
-            raise TypeError(f'Exclude and include are mutually exclusive.')
+        if include is not None:
+            if exclude is not None:
+                raise TypeError('Exclude and include are mutually exclusive.')
+            if exclude_relational_fields is True:
+                raise TypeError('Include and exclude_relational_fields=True are mutually exclusive.')
 
         if required and optional:
             shared = set(required) & set(optional)
@@ -471,7 +480,7 @@ class M(BaseModel):
             if exclude_relational_fields:
                 fields = {
                     key: data
-                    for key, data in _M_fields.items()
+                    for key, data in fields.items()
                     if key not in _M_relational_fields
                 }
 
@@ -564,8 +573,11 @@ class N(BaseModel):
         if name in _created_partial_types:
             raise ValueError(f'Partial type "{name}" has already been created.')
 
-        if include is not None and exclude is not None:
-            raise TypeError(f'Exclude and include are mutually exclusive.')
+        if include is not None:
+            if exclude is not None:
+                raise TypeError('Exclude and include are mutually exclusive.')
+            if exclude_relational_fields is True:
+                raise TypeError('Include and exclude_relational_fields=True are mutually exclusive.')
 
         if required and optional:
             shared = set(required) & set(optional)
@@ -609,7 +621,7 @@ class N(BaseModel):
             if exclude_relational_fields:
                 fields = {
                     key: data
-                    for key, data in _N_fields.items()
+                    for key, data in fields.items()
                     if key not in _N_relational_fields
                 }
 
@@ -700,8 +712,11 @@ class OneOptional(BaseModel):
         if name in _created_partial_types:
             raise ValueError(f'Partial type "{name}" has already been created.')
 
-        if include is not None and exclude is not None:
-            raise TypeError(f'Exclude and include are mutually exclusive.')
+        if include is not None:
+            if exclude is not None:
+                raise TypeError('Exclude and include are mutually exclusive.')
+            if exclude_relational_fields is True:
+                raise TypeError('Include and exclude_relational_fields=True are mutually exclusive.')
 
         if required and optional:
             shared = set(required) & set(optional)
@@ -745,7 +760,7 @@ class OneOptional(BaseModel):
             if exclude_relational_fields:
                 fields = {
                     key: data
-                    for key, data in _OneOptional_fields.items()
+                    for key, data in fields.items()
                     if key not in _OneOptional_relational_fields
                 }
 
@@ -837,8 +852,11 @@ class ManyRequired(BaseModel):
         if name in _created_partial_types:
             raise ValueError(f'Partial type "{name}" has already been created.')
 
-        if include is not None and exclude is not None:
-            raise TypeError(f'Exclude and include are mutually exclusive.')
+        if include is not None:
+            if exclude is not None:
+                raise TypeError('Exclude and include are mutually exclusive.')
+            if exclude_relational_fields is True:
+                raise TypeError('Include and exclude_relational_fields=True are mutually exclusive.')
 
         if required and optional:
             shared = set(required) & set(optional)
@@ -882,7 +900,7 @@ class ManyRequired(BaseModel):
             if exclude_relational_fields:
                 fields = {
                     key: data
-                    for key, data in _ManyRequired_fields.items()
+                    for key, data in fields.items()
                     if key not in _ManyRequired_relational_fields
                 }
 
@@ -971,8 +989,11 @@ class Lists(BaseModel):
         if name in _created_partial_types:
             raise ValueError(f'Partial type "{name}" has already been created.')
 
-        if include is not None and exclude is not None:
-            raise TypeError(f'Exclude and include are mutually exclusive.')
+        if include is not None:
+            if exclude is not None:
+                raise TypeError('Exclude and include are mutually exclusive.')
+            if exclude_relational_fields is True:
+                raise TypeError('Include and exclude_relational_fields=True are mutually exclusive.')
 
         if required and optional:
             shared = set(required) & set(optional)
@@ -1084,8 +1105,11 @@ class A(BaseModel):
         if name in _created_partial_types:
             raise ValueError(f'Partial type "{name}" has already been created.')
 
-        if include is not None and exclude is not None:
-            raise TypeError(f'Exclude and include are mutually exclusive.')
+        if include is not None:
+            if exclude is not None:
+                raise TypeError('Exclude and include are mutually exclusive.')
+            if exclude_relational_fields is True:
+                raise TypeError('Include and exclude_relational_fields=True are mutually exclusive.')
 
         if required and optional:
             shared = set(required) & set(optional)
@@ -1189,8 +1213,11 @@ class B(BaseModel):
         if name in _created_partial_types:
             raise ValueError(f'Partial type "{name}" has already been created.')
 
-        if include is not None and exclude is not None:
-            raise TypeError(f'Exclude and include are mutually exclusive.')
+        if include is not None:
+            if exclude is not None:
+                raise TypeError('Exclude and include are mutually exclusive.')
+            if exclude_relational_fields is True:
+                raise TypeError('Include and exclude_relational_fields=True are mutually exclusive.')
 
         if required and optional:
             shared = set(required) & set(optional)
@@ -1295,8 +1322,11 @@ class C(BaseModel):
         if name in _created_partial_types:
             raise ValueError(f'Partial type "{name}" has already been created.')
 
-        if include is not None and exclude is not None:
-            raise TypeError(f'Exclude and include are mutually exclusive.')
+        if include is not None:
+            if exclude is not None:
+                raise TypeError('Exclude and include are mutually exclusive.')
+            if exclude_relational_fields is True:
+                raise TypeError('Include and exclude_relational_fields=True are mutually exclusive.')
 
         if required and optional:
             shared = set(required) & set(optional)
@@ -1401,8 +1431,11 @@ class D(BaseModel):
         if name in _created_partial_types:
             raise ValueError(f'Partial type "{name}" has already been created.')
 
-        if include is not None and exclude is not None:
-            raise TypeError(f'Exclude and include are mutually exclusive.')
+        if include is not None:
+            if exclude is not None:
+                raise TypeError('Exclude and include are mutually exclusive.')
+            if exclude_relational_fields is True:
+                raise TypeError('Include and exclude_relational_fields=True are mutually exclusive.')
 
         if required and optional:
             shared = set(required) & set(optional)
@@ -1509,8 +1542,11 @@ class E(BaseModel):
         if name in _created_partial_types:
             raise ValueError(f'Partial type "{name}" has already been created.')
 
-        if include is not None and exclude is not None:
-            raise TypeError(f'Exclude and include are mutually exclusive.')
+        if include is not None:
+            if exclude is not None:
+                raise TypeError('Exclude and include are mutually exclusive.')
+            if exclude_relational_fields is True:
+                raise TypeError('Include and exclude_relational_fields=True are mutually exclusive.')
 
         if required and optional:
             shared = set(required) & set(optional)

--- a/tests/test_generation/test_partial_types.py
+++ b/tests/test_generation/test_partial_types.py
@@ -94,6 +94,7 @@ def test_partial_types(testdir: Testdir, location: str, options: str) -> None:
             PostModifiedAuthor,
             UserModifiedPosts,
             UserBytesList,
+            PostNoRelationsAndExclude,
         )
 
         base_fields = {
@@ -217,6 +218,18 @@ def test_partial_types(testdir: Testdir, location: str, options: str) -> None:
                 },
             )
 
+        def test_exclude_relations_and_others() -> None:
+            """Removing all relational fields using `exclude_relations` in combination with `exclude`"""
+            assert_expected(
+                PostNoRelationsAndExclude,
+                base_fields,
+                removed={
+                    'title',
+                    'author',
+                    'comments',
+                },
+            )
+
         def test_modified_relational_list_type() -> None:
             """Changing one-to-many relation field type"""
             UserModifiedPosts(
@@ -272,6 +285,11 @@ def test_partial_types(testdir: Testdir, location: str, options: str) -> None:
             'PostModifiedAuthor', relations={'author': 'UserOnlyName'}
         )
         Post.create_partial('PostNoRelations', exclude_relational_fields=True)
+        Post.create_partial(
+            'PostNoRelationsAndExclude',
+            exclude={'title'},
+            exclude_relational_fields=True,
+        )
 
         User.create_partial(
             'UserModifiedPosts',
@@ -283,7 +301,7 @@ def test_partial_types(testdir: Testdir, location: str, options: str) -> None:
     testdir.make_from_function(generator, name=location)
     testdir.generate(SCHEMA, options)
     testdir.make_from_function(tests)
-    testdir.runpytest().assert_outcomes(passed=10)
+    testdir.runpytest().assert_outcomes(passed=11)
 
 
 @pytest.mark.parametrize(
@@ -554,5 +572,37 @@ def test_exclude_relational_fields_and_relations_exclusive(
     )
     assert (
         'exclude_relational_fields and relations are mutually exclusive'
+        in output
+    )
+
+
+def test_exclude_relational_fields_and_include_exclusive(
+    testdir: Testdir,
+) -> None:
+    """exclude_relational_fields and include cannot be passed at the same time"""
+
+    def generator() -> None:  # mark: filedef
+        from prisma.models import Post
+
+        Post.create_partial(
+            'Placeholder',
+            include={'author'},
+            exclude_relational_fields=True,
+        )
+
+    testdir.make_from_function(generator, name='prisma/partial_types.py')
+
+    with pytest.raises(subprocess.CalledProcessError) as exc:
+        testdir.generate(SCHEMA)
+
+    output = exc.value.output.decode('utf-8')
+    assert 'prisma/partial_types.py' in output
+    assert 'TypeError' in output
+    assert (
+        'An exception ocurred while running the partial type generator'
+        in output
+    )
+    assert (
+        'Include and exclude_relational_fields=True are mutually exclusive.'
         in output
     )


### PR DESCRIPTION
## Change Summary

Closes #436 

This also enforces that `include` and `exclude_relational_fields=True` are mutually exclusive.

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [x] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
