### PR TITLE
refactor(tests): Pass through coverage context, refactor download binary tests to use mocks

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -29,6 +29,13 @@ exclude_lines =
     \.\.\.
 
 [paths]
+# https://coverage.readthedocs.io/en/6.4.4/config.html#paths
 prisma =
     src/prisma
     */**/prisma
+
+[html]
+show_contexts = True
+
+[json]
+show_contexts = True

--- a/pipelines/test.nox.py
+++ b/pipelines/test.nox.py
@@ -12,4 +12,13 @@ def test(session: nox.Session) -> None:
 
     generate(session)
 
-    session.run('coverage', 'run', '-m', 'pytest', *session.posargs)
+    # https://coverage.readthedocs.io/en/6.4.4/contexts.html
+    session.run(
+        'coverage',
+        'run',
+        '--context',
+        f'{session.python}',
+        '-m',
+        'pytest',
+        *session.posargs,
+    )

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,6 +7,13 @@ markers =
 # asyncio fixtures and tests must be explicitly marked
 asyncio_mode = strict
 
+# Record the slowest tests and print them
+addopts= --durations=20
+
+# Test timeout to weed out really slow tests -- if this is happening,
+# something is wrong
+faulthandler_timeout = 180
+
 # NOTE: this is required to stop pytest from loading conftest.py files
 # for our integration tests, as pytest eagerly loads conftests backwards
 # we cannot use a hook to ignore them as the integration conftest files

--- a/src/prisma/binaries/binaries.py
+++ b/src/prisma/binaries/binaries.py
@@ -9,7 +9,7 @@ import click
 from .binary import Binary
 from .engine import Engine
 from .constants import PRISMA_CLI_NAME
