### PR TITLE
feat(ci): add action to test documentation building

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,35 @@
+name: Docs
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - ".vscode/**"
+      - "LICENSE"
+  pull_request:
+    paths-ignore:
+      - ".vscode/**"
+      - "LICENSE"
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[docs]
+
+      # this is a basic test to ensure there are no warnings are generated
+      # TODO: upload built docs
+      - name: Build documentation
+        run: |
+          make docs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,8 @@ site_author: Robert Craigie
 repo_name: RobertCraigie/prisma-client-py
 repo_url: https://github.com/RobertCraigie/prisma-client-py
 
+strict: true
+
 theme:
   name: material
   palette:


### PR DESCRIPTION
## Change Summary

This PR adds a new `docs` action that simply builds the documentation to ensure there are no warnings generated. This will be useful for testing Dependabot PRs that update a documentation dependency.

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
