### PR TITLE
chore(dependabot): add pipelines requirements to config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,11 @@ updates:
       - RobertCraigie
     rebase-strategy: auto
     target-branch: main
+  - package-ecosystem: pip
+    directory: /pipelines/requirements/
+    schedule:
+      interval: daily
+    reviewers:
+      - RobertCraigie
+    rebase-strategy: auto
+    target-branch: main


### PR DESCRIPTION
## Change Summary

I've noticed that dependabot isn't opening PRs for any of our test dependencies. As per https://github.com/dependabot/dependabot-core/issues/2824 it looks like we have to explicitly add it as a separate entry in the config file.

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