-from .. import config
+from .. import config, utils
 
 
 __all__ = (
@@ -21,13 +21,15 @@ __all__ = (
 
 log: logging.Logger = logging.getLogger(__name__)
 
-ENGINES = [
+PRISMA_FORMAT_BINARY = Engine(name='prisma-fmt', env='PRISMA_FMT_BINARY')
+
+ENGINES: List[Engine] = [
     Engine(name='query-engine', env='PRISMA_QUERY_ENGINE_BINARY'),
     Engine(name='migration-engine', env='PRISMA_MIGRATION_ENGINE_BINARY'),
     Engine(
         name='introspection-engine', env='PRISMA_INTROSPECTION_ENGINE_BINARY'
     ),
-    Engine(name='prisma-fmt', env='PRISMA_FMT_BINARY'),
+    PRISMA_FORMAT_BINARY,
 ]
 
 BINARIES: List[Binary] = [
@@ -37,26 +39,29 @@ BINARIES: List[Binary] = [
 
 
 def ensure_cached() -> Path:
-    binaries: List[Binary] = []
+    undownloaded_binaries: List[Binary] = []
     for binary in BINARIES:
         path = binary.path
         if path.exists():
             log.debug('%s cached at %s', binary.name, path)
         else:
             log.debug('%s not cached at %s', binary.name, path)
-            binaries.append(binary)
+            undownloaded_binaries.append(binary)
 
-    if not binaries:
+    if not undownloaded_binaries:
         log.debug('All binaries are cached')
         return config.binary_cache_dir
 
     def show_item(item: Optional[Binary]) -> str:
         if item is not None:
-            return binary.name
+            if utils.DEBUG:
+                return f'{binary.name} ({binary.url})'
+            else:
+                return binary.name
         return ''
 
     with click.progressbar(
-        binaries,
+        undownloaded_binaries,
         label='Downloading binaries',
         fill_char=click.style('#', fg='yellow'),
         item_show_func=show_item,

--- a/src/prisma/generator/templates/models.py.jinja
+++ b/src/prisma/generator/templates/models.py.jinja
@@ -32,17 +32,27 @@ _implicit_subclass_packages: Set[str] = {
     'fastapi',
 }
 
+def _module_to_parent_package(frame):
+    try:
+        module_name = inspect.getmodule(frame).__name__
+        parent_package, *_ = module_name.split(".")
+        return parent_package
+    except:
+        return None
 
-def _maybe_warn_subclassing(new_model: str, base_model: str, *, stacklevel: int = 3) -> None:
+def _maybe_warn_subclassing(new_model: str, base_model: str, *, max_call_stack_depth_to_inspect: int = 5) -> None:
     # at least 3 frames are guaranteed to exist if we are being called from __init_subclass__
     # stack: 1 = __init_subclass__, 2 = abc, 3 = <caller>
+    # however, we look at a few extra as we are dealing with internal implementaiton details
+    # of external libraries. there is a performance penalty each time we do this, so we should
+    # be careful here and probably run some performance tests to see what the penalty is
+    # for this checking
     try:
-        frame = inspect.stack()[stacklevel]
-        module = inspect.getmodule(frame[0])
-        if module is not None:
-            name, *_ = module.__name__.split('.')
-            if name in _implicit_subclass_packages:
-                return
+        frames_to_inspect = inspect.stack()[:max_call_stack_depth_to_inspect+1]
+        parent_packages = set([_module_to_parent_package(subframe[0]) for subframe in frames_to_inspect])
+        package_to_ignore_overlap = parent_packages & _implicit_subclass_packages
+        if package_to_ignore_overlap:
+            return
     except Exception as exc:
         # disabling subclass warnings depending on the caller module is not a mission critical
         # feature, users can disable these warnings themselves
@@ -105,7 +115,7 @@ class {{ model.name }}(BaseModel):
     ) -> None:
         super().__init_subclass__()
         if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, '{{ model.name }}', stacklevel=3)
+            _maybe_warn_subclassing(cls.__name__, '{{ model.name }}')
     {% endif %}
 
     @staticmethod

--- a/tests/integrations/sync/tests/test_binary.py
+++ b/tests/integrations/sync/tests/test_binary.py
@@ -1,14 +1,23 @@
-import random
-from prisma.binaries import BINARIES
+import pathlib
+from pytest_mock import MockerFixture
+
+from prisma.binaries.binaries import PRISMA_FORMAT_BINARY
 
 
-def test_download() -> None:
+def test_download(
+    mocker: MockerFixture,
+    tmp_path: pathlib.Path,
+) -> None:
     """Binary can be downloaded"""
-    binary = random.choice(BINARIES)
-    assert binary.path.exists()
-    binary.path.unlink()
-    assert not binary.path.exists()
+    # Always use the format engine binary since its quite small relative
+    # to other binaries.
+    # NOTE: unlike the test_fetch tetsts, this is not mocked and will
+    # make the network transfer. We do it in a separate directory so
+    # as to not create issues for other tests if we start parallelizing
+    mocker.patch('prisma.config.binary_cache_dir', tmp_path)
 
+    binary = PRISMA_FORMAT_BINARY
+    assert not binary.path.exists()
     binary.download()
 
     assert binary.path.exists()

--- a/tests/test_cli/test_fetch.py
+++ b/tests/test_cli/test_fetch.py
@@ -1,70 +1,111 @@
-import random
+import pathlib
 import shutil
+from mock import MagicMock
+from typing import cast
+
+from pytest_mock import MockerFixture
 
 from click.testing import Result
-
-from prisma import binaries, config
 from tests.utils import Runner, skipif_windows
-
+from prisma import config
+from prisma.binaries import binary, BINARIES
+from prisma.binaries.binaries import PRISMA_FORMAT_BINARY
 
 # TODO: this could probably mess up other tests if one of these
 # tests fails mid run, as the global binaries are deleted
 
+# Use a closure to capture the original value of the path -- this is from the cache
+# which should have already been downloaded to by the time this test module
+# got invoked
+_original_binary_path = PRISMA_FORMAT_BINARY.path
 
-def assert_success(result: Result) -> None:
+
+def _copy_cached_binaries_to_dir(destination: pathlib.Path) -> None:
+    assert _original_binary_path.exists()
+    original_binaries = list(_original_binary_path.parent.glob('*'))
+    assert len(original_binaries) == len(BINARIES)
+    for f in original_binaries:
+        shutil.copy2(f, destination)
+
+
+def assert_success(result: Result, cache_dir: pathlib.Path) -> None:
     assert result.exit_code == 0
-    assert result.output.endswith(
-        f'Downloaded binaries to {config.binary_cache_dir}\n'
-    )
-
-    for binary in binaries.BINARIES:
-        assert binary.path.exists()
+    assert result.output.endswith(f'Downloaded binaries to {str(cache_dir)}\n')
 
 
-def test_fetch(runner: Runner) -> None:
+def test_fetch(runner: Runner, mocker: MockerFixture) -> None:
     """Basic usage, binaries are already cached"""
-    assert_success(runner.invoke(['py', 'fetch']))
+    # https://pytest-mock.readthedocs.io/en/latest/usage.html#
+    download_mock = cast(
+        MagicMock, mocker.patch.object(binary, 'download', autospec=True)
+    )
+    assert_success(runner.invoke(['py', 'fetch']), config.binary_cache_dir)
+    assert (
+        download_mock.call_count == 0
+    ), 'Download should not have been invoked'
 
 
 # it seems like we can't use `.unlink()` on binary paths on windows due to permissions errors
 
 
 @skipif_windows
-def test_fetch_one_binary_missing(runner: Runner) -> None:
+def test_fetch_one_binary_missing(
+    runner: Runner,
+    mocker: MockerFixture,
+    tmp_path: pathlib.Path,
+) -> None:
     """Downloads a binary if it is missing"""
-    binary = random.choice(binaries.BINARIES)
-    assert binary.path.exists()
-    binary.path.unlink()
-    assert not binary.path.exists()
+    # https://pytest-mock.readthedocs.io/en/latest/usage.html#
+    # monkeypatch.setenv("PRISMA_BINARY_CACHE_DIR", str(tmp_path))
+    _copy_cached_binaries_to_dir(tmp_path)
+    download_mock = cast(
+        MagicMock, mocker.patch.object(binary, 'download', autospec=True)
+    )
+    mocker.patch('prisma.config.binary_cache_dir', tmp_path)
 
-    assert_success(runner.invoke(['py', 'fetch']))
+    original_contents = list(tmp_path.glob('*'))
+    original_contents[0].unlink()
+    contents_after = list(tmp_path.glob('*'))
+    assert len(contents_after) == (len(original_contents) - 1)
+
+    assert_success(runner.invoke(['py', 'fetch']), tmp_path)
+    assert (
+        download_mock.call_count == 1
+    ), f'Exepected download to have been called for a single binary'
 
 
 @skipif_windows
-def test_fetch_force(runner: Runner) -> None:
+def test_fetch_force(
+    runner: Runner, mocker: MockerFixture, tmp_path: pathlib.Path
+) -> None:
     """Passing --force re-downloads an already existing binary"""
-    binary = random.choice(binaries.BINARIES)
-    assert binary.path.exists()
-    old_stat = binary.path.stat()
+    mocker.patch('prisma.config.binary_cache_dir', tmp_path)
+    assert not PRISMA_FORMAT_BINARY.path.exists()
+    _copy_cached_binaries_to_dir(tmp_path)
+    assert PRISMA_FORMAT_BINARY.path.exists()
 
-    assert_success(runner.invoke(['py', 'fetch', '--force']))
-
-    new_stat = binary.path.stat()
-
-    # modified time
-    assert old_stat.st_mtime_ns != new_stat.st_mtime_ns
-
-    # ensure downloaded the same as before
-    assert old_stat.st_size == new_stat.st_size
+    download_mock = cast(
+        MagicMock, mocker.patch.object(binary, 'download', autospec=True)
+    )
+    assert_success(runner.invoke(['py', 'fetch', '--force']), tmp_path)
+    assert download_mock.call_count == len(
+        BINARIES
+    ), f'Exepected download to have been called for each engine {BINARIES}'
 
 
 @skipif_windows
-def test_fetch_force_no_dir(runner: Runner) -> None:
+def test_fetch_force_no_dir(
+    runner: Runner, mocker: MockerFixture, tmp_path: pathlib.Path
+) -> None:
     """Passing --force when the base directory does not exist"""
-    binaries.remove_all()
-    shutil.rmtree(str(config.binary_cache_dir))
-
-    binary = binaries.BINARIES[0]
-    assert not binary.path.exists()
-
-    assert_success(runner.invoke(['py', 'fetch', '--force']))
+    assert tmp_path.exists()
+    mocker.patch('prisma.config.binary_cache_dir', tmp_path)
+    tmp_path.rmdir()
+    assert not tmp_path.exists()
+    download_mock = cast(
+        MagicMock, mocker.patch.object(binary, 'download', autospec=True)
+    )
+    assert_success(runner.invoke(['py', 'fetch', '--force']), tmp_path)
+    assert download_mock.call_count == len(
+        BINARIES
+    ), f'Exepected download to have been called for each engine {BINARIES}'

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[models.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[models.py].raw
@@ -66,17 +66,27 @@ _implicit_subclass_packages: Set[str] = {
     'fastapi',
 }
 
+def _module_to_parent_package(frame):
+    try:
+        module_name = inspect.getmodule(frame).__name__
+        parent_package, *_ = module_name.split(".")
+        return parent_package
+    except:
+        return None
 
-def _maybe_warn_subclassing(new_model: str, base_model: str, *, stacklevel: int = 3) -> None:
+def _maybe_warn_subclassing(new_model: str, base_model: str, *, max_call_stack_depth_to_inspect: int = 5) -> None:
     # at least 3 frames are guaranteed to exist if we are being called from __init_subclass__
     # stack: 1 = __init_subclass__, 2 = abc, 3 = <caller>
+    # however, we look at a few extra as we are dealing with internal implementaiton details
+    # of external libraries. there is a performance penalty each time we do this, so we should
+    # be careful here and probably run some performance tests to see what the penalty is
+    # for this checking
     try:
-        frame = inspect.stack()[stacklevel]
-        module = inspect.getmodule(frame[0])
-        if module is not None:
-            name, *_ = module.__name__.split('.')
-            if name in _implicit_subclass_packages:
-                return
+        frames_to_inspect = inspect.stack()[:max_call_stack_depth_to_inspect+1]
+        parent_packages = set([_module_to_parent_package(subframe[0]) for subframe in frames_to_inspect])
+        package_to_ignore_overlap = parent_packages & _implicit_subclass_packages
+        if package_to_ignore_overlap:
+            return
     except Exception as exc:
         # disabling subclass warnings depending on the caller module is not a mission critical
         # feature, users can disable these warnings themselves
@@ -130,7 +140,7 @@ class Post(BaseModel):
     ) -> None:
         super().__init_subclass__()
         if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'Post', stacklevel=3)
+            _maybe_warn_subclassing(cls.__name__, 'Post')
 
     @staticmethod
     def create_partial(
@@ -273,7 +283,7 @@ class User(BaseModel):
     ) -> None:
         super().__init_subclass__()
         if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'User', stacklevel=3)
+            _maybe_warn_subclassing(cls.__name__, 'User')
 
     @staticmethod
     def create_partial(
@@ -412,7 +422,7 @@ class M(BaseModel):
     ) -> None:
         super().__init_subclass__()
         if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'M', stacklevel=3)
+            _maybe_warn_subclassing(cls.__name__, 'M')
 
     @staticmethod
     def create_partial(
@@ -553,7 +563,7 @@ class N(BaseModel):
     ) -> None:
         super().__init_subclass__()
         if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'N', stacklevel=3)
