### PR TITLE
feat(project): add support for configuration through pyproject.toml

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,4 +4,5 @@ pydantic>=1.8.0
 click>=7.1.2
 python-dotenv>=0.12.0
 typing-extensions>=3.7
+tomlkit
 cached-property; python_version < '3.8'

--- a/src/prisma/__init__.py
+++ b/src/prisma/__init__.py
@@ -6,7 +6,11 @@ __license__ = 'APACHE'
 __copyright__ = 'Copyright 2020-2021 RobertCraigie'
 __version__ = '0.6.7a'
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
+
+from ._config import Config as _Config, LazyConfigProxy as _LazyConfigProxy
+
+config: _Config = cast(_Config, _LazyConfigProxy())
 
 from .utils import setup_logging
 from . import errors as errors

--- a/src/prisma/_config.py
+++ b/src/prisma/_config.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Union
+
+import tomlkit
+from pydantic import BaseSettings, Extra, Field
+
+from ._compat import cached_property
+
+if TYPE_CHECKING:
+    from pydantic.env_settings import SettingsSourceCallable
+
+
+class DefaultConfig(BaseSettings):
+    # CLI version
+    # TODO: if this version changes but the engine version
+    #       doesn't change then the CLI is incorrectly cached
+    prisma_version: str = '3.13.0'
+
+    # Engine binary versions can be found under https://github.com/prisma/prisma-engine/commits/main
+    engine_version: str = Field(
+        env='PRISMA_ENGINE_VERSION',
+        default='efdf9b1183dddfd4258cd181a72125755215ab7b',
+    )
+
+    # CLI binaries are stored here
+    prisma_url: str = Field(
+        env='PRISMA_CLI_URL',
+        default='https://prisma-photongo.s3-eu-west-1.amazonaws.com/prisma-cli-{version}-{platform}.gz',
+    )
+
+    # Engine binaries are stored here
+    engine_url: str = Field(
+        env='PRISMA_ENGINE_URL',
+        default='https://binaries.prisma.sh/all_commits/{0}/{1}/{2}.gz',
+    )
+
+    # Where to store the downloaded binaries
+    binary_cache_dir: Union[Path, None] = Field(
+        env='PRISMA_BINARY_CACHE_DIR',
+        default=None,
+    )
+
+    class Config(BaseSettings.Config):
+        extra: Extra = Extra.ignore
+
+        @classmethod
+        def customise_sources(
+            cls,
+            init_settings: SettingsSourceCallable,
+            env_settings: SettingsSourceCallable,
+            file_secret_settings: SettingsSourceCallable,
+        ) -> tuple[SettingsSourceCallable, ...]:
+            # prioritise env settings over init settings
+            return env_settings, init_settings, file_secret_settings
+
+
+class Config(DefaultConfig):
+    binary_cache_dir: Path
+
+    @classmethod
+    def from_base(cls, config: DefaultConfig) -> Config:
+        if config.binary_cache_dir is None:
+            config.binary_cache_dir = (
+                Path(tempfile.gettempdir())
+                / 'prisma'
+                / 'binaries'
+                / 'engines'
+                / config.engine_version
+            )
+
+        return cls.parse_obj(config.dict())
+
+    @classmethod
+    def load(cls, path: Path | None = None) -> Config:
+        if path is None:
+            path = Path('pyproject.toml')
+
+        if path.exists():
+            config = (
+                tomlkit.loads(path.read_text())
+                .get('tool', {})
+                .get('prisma', {})
+            )
+        else:
+            config = {}
+
+        return cls.from_base(DefaultConfig.parse_obj(config))
+
+
+# TODO: ensure things like __name__, __dir__ are proxied correctly
+class LazyConfigProxy:
+    def __getattr__(self, attr: str) -> object:
+        return getattr(self.__proxied, attr)
+
+    @cached_property
+    def __proxied(self) -> Config:
+        return Config.load()
+
+    def __repr__(self) -> str:
+        return repr(self.__proxied)
+
+    def __str__(self) -> str:
+        return str(self.__proxied)

--- a/src/prisma/_config.py
+++ b/src/prisma/_config.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Union
+from functools import lru_cache
 
 import tomlkit
 from pydantic import BaseSettings, Extra, Field
-
-from ._compat import cached_property
 
 if TYPE_CHECKING:
     from pydantic.env_settings import SettingsSourceCallable
