### PR TITLE
docs(getting-started): Fix comment example

### DIFF
--- a/docs/getting_started/advanced.md
+++ b/docs/getting_started/advanced.md
@@ -96,21 +96,25 @@ Now that a post and comments have been created, you can query for them as follow
 
 ```py
 # find all comments on a post
-comments = await db.comments.find_many({
-    'where': {
+comments = await db.comment.find_many(
+    where={
         'post_id': post.id
     }
-})
-print(f'comments of post with id {post.id}: {json.dumps(comments, indent=2)}')
+)
+print(f'comments of post with id {post.id}')
+for comment in comments:
+    print(comment.json(indent=2))
 
 # find at most 3 comments on a post
-filtered = await db.comments.find_many({
-    'where': {
+filtered = await db.comment.find_many(
+    where={
         'post_id': post.id
     },
-    'take': 3,
-})
-print(f'filtered comments of post with id {post.id}: {json.dumps(comments, indent=2)}')
+    take=3
+)
+print(f'filtered comments of post with id {post.id}')
+for comment in filtered:
+    print(comment.json(indent=2))
 ```
 
 Prisma also allows you to fetch multiple things at once. Instead of doing complicated joins, you can fetch a post and a


### PR DESCRIPTION
The examples to search comments were not working as expected, so I fixed them

## Change Summary

I fixed examples to read comments in the `getting started` documentation

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass without significant drop in coverage
- [x] Documentation reflects changes where applicable
- [x] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