+            _maybe_warn_subclassing(cls.__name__, 'N')
 
     @staticmethod
     def create_partial(
@@ -692,7 +702,7 @@ class OneOptional(BaseModel):
     ) -> None:
         super().__init_subclass__()
         if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'OneOptional', stacklevel=3)
+            _maybe_warn_subclassing(cls.__name__, 'OneOptional')
 
     @staticmethod
     def create_partial(
@@ -832,7 +842,7 @@ class ManyRequired(BaseModel):
     ) -> None:
         super().__init_subclass__()
         if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'ManyRequired', stacklevel=3)
+            _maybe_warn_subclassing(cls.__name__, 'ManyRequired')
 
     @staticmethod
     def create_partial(
@@ -969,7 +979,7 @@ class Lists(BaseModel):
     ) -> None:
         super().__init_subclass__()
         if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'Lists', stacklevel=3)
+            _maybe_warn_subclassing(cls.__name__, 'Lists')
 
     @staticmethod
     def create_partial(
@@ -1081,7 +1091,7 @@ class A(BaseModel):
     ) -> None:
         super().__init_subclass__()
         if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'A', stacklevel=3)
+            _maybe_warn_subclassing(cls.__name__, 'A')
 
     @staticmethod
     def create_partial(
@@ -1189,7 +1199,7 @@ class B(BaseModel):
     ) -> None:
         super().__init_subclass__()
         if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'B', stacklevel=3)
