### PR TITLE
fix(package): force utf-8 in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,11 @@ def requirements(name: str) -> List[str]:
     return root.joinpath(name).read_text().splitlines()
 
 
-with open('README.md', 'r') as f:
+with open('README.md', 'r', encoding="utf-8") as f:
     readme = f.read()
 
 version = ''
-with open('src/prisma/__init__.py') as f:
+with open('src/prisma/__init__.py', encoding="utf-8") as f:
     match = re.search(
         r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', f.read(), re.MULTILINE
     )

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,11 @@ def requirements(name: str) -> List[str]:
     return root.joinpath(name).read_text().splitlines()
 
 
-with open('README.md', 'r', encoding="utf-8") as f:
+with open('README.md', 'r', encoding='utf-8') as f:
     readme = f.read()
 
 version = ''
-with open('src/prisma/__init__.py', encoding="utf-8") as f:
+with open('src/prisma/__init__.py', encoding='utf-8') as f:
     match = re.search(
         r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', f.read(), re.MULTILINE
     )


### PR DESCRIPTION
## Change Summary

Changes `setup.py` to always open files in UTF-8 encoding to avoid weird encoding errors when installing the package.

## Checklist

N/A

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
