### PR TITLE
fix(ci): Docker build issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -289,5 +289,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Docker Build
         # Use --% to allow double hyphen
+        # Caching not currently working since we don't use buildx yet, windows
+        # support seems poor because of interactions with --prvileged
+        # --cache-from=type=gha --cache-to=type=gha,mode=max
         run: |
-          docker build --% -f tests/windows.Dockerfile -t prisma-client-py --cache-from=type=gha --cache-to=type=gha,mode=max .
+          docker build --% -f tests/windows.Dockerfile -t prisma-client-py .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -274,7 +274,11 @@ jobs:
           file: tests/Dockerfile
           platforms: "${{ matrix.docker-platform }}"
           build-args: OS_DISTRO=${{ matrix.python-os-distro }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
+  # Note: Windows does not play well with the standard GH Docker + buildx
+  # actions
   docker-windows:
     name: docker (windows)
     runs-on: windows-latest
@@ -282,19 +286,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Docker Build
         run: |
-          docker build -f tests/windows.Dockerfile -t prisma-client-py .
-  docker-windows-experimental:
-    name: docker (windows experimental)
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Docker Build
-        uses: docker/build-push-action@v3
-        # https://github.com/docker/build-push-action/#inputs
-        # Test each platform individually for easier testing
-        with:
-          context: .
-          file: tests/Dockerfile
-          platforms: windows/amd64
+          docker build \
+            -f tests/windows.Dockerfile \
+            -t prisma-client-py \
+            --cache-from=type=gha \
+            --cache-to=type=gha,mode=max \
+            .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -257,7 +257,10 @@ jobs:
         # TODO: Uncomment this to add testing support for arm64 and delete
         # the above
         # docker-platform: ["linux/amd64", "linux/arm64"]
-        python-os-distro: [slim-bullseye, alpine]
+        # TODO: Uncomment this later, Go-based CLI does not run on Alpine
+        # https://github.com/prisma/prisma-client-go/issues/357
+        # python-os-distro: [slim-bullseye, alpine]
+        python-os-distro: [slim-bullseye]
     steps:
       - uses: actions/checkout@v3
       # https://github.com/docker/build-push-action/
@@ -285,10 +288,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Docker Build
+        # Use --% to allow double hyphen
         run: |
-          docker build \
-            -f tests/windows.Dockerfile \
-            -t prisma-client-py \
-            --cache-from=type=gha \
-            --cache-to=type=gha,mode=max \
-            .
+          docker build --% -f tests/windows.Dockerfile -t prisma-client-py --cache-from=type=gha --cache-to=type=gha,mode=max .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,6 @@ on:
       - "LICENSE"
       - "mkdocs.yml"
   pull_request:
-    branches:
-      - main
     paths-ignore:
       - "*.md"
       - ".vscode/**"
@@ -255,11 +253,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        docker-platform: ["linux/amd64"]
+        docker-platform: [linux/amd64]
         # TODO: Uncomment this to add testing support for arm64 and delete
         # the above
         # docker-platform: ["linux/amd64", "linux/arm64"]
-        python-os-distro: ["slim-bullseye", "alpine"]
+        python-os-distro: [slim-bullseye, alpine]
     steps:
       - uses: actions/checkout@v3
       # https://github.com/docker/build-push-action/
@@ -275,14 +273,28 @@ jobs:
           context: .
           file: tests/Dockerfile
           platforms: "${{ matrix.docker-platform }}"
-          build-args: "${{ matrix.python-os-distro }}"
+          build-args: OS_DISTRO=${{ matrix.python-os-distro }}
 
   docker-windows:
     name: docker (windows)
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-
       - name: Docker Build
         run: |
           docker build -f tests/windows.Dockerfile -t prisma-client-py .
+  docker-windows-experimental:
+    name: docker (windows experimental)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Docker Build
+        uses: docker/build-push-action@v3
+        # https://github.com/docker/build-push-action/#inputs
+        # Test each platform individually for easier testing
+        with:
+          context: .
+          file: tests/Dockerfile
+          platforms: windows/amd64

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -6,7 +6,41 @@ ARG OS_DISTRO=slim-bullseye
 
 FROM python:${PYTHON_VERSION}-${OS_DISTRO}
 
-RUN useradd --create-home --uid 9999 --shell /bin/bash prisma
+# These are are own build args recorded as env variables
+ARG OS_DISTRO
+ENV OS_DISTRO=${OS_DISTRO}
+ENV PRISMA_USER_ID=9999
+
+# These are provided by Docker
+ARG BUILDPLATFORM
+ARG BUILDOS
+ARG BUILDARCH
+ARG BUILDVARIANT
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
+ENV DOCKER_BUILDPLATFORM=${BUILDPLATFORM}
+ENV DOCKER_BUILDOS=${BUILDOS}
+ENV DOCKER_BUILDARCH=${BUILDARCH}
+ENV DOCKER_BUILDVARIANT=${BUILDVARIANT}
+ENV DOCKER_TARGETPLATFORM=${TARGETPLATFORM}
+ENV DOCKER_TARGETOS=${TARGETOS}
+ENV DOCKER_TARGETARCH=${TARGETARCH}
+
+# TODO: Using the slim variant is a bit hackier. Better to
+# cat and grep /etc/*release*. Also, the [[ ]] command
+# is a bash thing so thats why we subshell for the test
+RUN \
+    if [[ $OS_DISTRO =~ alpine ]]; then \
+    adduser -u ${PRISMA_USER_ID} -D prisma; \
+    apk add gcc musl-dev yaml-dev yaml libffi-dev; \
+    elif bash -c "[[ ${OS_DISTRO} =~ slim ]]"; then \
+    useradd --create-home --uid ${PRISMA_USER_ID} --shell /bin/bash prisma; \
+    else \
+    echo "Unrecognized distro $OS_DISTRO"; \
+    exit 99; \
+    fi
 
 USER prisma
 WORKDIR /home/prisma/prisma-client-py
@@ -14,7 +48,8 @@ ENV PATH="/home/prisma/.local/bin:${PATH}"
 
 COPY --chown=prisma:prisma . .
 
-RUN pip install .
+RUN pip install --upgrade pip && \
+    pip install .[dev]
 
 # This has the side-effect of downing the prisma binaries
 # and will fail if the CLI cannot get run

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -33,13 +33,13 @@ ENV DOCKER_TARGETARCH=${TARGETARCH}
 # is a bash thing so thats why we subshell for the test
 RUN \
     if [[ $OS_DISTRO =~ alpine ]]; then \
-    adduser -u ${PRISMA_USER_ID} -D prisma; \
-    apk add gcc musl-dev yaml-dev yaml libffi-dev; \
+      adduser -u ${PRISMA_USER_ID} -D prisma; \
+      apk add gcc musl-dev yaml-dev yaml libffi-dev; \
     elif bash -c "[[ ${OS_DISTRO} =~ slim ]]"; then \
-    useradd --create-home --uid ${PRISMA_USER_ID} --shell /bin/bash prisma; \
+      useradd --create-home --uid ${PRISMA_USER_ID} --shell /bin/bash prisma; \
     else \
-    echo "Unrecognized distro $OS_DISTRO"; \
-    exit 99; \
+      echo "Unrecognized distro $OS_DISTRO"; \
+      exit 99; \
     fi
 
 USER prisma

--- a/tests/windows.Dockerfile
+++ b/tests/windows.Dockerfile
@@ -4,6 +4,8 @@
 
 FROM winamd64/python:3.10
 
+ENV PRISMA_PY_DEBUG=1
+
 WORKDIR /home/prisma/prisma-client-py
 
 RUN pip install certifi

--- a/tests/windows.Dockerfile
+++ b/tests/windows.Dockerfile
@@ -6,9 +6,28 @@ FROM winamd64/python:3.10
 
 WORKDIR /home/prisma/prisma-client-py
 
+RUN pip install certifi
+
+# Santity check of powershell invocation
+RUN python -c \"import certifi; certifi.where()\"
+
+# https://learn.microsoft.com/en-us/powershell/module/pki/import-certificate?view=windowsserver2022-ps
+# Import to the system root -- this should be enough?
+RUN Set-PSDebug -Trace 2; \
+    $CERTIFI_LOCATION = python -c \"import certifi; print(certifi.where())\"; \
+    Import-Certificate \
+    -FilePath $CERTIFI_LOCATION \
+    -CertStoreLocation Cert:\LocalMachine\Root\;
+
+# Imports the cert into the "local" trust store, whatever that means (user specific?)
+RUN Set-PSDebug -Trace 2; \
+    $CERTIFI_LOCATION = python -c \"import certifi; print(certifi.where())\"; \
+    Import-Certificate \
+    -FilePath $CERTIFI_LOCATION;
+
 COPY . .
 
-RUN pip install .
+RUN pip install .[dev]
 
 # This has the side-effect of downing the prisma binaries
 # and will fail if the CLI cannot get run

--- a/tests/windows.Dockerfile
+++ b/tests/windows.Dockerfile
@@ -8,25 +8,8 @@ ENV PRISMA_PY_DEBUG=1
 
 WORKDIR /home/prisma/prisma-client-py
 
-RUN pip install certifi
-
-# Santity check of powershell invocation
-RUN python -c \"import certifi; certifi.where()\"
-
-# https://learn.microsoft.com/en-us/powershell/module/pki/import-certificate?view=windowsserver2022-ps
-# Import to the system root -- this should be enough?
-RUN Set-PSDebug -Trace 2; \
-    $CERTIFI_LOCATION = python -c \"import certifi; print(certifi.where())\"; \
-    Import-Certificate \
-    -FilePath $CERTIFI_LOCATION \
-    -CertStoreLocation Cert:\LocalMachine\Root\;
-
-# Imports the cert into the "local" trust store, whatever that means (user specific?)
-# This is currently not working
-# RUN Set-PSDebug -Trace 2; \
-#     $CERTIFI_LOCATION = python -c \"import certifi; print(certifi.where())\"; \
-#     Import-Certificate \
-#     -FilePath $CERTIFI_LOCATION;
+# https://github.com/docker-library/python/issues/359
+RUN certutil -generateSSTFromWU roots.sst; certutil -addstore -f root roots.sst;  del roots.sst
 
 COPY . .
 

--- a/tests/windows.Dockerfile
+++ b/tests/windows.Dockerfile
@@ -22,10 +22,11 @@ RUN Set-PSDebug -Trace 2; \
     -CertStoreLocation Cert:\LocalMachine\Root\;
 
 # Imports the cert into the "local" trust store, whatever that means (user specific?)
-RUN Set-PSDebug -Trace 2; \
-    $CERTIFI_LOCATION = python -c \"import certifi; print(certifi.where())\"; \
-    Import-Certificate \
-    -FilePath $CERTIFI_LOCATION;
+# This is currently not working
+# RUN Set-PSDebug -Trace 2; \
+#     $CERTIFI_LOCATION = python -c \"import certifi; print(certifi.where())\"; \
+#     Import-Certificate \
+#     -FilePath $CERTIFI_LOCATION;
 
 COPY . .
 


### PR DESCRIPTION
## Change Summary

* Fix issue with testing alpine-based docker in CI. However, since the Go Prisma CLI does not work on Alpine, I had to disable the test as it fails
* Start to set up PKI machinery for Windows to deal with nodeenv downloads -- unclear why we need this but starts to put the infrasctructure there inc ase we need it
* Implement better caching to speed up docker build times -- but does not work on Windows since we don't have buildx so we won't see an improvement there

In the initial PR (#521) where I added Docker-based CI I forgot to pass through the Docker build arg with `=` -- so the variation we wanted to test on Alpine was not working as expected. This PR fixes that, so that the `OS_DISTRO` is properly populated

## Checklist

- [X] Unit tests for the changes exist
- [X] Tests pass without significant drop in coverage
- [X] Documentation reflects changes where applicable
- [X] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