+            _maybe_warn_subclassing(cls.__name__, 'B')
 
     @staticmethod
     def create_partial(
@@ -1298,7 +1308,7 @@ class C(BaseModel):
     ) -> None:
         super().__init_subclass__()
         if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'C', stacklevel=3)
+            _maybe_warn_subclassing(cls.__name__, 'C')
 
     @staticmethod
     def create_partial(
@@ -1407,7 +1417,7 @@ class D(BaseModel):
     ) -> None:
         super().__init_subclass__()
         if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'D', stacklevel=3)
+            _maybe_warn_subclassing(cls.__name__, 'D')
 
     @staticmethod
     def create_partial(
@@ -1514,7 +1524,7 @@ class E(BaseModel):
     ) -> None:
         super().__init_subclass__()
         if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'E', stacklevel=3)
+            _maybe_warn_subclassing(cls.__name__, 'E')
 
     @staticmethod
     def create_partial(

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[models.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[models.py].raw
@@ -66,17 +66,27 @@ _implicit_subclass_packages: Set[str] = {
     'fastapi',
 }
 
+def _module_to_parent_package(frame):
+    try:
+        module_name = inspect.getmodule(frame).__name__
+        parent_package, *_ = module_name.split(".")
+        return parent_package
+    except:
+        return None
 
-def _maybe_warn_subclassing(new_model: str, base_model: str, *, stacklevel: int = 3) -> None:
+def _maybe_warn_subclassing(new_model: str, base_model: str, *, max_call_stack_depth_to_inspect: int = 5) -> None:
     # at least 3 frames are guaranteed to exist if we are being called from __init_subclass__
     # stack: 1 = __init_subclass__, 2 = abc, 3 = <caller>
+    # however, we look at a few extra as we are dealing with internal implementaiton details
+    # of external libraries. there is a performance penalty each time we do this, so we should
+    # be careful here and probably run some performance tests to see what the penalty is
+    # for this checking
     try:
-        frame = inspect.stack()[stacklevel]
-        module = inspect.getmodule(frame[0])
-        if module is not None:
-            name, *_ = module.__name__.split('.')
-            if name in _implicit_subclass_packages:
-                return
+        frames_to_inspect = inspect.stack()[:max_call_stack_depth_to_inspect+1]
+        parent_packages = set([_module_to_parent_package(subframe[0]) for subframe in frames_to_inspect])
+        package_to_ignore_overlap = parent_packages & _implicit_subclass_packages
+        if package_to_ignore_overlap:
+            return
     except Exception as exc:
         # disabling subclass warnings depending on the caller module is not a mission critical
         # feature, users can disable these warnings themselves
@@ -130,7 +140,7 @@ class Post(BaseModel):
     ) -> None:
         super().__init_subclass__()
         if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'Post', stacklevel=3)
