### PR TITLE
feat(coverage): store coverage reports too

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -31,6 +31,7 @@ exclude_lines =
     \.\.\.
 
 partial_branches =
+    pragma: no branch
     if not TYPE_CHECKING:
 
 [paths]

--- a/.coveragerc
+++ b/.coveragerc
@@ -30,6 +30,9 @@ exclude_lines =
     if TYPE_CHECKING
     \.\.\.
 
+partial_branches =
+    if not TYPE_CHECKING:
+
 [paths]
 prisma =
     src/prisma

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,10 +174,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-mypy
 
-      # TODO: add codecov for our mypy plugin
       - name: Check Mypy
         run: |
           nox -s mypy
+
+      - name: Upload coverage
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-data
+          path: ".cache/.coverage*"
 
   databases:
     name: ${{ matrix.name }} ${{ matrix.version }}
@@ -251,7 +256,7 @@ jobs:
   coverage:
     name: coverage
     runs-on: ubuntu-latest
-    needs: [databases, test]
+    needs: [databases, test, mypy]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,19 +174,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-mypy
 
+      # TODO: figure out how to get coverage for the mypy plugin
       - name: Check Mypy
         run: |
           nox -s mypy
-
-      - name: Debug
-        run: |
-          ls -a -R .cache
-
-      - name: Upload coverage
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage-data
-          path: ".cache/.coverage*"
 
   databases:
     name: ${{ matrix.name }} ${{ matrix.version }}
@@ -260,7 +251,7 @@ jobs:
   coverage:
     name: coverage
     runs-on: ubuntu-latest
-    needs: [databases, test, mypy]
+    needs: [databases, test]
     steps:
       - uses: actions/checkout@v3
 
@@ -292,7 +283,7 @@ jobs:
           path: htmlcov
 
       - name: Update static coverage
-        if: (success() || failure()) && github.repository == 'RobertCraigie/prisma-client-py'
+        if: (success() || failure()) && github.ref == 'refs/heads/main' && github.repository == 'RobertCraigie/prisma-client-py'
         run: |
           nox -s push-coverage
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -178,6 +178,10 @@ jobs:
         run: |
           nox -s mypy
 
+      - name: Debug
+        run: |
+          ls -a -R .cache
+
       - name: Upload coverage
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -288,7 +288,7 @@ jobs:
           path: htmlcov
 
       - name: Update static coverage
-        if: (success() || failure()) && github.ref == 'refs/heads/main' && github.repository == 'RobertCraigie/prisma-client-py'
+        if: (success() || failure()) && github.repository == 'RobertCraigie/prisma-client-py'
         run: |
           nox -s push-coverage
 

