### PR TITLE
fix(generator): validate model name is not a reserved keyword

### DIFF
--- a/src/prisma/generator/models.py
+++ b/src/prisma/generator/models.py
@@ -564,6 +564,23 @@ class Model(BaseModel):
         super().__init__(**data)
         self._sampler = Sampler(self)
 
+    @validator('name')
+    @classmethod
+    def name_validator(cls, name: str) -> str:
+        if iskeyword(name):
+            raise ValueError(
+                f'Model name "{name}" shadows a Python keyword; '
+                f'use a different model name with \'@@map("{name}")\'.'
+            )
+
+        if iskeyword(name.lower()):
+            raise ValueError(
+                f'Model name "{name}" results in a client property that shadows a Python keyword; '
+                f'use a different model name with \'@@map("{name}")\'.'
+            )
+
+        return name
+
     @root_validator(allow_reuse=True)
     @classmethod
     def validate_compound_constraints_are_unique(

--- a/tests/test_generation/test_validation.py
+++ b/tests/test_generation/test_validation.py
@@ -23,6 +23,46 @@ def assert_no_generator_output(output: str) -> None:
     assert 'prisma:GeneratorProcess' not in _remove_coverage_warnings(output)
 
 
+def test_model_name_python_keyword(testdir: Testdir) -> None:
+    """Model name shadowing a python keyword is not allowed"""
+    schema = (
+        testdir.SCHEMA_HEADER
+        + """
+        model from {{
+            id   String @id
+            name String
+        }}
+    """
+    )
+    with pytest.raises(subprocess.CalledProcessError) as exc:
+        testdir.generate(schema=schema)
+
+    assert (
+        'Model name "from" shadows a Python keyword; use a different model name with \'@@map("from")\''
+        in str(exc.value.output, 'utf-8')
+    )
+
+
+def test_model_name_lowercase_python_keyword(testdir: Testdir) -> None:
+    """Model name that when transformed to lowercase a python keyword is not allowed"""
+    schema = (
+        testdir.SCHEMA_HEADER
+        + """
+        model Class {{
+            id   String @id
+            name String
+        }}
+    """
+    )
+    with pytest.raises(subprocess.CalledProcessError) as exc:
+        testdir.generate(schema=schema)
+
+    assert (
+        'Model name "Class" results in a client property that shadows a Python keyword; use a different model name with \'@@map("Class")\''
+        in str(exc.value.output, 'utf-8')
+    )
+
+
 def test_field_name_basemodel_attribute(testdir: Testdir) -> None:
     """Field name shadowing a basemodel attribute is not allowed"""
     schema = (


### PR DESCRIPTION
## Change Summary

closes #594

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
