### PR TITLE
fix(client): prevent the deletion of sqlite dbname

### DIFF
--- a/src/prisma/_compat.py
+++ b/src/prisma/_compat.py
@@ -47,3 +47,9 @@ if sys.version_info[:2] < (3, 8):
         from cached_property import cached_property as cached_property
 else:
     from functools import cached_property as cached_property
+
+
+def removeprefix(string: str, prefix: str) -> str:
+    if string.startswith(prefix):
+        return string[len(prefix):]
+    return string

--- a/src/prisma/_compat.py
+++ b/src/prisma/_compat.py
@@ -51,5 +51,5 @@ else:
 
 def removeprefix(string: str, prefix: str) -> str:
     if string.startswith(prefix):
-        return string[len(prefix):]
+        return string[len(prefix) :]
     return string

--- a/src/prisma/generator/templates/client.py.jinja
+++ b/src/prisma/generator/templates/client.py.jinja
@@ -10,6 +10,7 @@ from ._types import BaseModelT
 from .engine import AbstractEngine, QueryEngine
 from .builder import QueryBuilder
 from .generator.models import EngineType, OptionalValueFromEnvVar
+from ._compat import removeprefix
 
 
 __all__ = (
@@ -347,7 +348,7 @@ class Prisma:
         }
 
     def _make_sqlite_url(self, url: str, *, relative_to: Path = SCHEMA_PATH.parent) -> str:
-        url_path = url.lstrip('file').lstrip('sqlite')[1:]
+        url_path = removeprefix(removeprefix(url, 'file:'), 'sqlite:')
         if url_path == url:
             return url
 

--- a/src/prisma/generator/templates/client.py.jinja
+++ b/src/prisma/generator/templates/client.py.jinja
@@ -347,7 +347,7 @@ class Prisma:
         }
 
     def _make_sqlite_url(self, url: str, *, relative_to: Path = SCHEMA_PATH.parent) -> str:
-        url_path = url.lstrip('file:').lstrip('sqlite:')
+        url_path = url.lstrip('file').lstrip('sqlite')[1:]
         if url_path == url:
             return url
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -197,3 +197,10 @@ def test_sqlite_url(client: Prisma) -> None:
     # unknown prefixes are not updated
     url = client._make_sqlite_url('unknown:dev.db', relative_to=rootdir)
     assert url == 'unknown:dev.db'
+
+    # prefixes being dropped without affecting file name
+    url = client._make_sqlite_url('file:file.db')
+    assert url == f'file:{SCHEMA_PATH.parent.joinpath("file.db")}'
+
+    url = client._make_sqlite_url('sqlite:sqlite.db')
+    assert url == f'file:{SCHEMA_PATH.parent.joinpath("sqlite.db")}'

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
@@ -373,7 +373,7 @@ class Prisma:
         }
 
     def _make_sqlite_url(self, url: str, *, relative_to: Path = SCHEMA_PATH.parent) -> str:
-        url_path = url.lstrip('file:').lstrip('sqlite:')
+        url_path = url.lstrip('file').lstrip('sqlite')[1:]
         if url_path == url:
             return url
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
@@ -44,6 +44,7 @@ from ._types import BaseModelT
 from .engine import AbstractEngine, QueryEngine
 from .builder import QueryBuilder
 from .generator.models import EngineType, OptionalValueFromEnvVar
+from ._compat import removeprefix
 
 
 __all__ = (
@@ -373,7 +374,7 @@ class Prisma:
         }
 
     def _make_sqlite_url(self, url: str, *, relative_to: Path = SCHEMA_PATH.parent) -> str:
-        url_path = url.lstrip('file').lstrip('sqlite')[1:]
+        url_path = removeprefix(removeprefix(url, 'file:'), 'sqlite:')
         if url_path == url:
             return url
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
@@ -372,7 +372,7 @@ class Prisma:
         }
 
     def _make_sqlite_url(self, url: str, *, relative_to: Path = SCHEMA_PATH.parent) -> str:
-        url_path = url.lstrip('file:').lstrip('sqlite:')
+        url_path = url.lstrip('file').lstrip('sqlite')[1:]
         if url_path == url:
             return url
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
@@ -44,6 +44,7 @@ from ._types import BaseModelT
 from .engine import AbstractEngine, QueryEngine
 from .builder import QueryBuilder
 from .generator.models import EngineType, OptionalValueFromEnvVar
+from ._compat import removeprefix
 
 
 __all__ = (
@@ -372,7 +373,7 @@ class Prisma:
         }
 
     def _make_sqlite_url(self, url: str, *, relative_to: Path = SCHEMA_PATH.parent) -> str:
-        url_path = url.lstrip('file').lstrip('sqlite')[1:]
+        url_path = removeprefix(removeprefix(url, 'file:'), 'sqlite:')
         if url_path == url:
             return url
 


### PR DESCRIPTION
## Summary

I adjusted how SQLite URL is trimming "file:" and "sqlite:" prefixes in the beginning of connection string.
This was causing incorrect trimming when database file name starts with any character from those prefixes.

Example: "sqlite:teh.db" has been trimmed to "h.db".
The nature of lstrip method trims characters left to right while next symbol is found in the set of given characters.

Workaround: use relative path syntax like "sqlite:./teh.db".

## Checklist

- [x] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