--- a/databases/main.py
+++ b/databases/main.py
@@ -68,7 +68,7 @@ def test(
     with session.chdir(DATABASES_DIR):
         # setup env
         session.install('-r', 'requirements.txt')
-        if inplace:
+        if inplace:  # pragma: no cover
             # useful for updating the generated code so that Pylance picks it up
             session.install('-U', '-e', '..')
         else:
@@ -81,16 +81,16 @@ def test(
 
             # point coverage to store data in a database specific location
             # as to not overwrite any existing data from other database tests
-            if coverage:
+            if coverage:  # pragma: no branch
                 setup_coverage(session, identifier=database)
 
             runner = Runner(database=database, track_coverage=coverage)
             runner.setup()
 
-            if test:
+            if test:  # pragma: no branch
                 runner.test(pytest_args=pytest_args)
 
-            if lint:
+            if lint:  # pragma: no branch
                 runner.lint()
 
 
@@ -122,7 +122,7 @@ class Runner:
 
     def _create_cache_dir(self) -> None:
         cache_dir = self.cache_dir
-        if cache_dir.exists():
+        if cache_dir.exists():  # pragma: no cover
             shutil.rmtree(cache_dir)
 
         cache_dir.mkdir(parents=True, exist_ok=True)
@@ -186,7 +186,7 @@ class Runner:
         )
 
         args = []
-        if pytest_args is not None:
+        if pytest_args is not None:  # pragma: no cover
             args = shlex.split(pytest_args)
 
         # TODO: use PYTEST_ADDOPTS instead
@@ -257,7 +257,7 @@ def validate_database(database: str) -> SupportedDatabase:
     # We convert the input to lowercase so that we don't have to define
     # two separate names in the CI matrix.
     database = database.lower()
-    if database not in SUPPORTED_DATABASES:
+    if database not in SUPPORTED_DATABASES:  # pragma: no cover
         raise ValueError(f'Unknown database: {database}')
 
     return cast(SupportedDatabase, database)
@@ -303,7 +303,3 @@ def entrypoint(session: nox.Session) -> None:
     # copy the current context so that the session object is not leaked
     ctx = copy_context()
     return ctx.run(wrapper)
-
-
-if __name__ == '__main__':
-    cli()

--- a/pipelines/coverage.nox.py
+++ b/pipelines/coverage.nox.py
@@ -59,7 +59,7 @@ def push_coverage(session: nox.Session) -> None:
 
     print(git.status())
 
-    git.add('htmlcov/*')
+    git.add('htmlcov/')
     git.add('coverage.svg')
 
     if not repo.is_dirty():

--- a/pipelines/coverage.nox.py
+++ b/pipelines/coverage.nox.py
@@ -70,7 +70,7 @@ def push_coverage(session: nox.Session) -> None:
             '41898282+github-actions[bot]@users.noreply.github.com',
         )
 
-    git.add('htmlcov')
+    git.add('htmlcov/*')
     git.add('coverage.svg')
     git.commit(
         m=head_summary,

--- a/pipelines/coverage.nox.py
+++ b/pipelines/coverage.nox.py
@@ -59,6 +59,9 @@ def push_coverage(session: nox.Session) -> None:
 
     print(git.status())
 
+    git.add('htmlcov/*')
+    git.add('coverage.svg')
+
     if not repo.is_dirty():
         print('No changes!')
         return
@@ -70,8 +73,6 @@ def push_coverage(session: nox.Session) -> None:
             '41898282+github-actions[bot]@users.noreply.github.com',
         )
 
