### PR TITLE
chore(project): Removed UnicodeExpr as it is no longer supported

### DIFF
--- a/src/prisma/mypy.py
+++ b/src/prisma/mypy.py
@@ -30,7 +30,6 @@ from mypy.nodes import (
     NameExpr,
     Var,
     BytesExpr,
-    UnicodeExpr,
     CallExpr,
     IntExpr,
     Context,
@@ -362,7 +361,7 @@ class PrismaPlugin(Plugin):
         return parsed
 
     def _resolve_expression(self, expression: Expression) -> Any:
-        if isinstance(expression, (StrExpr, BytesExpr, UnicodeExpr, IntExpr)):
+        if isinstance(expression, (StrExpr, BytesExpr, IntExpr)):
             return expression.value
 
         if isinstance(expression, NameExpr):


### PR DESCRIPTION
## Change Summary

`mypy` command gives the following error and I found https://github.com/python/mypy/pull/13254 and https://github.com/python/mypy/issues/12237 .
So, I removed it.

<img width="634" alt="Screen Shot 2022-10-23 at 14 31 21" src="https://user-images.githubusercontent.com/13819005/197376074-75b0d0dd-14c3-4462-8389-c57ba8ea0b6d.png">


## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