+            _maybe_warn_subclassing(cls.__name__, 'Post')
 
     @staticmethod
     def create_partial(
@@ -273,7 +283,7 @@ class User(BaseModel):
     ) -> None:
         super().__init_subclass__()
         if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'User', stacklevel=3)
+            _maybe_warn_subclassing(cls.__name__, 'User')
 
     @staticmethod
     def create_partial(
@@ -412,7 +422,7 @@ class M(BaseModel):
     ) -> None:
         super().__init_subclass__()
         if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'M', stacklevel=3)
+            _maybe_warn_subclassing(cls.__name__, 'M')
 
     @staticmethod
     def create_partial(
@@ -553,7 +563,7 @@ class N(BaseModel):
     ) -> None:
         super().__init_subclass__()
         if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'N', stacklevel=3)
+            _maybe_warn_subclassing(cls.__name__, 'N')
 
     @staticmethod
     def create_partial(
@@ -692,7 +702,7 @@ class OneOptional(BaseModel):
     ) -> None:
         super().__init_subclass__()
         if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'OneOptional', stacklevel=3)
+            _maybe_warn_subclassing(cls.__name__, 'OneOptional')
 
     @staticmethod
     def create_partial(
@@ -832,7 +842,7 @@ class ManyRequired(BaseModel):
     ) -> None:
         super().__init_subclass__()
         if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'ManyRequired', stacklevel=3)
