### PR TITLE
fix(pre-commit): bump blue hook to `v0.9.1`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,6 @@ repos:
           - id: mixed-line-ending
             args: [--fix=lf]
     - repo: https://github.com/grantjenks/blue.git
-      rev: v0.9.0
+      rev: v0.9.1
       hooks:
       - id: blue


### PR DESCRIPTION
## Change Summary

A release of `flake8` broke `blue` so we need to bump `blue` to the latest version.

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
