### PR TITLE
docs(readme): add missing required email in insert examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ async def main() -> None:
     user = await prisma.user.create(
         data={
             'name': 'Robert',
+            'email': 'robert@craigie.dev'
         },
     )
 
@@ -208,6 +209,7 @@ async def main() -> None:
     user = await User.prisma().create(
         data={
             'name': 'Robert',
+            'email': 'robert@craigie.dev'
         },
     )
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -184,6 +184,7 @@ async def main() -> None:
     user = await prisma.user.create(
         data={
             'name': 'Robert',
+            'email': 'robert@craigie.dev'
         },
     )
 
@@ -208,6 +209,7 @@ async def main() -> None:
     user = await User.prisma().create(
         data={
             'name': 'Robert',
+            'email': 'robert@craigie.dev'
         },
     )
 


### PR DESCRIPTION
## Change Summary

Hello.
In example `schema.prisma` file User has email required field. But in example with python client specified only name. If run it example than an error will occur:
```prisma.errors.MissingRequiredValueError: Failed to validate the query: `Unable to match input value to any allowed input type for the field. Parse errors: [Query parsing/validation error at `Mutation.createOneUser.data.UserCreateInput.email`: A value is required but not set., Query parsing/validation error at `Mutation.createOneUser.data.UserUncheckedCreateInput.email`: A value is required but not set.]` at `Mutation.createOneUser.data```

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass without significant drop in coverage
- [x] Documentation reflects changes where applicable
- [x] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