-    git.add('htmlcov/*')
-    git.add('coverage.svg')
     git.commit(
         m=head_summary,
         env={

--- a/pipelines/coverage.nox.py
+++ b/pipelines/coverage.nox.py
@@ -45,7 +45,7 @@ def push_coverage(session: nox.Session) -> None:
     git.checkout(f'origin/{BADGE_BRANCH}', b=BADGE_BRANCH)
 
     # ensure only the files relevant to the static branch will be present
-    git.rm('-rf')
+    git.rm('-rf', '.')
 
     shutil.copy(TMP_SVG_PATH, 'coverage.svg')
 

--- a/pipelines/coverage.nox.py
+++ b/pipelines/coverage.nox.py
@@ -52,6 +52,8 @@ def push_coverage(session: nox.Session) -> None:
 
     shutil.copytree(TMP_HTMLCOV_PATH, htmlcov)
 
+    print(git.status())
+
     if not repo.is_dirty(untracked_files=True):
         print('No changes!')
         return

--- a/pipelines/coverage.nox.py
+++ b/pipelines/coverage.nox.py
@@ -45,7 +45,7 @@ def push_coverage(session: nox.Session) -> None:
     git.checkout(f'origin/{BADGE_BRANCH}', b=BADGE_BRANCH)
 
     shutil.copy(svg_path, 'coverage.svg')
-    shutil.copy(htmlcov_path, 'htmlcov')
+    shutil.copytree(htmlcov_path, 'htmlcov')
 
     if not repo.is_dirty(untracked_files=True):
         print('No changes!')

--- a/pipelines/coverage.nox.py
+++ b/pipelines/coverage.nox.py
@@ -130,3 +130,6 @@ def report_strict(session: nox.Session) -> None:
         '--include=databases/tests/**',
         '--fail-under=100',
     )
+
+    # output overall coverage
+    session.run('coverage', 'report', '-i', '--skip-covered')

--- a/pipelines/coverage.nox.py
+++ b/pipelines/coverage.nox.py
@@ -44,6 +44,9 @@ def push_coverage(session: nox.Session) -> None:
     git.fetch('--all')
     git.checkout(f'origin/{BADGE_BRANCH}', b=BADGE_BRANCH)
 
+    # ensure only the files relevant to the static branch will be present
+    git.rm('-rf')
+
     shutil.copy(TMP_SVG_PATH, 'coverage.svg')
 
     htmlcov = Path.cwd() / 'htmlcov'
@@ -59,7 +62,7 @@ def push_coverage(session: nox.Session) -> None:
 
     print(git.status())
 
-    git.add('htmlcov/')
+    git.add('-f', 'htmlcov/*')
     git.add('coverage.svg')
 
     if not repo.is_dirty():

--- a/pipelines/coverage.nox.py
+++ b/pipelines/coverage.nox.py
@@ -51,17 +51,13 @@ def push_coverage(session: nox.Session) -> None:
 
     htmlcov = Path.cwd() / 'htmlcov'
     if htmlcov.exists():
+        # remove the `htmlcov` directory in case it exists so that we
+        # don't include now redundant files.
         shutil.rmtree(htmlcov)
 
     shutil.copytree(TMP_HTMLCOV_PATH, htmlcov)
 
-    print('\n----- debug ----')
-    for p in htmlcov.iterdir():
-        print(p)
-    print('----- debug ----\n')
-
-    print(git.status())
-
+    # stage potential changes
     git.add('-f', 'htmlcov/*')
     git.add('coverage.svg')
 

--- a/pipelines/coverage.nox.py
+++ b/pipelines/coverage.nox.py
@@ -24,11 +24,13 @@ def push_coverage(session: nox.Session) -> None:
     )
 
     svg_path = TMP_DIR / 'coverage.svg'
-
     with session.chdir(CACHE_DIR):
         session.run(
             'coverage-badge', '-o', str(svg_path), '--cov-ignore-errors'
         )
+
+    htmlcov_path = TMP_DIR / 'htmlcov'
+    shutil.copytree('htmlcov', htmlcov_path)
 
     repo = Repo(Path.cwd())
     if repo.is_dirty():
@@ -42,6 +44,9 @@ def push_coverage(session: nox.Session) -> None:
     git.fetch('--all')
     git.checkout(f'origin/{BADGE_BRANCH}', b=BADGE_BRANCH)
 
+    shutil.copy(svg_path, 'coverage.svg')
+    shutil.copy(htmlcov_path, 'htmlcov')
+
     if not repo.is_dirty(untracked_files=True):
         print('No changes!')
         return
@@ -53,8 +58,7 @@ def push_coverage(session: nox.Session) -> None:
             '41898282+github-actions[bot]@users.noreply.github.com',
         )
 
-    shutil.copy(svg_path, 'coverage.svg')
-
+    git.add('htmlcov')
     git.add('coverage.svg')
     git.commit(
         m=head_summary,

--- a/pipelines/coverage.nox.py
+++ b/pipelines/coverage.nox.py
@@ -52,9 +52,14 @@ def push_coverage(session: nox.Session) -> None:
 
     shutil.copytree(TMP_HTMLCOV_PATH, htmlcov)
 
+    print('\n----- debug ----')
+    for p in htmlcov.iterdir():
+        print(p)
+    print('----- debug ----\n')
+
     print(git.status())
 
-    if not repo.is_dirty(untracked_files=True):
+    if not repo.is_dirty():
         print('No changes!')
         return
 


### PR DESCRIPTION
## Change Summary

This PR includes the generated `htmlcov` report in the `static/coverage` branch and improves coverage in some small areas.

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