+            _maybe_warn_subclassing(cls.__name__, 'ManyRequired')
 
     @staticmethod
     def create_partial(
@@ -969,7 +979,7 @@ class Lists(BaseModel):
     ) -> None:
         super().__init_subclass__()
         if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'Lists', stacklevel=3)
+            _maybe_warn_subclassing(cls.__name__, 'Lists')
 
     @staticmethod
     def create_partial(
@@ -1081,7 +1091,7 @@ class A(BaseModel):
     ) -> None:
         super().__init_subclass__()
         if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'A', stacklevel=3)
+            _maybe_warn_subclassing(cls.__name__, 'A')
 
     @staticmethod
     def create_partial(
@@ -1189,7 +1199,7 @@ class B(BaseModel):
     ) -> None:
         super().__init_subclass__()
         if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'B', stacklevel=3)
+            _maybe_warn_subclassing(cls.__name__, 'B')
 
     @staticmethod
     def create_partial(
@@ -1298,7 +1308,7 @@ class C(BaseModel):
     ) -> None:
         super().__init_subclass__()
         if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'C', stacklevel=3)
+            _maybe_warn_subclassing(cls.__name__, 'C')
 
     @staticmethod
     def create_partial(
@@ -1407,7 +1417,7 @@ class D(BaseModel):
     ) -> None:
         super().__init_subclass__()
         if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'D', stacklevel=3)
+            _maybe_warn_subclassing(cls.__name__, 'D')
 
     @staticmethod
     def create_partial(
@@ -1514,7 +1524,7 @@ class E(BaseModel):
     ) -> None:
         super().__init_subclass__()
         if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'E', stacklevel=3)
+            _maybe_warn_subclassing(cls.__name__, 'E')
 
     @staticmethod
     def create_partial(


### PR DESCRIPTION
## Change Summary

This MR is the result of my local installation and having run the test suite now many times. It does a few things to help make local development easier:

* Adds the a [static context](https://coverage.readthedocs.io/en/6.4.4/contexts.html) to the coverage so that we know which Python versions executed which sections of code. This will be eve more useful once we add the integration tests for different databases
* The `test_fetch` module which exercises the CLI was running notoriously slow on my machine. I am in the US and it seems Prisma hosts the binaries in an EU-based S3, which should have still been fast, but was not. Regardless, I turned this into more of a pure unit test with mocking, but left a real "download" test in `tests/integrations/sync/tests/test_binary.py`
* Speaking of `tests/integrations/sync/tests/test_binary.py`, I switched that to download the smallest Prisma binary (the formatter) so as to spare long download times
* Add the longest test durations to the `pytest` output to we know which tests are taking the longest
* Added a global test timeout of 3 minutes (applies to each test function) to help capture issues as people add things that might get quite slow in CI (this helped me identify the issues with the fetch tests)

The one thing that is slightly suspect about this changeset are the changes I had to make to the `_maybe_warn_subclassing` function. I could not for the life of me get that to work locally on my machine in Python 3.7. I think this solution is slightly more robust, but also slightly slower. Please definitely take a look at that change.

## Checklist

- [X] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [X] Documentation reflects changes where applicable
- [X] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
