### PR TITLE
fix(engine): explicitly cast `Path` to a string for env variables

### DIFF
--- a/src/prisma/generator/templates/engine/query.py.jinja
+++ b/src/prisma/generator/templates/engine/query.py.jinja
@@ -103,7 +103,7 @@ class QueryEngine(HTTPEngine):
 
         env = os.environ.copy()
         env.update(
-            PRISMA_DML_PATH=self.dml_path,
+            PRISMA_DML_PATH=str(self.dml_path.absolute()),
             RUST_LOG='error',
             RUST_LOG_FORMAT='json',
             PRISMA_CLIENT_ENGINE_TYPE='binary',

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enginequery.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enginequery.py].raw
@@ -134,7 +134,7 @@ class QueryEngine(HTTPEngine):
 
         env = os.environ.copy()
         env.update(
-            PRISMA_DML_PATH=self.dml_path,
+            PRISMA_DML_PATH=str(self.dml_path.absolute()),
             RUST_LOG='error',
             RUST_LOG_FORMAT='json',
             PRISMA_CLIENT_ENGINE_TYPE='binary',

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enginequery.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enginequery.py].raw
@@ -135,7 +135,7 @@ class QueryEngine(HTTPEngine):
 
         env = os.environ.copy()
         env.update(
-            PRISMA_DML_PATH=self.dml_path,
+            PRISMA_DML_PATH=str(self.dml_path.absolute()),
             RUST_LOG='error',
             RUST_LOG_FORMAT='json',
             PRISMA_CLIENT_ENGINE_TYPE='binary',


### PR DESCRIPTION
## Change Summary

The previous implicit cast to `str` may break on some systems.

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