@@ -93,14 +92,14 @@ class Config(DefaultConfig):
 # TODO: ensure things like __name__, __dir__ are proxied correctly
 class LazyConfigProxy:
     def __getattr__(self, attr: str) -> object:
-        return getattr(self.__proxied, attr)
+        return getattr(self.__get_proxied(), attr)
 
-    @cached_property
-    def __proxied(self) -> Config:
+    @lru_cache(maxsize=None)
+    def __get_proxied(self) -> Config:
         return Config.load()
 
     def __repr__(self) -> str:
-        return repr(self.__proxied)
+        return repr(self.__get_proxied())
 
     def __str__(self) -> str:
-        return str(self.__proxied)
+        return str(self.__get_proxied())

--- a/src/prisma/binaries/binaries.py
+++ b/src/prisma/binaries/binaries.py
@@ -8,7 +8,8 @@ import click
 
 from .binary import Binary
 from .engine import Engine
-from .constants import GLOBAL_TEMP_DIR, PRISMA_CLI_NAME
+from .constants import PRISMA_CLI_NAME
+from .. import config
 
 
 __all__ = (
@@ -47,7 +48,7 @@ def ensure_cached() -> Path:
 
     if not binaries:
         log.debug('All binaries are cached')
-        return GLOBAL_TEMP_DIR
+        return config.binary_cache_dir
 
     def show_item(item: Optional[Binary]) -> str:
         if item is not None:
@@ -63,7 +64,7 @@ def ensure_cached() -> Path:
         for binary in iterator:
             binary.download()
 
-    return GLOBAL_TEMP_DIR
+    return config.binary_cache_dir
 
 
 def remove_all() -> None:

--- a/src/prisma/binaries/binary.py
+++ b/src/prisma/binaries/binary.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 
 from . import platform
 from .utils import download
-from .constants import GLOBAL_TEMP_DIR, PRISMA_URL, PRISMA_VERSION
+from .. import config
 
 
 __all__ = ('Binary',)
@@ -32,8 +32,8 @@ class Binary(BaseModel):
 
     @property
     def url(self) -> str:
-        return platform.check_for_extension(PRISMA_URL).format(
-            version=PRISMA_VERSION, platform=platform.name()
+        return platform.check_for_extension(config.prisma_url).format(
+            version=config.prisma_version, platform=platform.name()
         )
 
     @property
@@ -47,6 +47,6 @@ class Binary(BaseModel):
             )
             return Path(env)
 
-        return GLOBAL_TEMP_DIR.joinpath(
+        return config.binary_cache_dir.joinpath(
             platform.check_for_extension(self.name)
         )

--- a/src/prisma/binaries/constants.py
+++ b/src/prisma/binaries/constants.py
@@ -1,50 +1,8 @@
-import os
-import tempfile
-from pathlib import Path
-
 from . import platform
 
 
-__all__ = (
-    'PRISMA_URL',
-    'PRISMA_VERSION',
-    'ENGINE_URL',
-    'ENGINE_VERSION',
-    'GLOBAL_TEMP_DIR',
-    'PRISMA_CLI_NAME',
-)
+__all__ = ('PRISMA_CLI_NAME',)
 
-
-# TODO: if this version changes but the engine version
-#       doesn't change then the CLI is incorrectly cached
-# hardcoded CLI version version
-PRISMA_VERSION = '3.13.0'
-
-# CLI binaries are stored here
-PRISMA_URL = os.environ.get(
-    'PRISMA_CLI_URL',
-    'https://prisma-photongo.s3-eu-west-1.amazonaws.com/prisma-cli-{version}-{platform}.gz',
-)
-
-# engine binaries are stored here
-ENGINE_URL = os.environ.get(
-    'PRISMA_ENGINE_URL',
-    'https://binaries.prisma.sh/all_commits/{0}/{1}/{2}.gz',
-)
-
-# versions can be found under https://github.com/prisma/prisma-engine/commits/main
-ENGINE_VERSION = os.environ.get(
-    'PRISMA_ENGINE_VERSION', 'efdf9b1183dddfd4258cd181a72125755215ab7b'
-)
-
-# where the binaries live
-GLOBAL_TEMP_DIR = (
-    Path(tempfile.gettempdir())
-    / 'prisma'
-    / 'binaries'
-    / 'engines'
-    / ENGINE_VERSION
-)
 
 # local file path for the prisma CLI
 if platform.name() == 'windows':

--- a/src/prisma/binaries/engine.py
+++ b/src/prisma/binaries/engine.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from . import platform
 from .binary import Binary
-from .constants import ENGINE_URL, ENGINE_VERSION, GLOBAL_TEMP_DIR
+from .. import config
 
 
 __all__ = ('Engine',)
@@ -19,8 +19,8 @@ class Engine(Binary):
     @property
     def url(self) -> str:
         return platform.check_for_extension(
-            ENGINE_URL.format(
-                ENGINE_VERSION, platform.binary_platform(), self.name
+            config.engine_url.format(
+                config.engine_version, platform.binary_platform(), self.name
             )
         )
 
@@ -39,7 +39,7 @@ class Engine(Binary):
         return Path(
             platform.check_for_extension(
                 str(
-                    GLOBAL_TEMP_DIR.joinpath(
+                    config.binary_cache_dir.joinpath(
                         f'prisma-{self.name}-{binary_name}'
                     )
                 )

--- a/src/prisma/cli/commands/version.py
+++ b/src/prisma/cli/commands/version.py
@@ -6,8 +6,7 @@ from importlib import import_module
 import click
 
 from ..utils import pretty_info
-from ... import __version__
-from ...binaries import PRISMA_VERSION, ENGINE_VERSION
+from ... import __version__, config
 from ...binaries.platform import binary_platform
 
 
@@ -36,10 +35,10 @@ def cli(output_json: bool) -> None:
             installed.append(extra)
 
     info = {
-        'prisma': PRISMA_VERSION,
+        'prisma': config.prisma_version,
         'prisma client python': __version__,
         'platform': binary_platform(),
-        'engines': ENGINE_VERSION,
+        'engines': config.engine_version,
         'install path': str(Path(__file__).resolve().parent.parent.parent),
         'installed extras': installed,
     }

--- a/src/prisma/engine/utils.py
+++ b/src/prisma/engine/utils.py
@@ -10,9 +10,10 @@ from typing import NoReturn, Dict, Type, Any
 from . import errors
 from .. import errors as prisma_errors
 
+from .. import config
 from ..http_abstract import AbstractResponse
 from ..utils import time_since
-from ..binaries import GLOBAL_TEMP_DIR, ENGINE_VERSION, platform
+from ..binaries import platform
 
 
 log: logging.Logger = logging.getLogger(__name__)
@@ -36,7 +37,7 @@ def ensure() -> Path:
 
     name = f'prisma-query-engine-{binary_name}'
     local_path = Path.cwd().joinpath(name)
-    global_path = GLOBAL_TEMP_DIR.joinpath(name)
+    global_path = config.binary_cache_dir.joinpath(name)
 
     log.debug('Expecting local query engine %s', local_path)
     log.debug('Expecting global query engine %s', global_path)
@@ -80,9 +81,9 @@ def ensure() -> Path:
     )
     log.debug('Using query engine version %s', version)
 
-    if force_version and version != ENGINE_VERSION:
+    if force_version and version != config.engine_version:
         raise errors.MismatchedVersionsError(
-            expected=ENGINE_VERSION, got=version
+            expected=config.engine_version, got=version
         )
 
     log.debug('Using query engine at %s', file)

--- a/tests/test_cli/test_fetch.py
+++ b/tests/test_cli/test_fetch.py
@@ -3,7 +3,7 @@ import shutil
 
 from click.testing import Result
 
-from prisma import binaries
+from prisma import binaries, config
 from tests.utils import Runner
 
 
@@ -14,7 +14,7 @@ from tests.utils import Runner
 def assert_success(result: Result) -> None:
     assert result.exit_code == 0
     assert result.output.endswith(
-        f'Downloaded binaries to {binaries.GLOBAL_TEMP_DIR}\n'
+        f'Downloaded binaries to {config.binary_cache_dir}\n'
     )
 
     for binary in binaries.BINARIES:
@@ -56,7 +56,7 @@ def test_fetch_force(runner: Runner) -> None:
 def test_fetch_force_no_dir(runner: Runner) -> None:
     """Passing --force when the base directory does not exist"""
     binaries.remove_all()
-    shutil.rmtree(str(binaries.GLOBAL_TEMP_DIR))
+    shutil.rmtree(str(config.binary_cache_dir))
 
     binary = binaries.BINARIES[0]
     assert not binary.path.exists()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+from typing import cast
+from textwrap import dedent
+
+from pytest_mock import MockerFixture
+from prisma._config import Config, LazyConfigProxy
+from prisma.utils import temp_env_update
+
+from .utils import Testdir
+
+
+def test_lazy_proxy(mocker: MockerFixture) -> None:
+    """Laxy proxy only instantiates Config once"""
+    proxy = cast(Config, LazyConfigProxy())
+    mocked = mocker.patch.object(Config, 'load', spec=Config)
+    print(proxy.binary_cache_dir)
+    mocked.assert_called_once()
+
+    for _ in range(10):
+        print(proxy.prisma_url)
+
+    mocked.assert_called_once()
+
+
+def test_no_file(testdir: Testdir) -> None:
+    """Config loading works with no pyproject.toml present"""
+    path = Path('pyproject.toml')
+    assert not path.exists()
+
+    config = Config.load(path)
+    assert isinstance(config.prisma_version, str)
+
+
+def test_loading(testdir: Testdir) -> None:
+    """Config loading overrides defaults"""
+    testdir.makefile(
+        '.toml',
+        pyproject=dedent(
+            """
+            [tool.prisma]
+            prisma_version = '0.1.2.3'
+            engine_version = 'foo'
+            """
+        ),
+    )
+    config = Config.load()
+    assert config.prisma_version == '0.1.2.3'
+
+    # updated options are used in computed options
+    assert 'foo' in str(config.binary_cache_dir)
+
+
+def test_allows_extra_keys(testdir: Testdir) -> None:
+    """Config loading works with no pyproject.toml present"""
+    testdir.makefile(
+        '.toml',
+        pyproject=dedent(
+            """
+            [tool.prisma]
+            foo = 'bar'
+            prisma_version = 0.3
+            """
+        ),
+    )
+    config = Config.load()
+    assert config.prisma_version == '0.3'
+    assert not hasattr(config, 'foo')
+
+
+def test_env_var_takes_priority(testdir: Testdir) -> None:
+    """Any env variable present should be used instead of the given option"""
+    testdir.makefile(
+        '.toml',
+        pyproject=dedent(
+            """
+            [tool.prisma]
+            prisma_version = '0.3'
+            """
+        ),
+    )
+    config = Config.load()
+    assert config.prisma_version == '0.3'
+
+    with temp_env_update({'PRISMA_VERSION': '1.5'}):
+        config = Config.load()
+        assert config.prisma_version == '1.5'

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -7,10 +7,10 @@ import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from pytest_subprocess import FakeProcess
 
-from prisma import Prisma
+from prisma import Prisma, config
 from prisma.utils import temp_env_update
 from prisma.binaries import platform
-from prisma.binaries import BINARIES, ENGINE_VERSION
+from prisma.binaries import BINARIES
 from prisma.engine import errors, utils
 from prisma.engine.query import QueryEngine
 from prisma._compat import get_running_loop
@@ -88,7 +88,7 @@ def test_mismatched_version_error(fake_process: FakeProcess) -> None:
         utils.ensure()
 
     assert exc.match(
-        f'Expected query engine version `{ENGINE_VERSION}` but got `unexpected-hash`'
+        f'Expected query engine version `{config.engine_version}` but got `unexpected-hash`'
     )
 
 
@@ -110,7 +110,7 @@ def test_ensure_local_path(
 
     fake_process.register_subprocess(
         [fake_engine, '--version'],  # type: ignore[list-item]
-        stdout=f'query-engine {ENGINE_VERSION}',
+        stdout=f'query-engine {config.engine_version}',
     )
     path = utils.ensure()
     assert path == fake_engine

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -85,7 +85,7 @@ class Runner:
     def __init__(self, patcher: 'MonkeyPatch') -> None:
         self._runner = CliRunner()
         self._patcher = patcher
-        self.default_cli = None  # type: Optional[click.Command]
+        self.default_cli: Optional[click.Command] = None
         self.patch_subprocess()
 
     def invoke(


### PR DESCRIPTION
## Change Summary

You can now configure certain options using an entry in your `pyproject.toml` file instead of having to set environment variables, e.g.

```toml
[tool.prisma]
binary_cache_dir = '.binaries'
```

It should be noted that you can still use environment variables if you so desire, e.g.

```sh
PRISMA_BINARY_CACHE_DIR=".binaries"
```

This will be useful as a workaround for #413 until the default behaviour is changed.

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [x] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
