### PR TITLE
chore(tests): disable snapshot diffs

### DIFF
--- a/tests/test_generation/exhaustive/test_exhaustive.py
+++ b/tests/test_generation/exhaustive/test_exhaustive.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import sys
 import subprocess
 from pathlib import Path
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, Iterator, List, Optional
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -30,6 +32,18 @@ class OSAgnosticSingleFileExtension(SingleFileSnapshotExtension):
             data, exclude=exclude, matcher=matcher
         )
         return bytes(serialized, 'utf-8')
+
+    # we disable diffs as we don't really care what the diff is
+    # we just care that there is a diff and it can take a very
+    # long time for syrupy to calculate the diff
+    # https://github.com/tophat/syrupy/issues/581
+    def diff_snapshots(self, serialized_data: Any, snapshot_data: Any) -> str:
+        return 'diff-is-disabled'
+
+    def diff_lines(
+        self, serialized_data: Any, snapshot_data: Any
+    ) -> Iterator[str]:
+        yield 'diff-is-disabled'
 
 
 @pytest.fixture


### PR DESCRIPTION
## Change Summary

This PR disables the creation of diffs for our snapshot tests on the generated client code. This is because it can take a *long* time to generate this diff in CI and we don't really care what the actual diff is, we just need to know that there is a difference.

https://github.com/tophat/syrupy/issues/581

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
