### PR TITLE
feat(ci): Add initial test case for a Docker build in CI for multi-platform builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+*
+!setup.py
+!README.md
+!src/
+!tests
+!requirements/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -255,7 +255,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        docker-platform: ["linux/amd64", "linux/arm64"]
+        docker-platform: ["linux/amd64"]
+        # TODO: Uncomment this to add testing support for arm64 and delete
+        # the above
+        # docker-platform: ["linux/amd64", "linux/arm64"]
         python-os-distro: ["slim-bullseye", "alpine"]
     steps:
       - uses: actions/checkout@v3
@@ -269,5 +272,7 @@ jobs:
         # https://github.com/docker/build-push-action/#inputs
         # Test each platform individually for easier testing
         with:
+          context: .
+          file: tests/Dockerfile
           platforms: "${{ matrix.docker-platform }}"
           build-args: "${{ matrix.python-os-distro }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11.0-rc.1']
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11.0-rc.1"]
 
     steps:
       - uses: actions/checkout@v3
@@ -248,3 +248,26 @@ jobs:
           codecov --file coverage.xml
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  docker:
+    name: docker
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        docker-platform: ["linux/amd64", "linux/arm64"]
+        python-os-distro: ["slim-bullseye", "alpine"]
+    steps:
+      - uses: actions/checkout@v3
+      # https://github.com/docker/build-push-action/
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Docker Build
+        uses: docker/build-push-action@v3
+        # https://github.com/docker/build-push-action/#inputs
+        # Test each platform individually for easier testing
+        with:
+          platforms: "${{ matrix.docker-platform }}"
+          build-args: "${{ matrix.python-os-distro }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+ARG PYTHON_VERSION=3.10
+ARG OS_DISTRO=slim-bullseye
+
+FROM python:${PYTHON_VERSION}-${OS_DISTRO}
+
+RUN useradd --create-home --uid 9999 --shell /bin/bash prisma
+
+USER prisma
+WORKDIR /home/prisma/prisma-client-py
+ENV PATH="/home/prisma/.local/bin:${PATH}"
+
+COPY --chown=prisma:prisma . .
+
+RUN pip install .
+
+# This has the side-effect of downing the prisma binaries
+# and will fail if the CLI cannot get run
+RUN prisma -v
+
+# Very light-weight test that CLI generation works
+RUN prisma generate --schema ./tests/data/schema.prisma

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,10 @@ docs-serve:
 	python scripts/docs.py
 	mkdocs serve
 
+.PHONY: docker
+docker:
+	docker build -t prisma-client-py --load .
+
 .PHONY: clean
 clean:
 	python -m prisma_cleanup

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,9 @@ docs-serve:
 
 .PHONY: docker
 docker:
-	docker build -t prisma-client-py --load .
+	# Note: the below will fail on linux/arm64 systems until
+	# we fix it in the upstream project
+	docker build -f tests/Dockerfile -t prisma-client-py --load .
 
 .PHONY: clean
 clean:

--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -217,3 +217,7 @@ tox -e typesafety-mypy
 ```
 
 See the [pytest-mypy-plugins documentation](https://github.com/TypedDjango/pytest-mypy-plugins) for more information.
+
+## Docker Testing + Multi-Platform (CPU Architecture) Support
+
+Since Github Actions (CI) does not allow for running code on multiple CPU architectures (and uses the amd64 aka x86_64 instruction set), we use a docker build process that uses its QEMU support to emulate multiple CPU platforms. The `make docker` command can be used to perform such a build locally. In CI this is enforced via the `docker` job in the test workflow.

--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -221,3 +221,7 @@ See the [pytest-mypy-plugins documentation](https://github.com/TypedDjango/pytes
 ## Docker Testing + Multi-Platform (CPU Architecture) Support
 
 Since Github Actions (CI) does not allow for running code on multiple CPU architectures (and uses the amd64 aka x86_64 instruction set), we use a docker build process that uses its QEMU support to emulate multiple CPU platforms. The `make docker` command can be used to perform such a build locally. In CI this is enforced via the `docker` job in the test workflow.
+
+We also use a docker build arg for the `OS_DISTRO` so that we can try and test against several of the official upstream [Python docker image flavors](https://hub.docker.com/_/python).
+
+**NOTE:** The docker setup should only be used internally for testing and not for re-distribution via a remote registry.

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,3 +1,6 @@
+# NOTE: This dockerfile should only be used for internal testing purposes
+# and should not form the basis of an official image pushed out
+# to a registry
 ARG PYTHON_VERSION=3.10
 ARG OS_DISTRO=slim-bullseye
 


### PR DESCRIPTION
## Change Summary

This PR adds a basic docker build setup that exercises the `prisma` CLI, building for multiple platforms in Docker via `--platform=linux/amd64,linux=arm64`

Additionally, it starts to exercise the build against multiple [Linux distributions for Python](https://hub.docker.com/_/python), starting with a basic support matrix for Debian Buster and Alpine (latest).

The scope is **not to publish** any sort of official image, but rather since GH Actions does not support an ARM CPU runner we can emulate how a build would have performed via the QEMU emulation of docker.

Relates to #454
Relates to #461
Relates to #507 

CI results for this running off of my fork can be found here: https://github.com/jacobdr/prisma-client-py/pull/1

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
