### PR TITLE
feat(proxy): add helper method for casting types and tests

### DIFF
--- a/src/prisma/_config.py
+++ b/src/prisma/_config.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Union, cast
+from typing import TYPE_CHECKING, Union
 
 import tomlkit
 from pydantic import BaseSettings, Extra, Field

--- a/src/prisma/_config.py
+++ b/src/prisma/_config.py
@@ -98,4 +98,4 @@ class LazyConfigProxy(LazyProxy[Config]):
         return Config.load()
 
 
-config: Config = cast(Config, LazyConfigProxy())
+config = LazyConfigProxy().__as_proxied__()

--- a/src/prisma/_config.py
+++ b/src/prisma/_config.py
@@ -98,4 +98,4 @@ class LazyConfigProxy(LazyProxy[Config]):
         return Config.load()
 
 
-config = LazyConfigProxy().__as_proxied__()
+config: Config = LazyConfigProxy().__as_proxied__()

--- a/src/prisma/_proxy.py
+++ b/src/prisma/_proxy.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar
+from typing import Generic, Iterable, TypeVar, cast
 
 
 T = TypeVar('T')
 
 
-# TODO: ensure things like __name__, __dir__ are proxied correctly
+# NOTE: this is not an exhaustive list of supported data methods.
+# Feel free to add any more if need be.
+
+
 class LazyProxy(Generic[T], ABC):
     def __init__(self) -> None:
         self.__proxied: T | None = None
@@ -21,6 +24,9 @@ class LazyProxy(Generic[T], ABC):
     def __str__(self) -> str:
         return str(self.__get_proxied())
 
+    def __dir__(self) -> Iterable[str]:
+        return self.__get_proxied().__dir__()
+
     def __get_proxied(self) -> T:
         proxied = self.__proxied
         if proxied is not None:
@@ -28,6 +34,10 @@ class LazyProxy(Generic[T], ABC):
 
         self.__proxied = proxied = self.__load__()
         return proxied
+
+    def __as_proxied__(self) -> T:
+        """Helper method that returns the current proxy, typed as the loaded object"""
+        return cast(T, self)
 
     @abstractmethod
     def __load__(self) -> T:

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,4 +1,4 @@
-from typing import final
+from typing_extensions import final
 
 from pytest_mock import MockerFixture
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,0 +1,50 @@
+from typing import final
+
+from pytest_mock import MockerFixture
+
+from prisma._proxy import LazyProxy
+
+
+class MyObject:
+    def __repr__(self) -> str:
+        return '<MyObject foo!>'
+
+    def __str__(self) -> str:
+        return 'foo!'
+
+    @property
+    def foo(self) -> str:
+        return 'FOO'
+
+
+@final
+class MyProxy(LazyProxy[MyObject]):
+    def __load__(self) -> MyObject:
+        return MyObject()
+
+
+def test_proxied_data_methods() -> None:
+    """Supported data methods work as expected"""
+    obj = MyProxy().__as_proxied__()
+    assert str(obj) == 'foo!'
+    assert repr(obj) == '<MyObject foo!>'
+
+    props = [p for p in dir(obj) if not p.startswith('_')]
+    assert props == ['foo']
+
+
+def test_proxied_properties() -> None:
+    """Ensure properties can be accessed"""
+    obj = MyProxy().__as_proxied__()
+    assert obj.foo == 'FOO'
+
+
+def test_load_once(mocker: MockerFixture) -> None:
+    """The `__load__` function is only called once for multiple proxy attribute accesses"""
+    obj = MyProxy().__as_proxied__()
+    spy = mocker.spy(MyProxy, '__load__')
+
+    assert obj.foo == 'FOO'
+    assert obj.foo == 'FOO'
+
+    assert spy.call_count == 1


### PR DESCRIPTION
## Change Summary

This PR improves our internal proxy type:

- adds an `__as_proxied__` method that performs type casting for you.
- adds unit tests

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
