### PR TITLE
fix(partials): remove data leak when modifying relational types

### DIFF
--- a/pipelines/coverage.nox.py
+++ b/pipelines/coverage.nox.py
@@ -130,16 +130,19 @@ def report_strict(session: nox.Session) -> None:
     _setup_report(session)
 
     # core tests
+    omit_files = [
+        # integration tests are broken
+        'tests/integrations/conftest.py'
+        # difficult to run under coverage + not valuable to figure out
+        'tests/test_generation/exhaustive/partials.py',
+    ]
     session.run(
         'coverage',
         'report',
         '-i',
         '--skip-covered',
         '--include=tests/**',
-        # integration tests are broken
-        '--omit=tests/integrations/conftest.py',
-        # difficult to run under coverage + not valuable to figure out
-        '--omit=tests/test_generation/exhaustive/partials.py',
+        f'--omit={",".join(omit_files)}',
         '--fail-under=100',
     )
 

--- a/pipelines/coverage.nox.py
+++ b/pipelines/coverage.nox.py
@@ -132,7 +132,7 @@ def report_strict(session: nox.Session) -> None:
     # core tests
     omit_files = [
         # integration tests are broken
-        'tests/integrations/conftest.py'
+        'tests/integrations/conftest.py',
         # difficult to run under coverage + not valuable to figure out
         'tests/test_generation/exhaustive/partials.py',
     ]

--- a/pipelines/coverage.nox.py
+++ b/pipelines/coverage.nox.py
@@ -138,6 +138,8 @@ def report_strict(session: nox.Session) -> None:
         '--include=tests/**',
         # integration tests are broken
         '--omit=tests/integrations/conftest.py',
+        # difficult to run under coverage + not valuable to figure out
+        '--omit=tests/test_generation/exhaustive/partials.py',
         '--fail-under=100',
     )
 

--- a/src/prisma/generator/templates/models.py.jinja
+++ b/src/prisma/generator/templates/models.py.jinja
@@ -5,6 +5,8 @@ import os
 import logging
 import inspect
 import warnings
+from collections import OrderedDict
+
 from pydantic import BaseConfig, BaseModel, Field, validator
 
 from . import types, enums, errors, fields
@@ -144,7 +146,7 @@ class {{ model.name }}(BaseModel):
                 'exclude_relational_fields and relations are mutually exclusive'
             )
 
-        fields: Dict['types.{{ model.name }}Keys', PartialModelField] = {}
+        fields: Dict['types.{{ model.name }}Keys', PartialModelField] = OrderedDict()
 
         try:
             if include:
@@ -233,17 +235,19 @@ class {{ model.name }}(BaseModel):
 {% else -%}
     _{{ model.name }}_relational_fields: Set[str] = set()  # pyright: ignore[reportUnusedVariable]
 {% endif %}
-_{{ model.name }}_fields: Dict['types.{{ model.name }}Keys', PartialModelField] = {
-    {% for field in model.all_fields %}
-    '{{ field.name }}': {
-        'name': '{{ field.name }}',
-        'is_list': {{ field.is_list }},
-        'optional': {{ field.is_optional }},
-        'type': {{ field.python_type_as_string }},
-        'documentation': {% if field.documentation is none %}None{% else %}'''{{ field.documentation }}'''{% endif %},
-    },
-    {% endfor %}
-}
+_{{ model.name }}_fields: Dict['types.{{ model.name }}Keys', PartialModelField] = OrderedDict(
+    [
+        {% for field in model.all_fields %}
+        ('{{ field.name }}', {
+            'name': '{{ field.name }}',
+            'is_list': {{ field.is_list }},
+            'optional': {{ field.is_optional }},
+            'type': {{ field.python_type_as_string }},
+            'documentation': {% if field.documentation is none %}None{% else %}'''{{ field.documentation }}'''{% endif %},
+        }),
+        {% endfor %}
+    ],
+)
 
 {% endfor %}
 

--- a/src/prisma/generator/templates/models.py.jinja
+++ b/src/prisma/generator/templates/models.py.jinja
@@ -149,28 +149,29 @@ class {{ model.name }}(BaseModel):
         try:
             if include:
                 for field in include:
-                    fields[field] = _{{ model.name }}_fields[field]
+                    fields[field] = _{{ model.name }}_fields[field].copy()
             elif exclude:
                 for field in exclude:
                     if field not in _{{ model.name }}_fields:
                         raise KeyError(field)
 
                 fields = {
-                    key: data
+                    key: data.copy()
                     for key, data in _{{ model.name }}_fields.items()
                     if key not in exclude
                 }
             else:
-                fields = _{{ model.name }}_fields.copy()
+                fields = {
+                    key: data.copy()
+                    for key, data in _{{ model.name }}_fields.items()
+                }
 
             if required:
                 for field in required:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = False
 
             if optional:
                 for field in optional:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = True
 
             {% if model.has_relational_fields %}

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[models.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[models.py].raw
@@ -39,6 +39,8 @@ import os
 import logging
 import inspect
 import warnings
+from collections import OrderedDict
+
 from pydantic import BaseConfig, BaseModel, Field, validator
 
 from . import types, enums, errors, fields
@@ -166,7 +168,7 @@ class Post(BaseModel):
                 'exclude_relational_fields and relations are mutually exclusive'
             )
 
-        fields: Dict['types.PostKeys', PartialModelField] = {}
+        fields: Dict['types.PostKeys', PartialModelField] = OrderedDict()
 
         try:
             if include:
@@ -310,7 +312,7 @@ class User(BaseModel):
                 'exclude_relational_fields and relations are mutually exclusive'
             )
 
-        fields: Dict['types.UserKeys', PartialModelField] = {}
+        fields: Dict['types.UserKeys', PartialModelField] = OrderedDict()
 
         try:
             if include:
@@ -450,7 +452,7 @@ class M(BaseModel):
                 'exclude_relational_fields and relations are mutually exclusive'
             )
 
-        fields: Dict['types.MKeys', PartialModelField] = {}
+        fields: Dict['types.MKeys', PartialModelField] = OrderedDict()
 
         try:
             if include:
@@ -592,7 +594,7 @@ class N(BaseModel):
                 'exclude_relational_fields and relations are mutually exclusive'
             )
 
-        fields: Dict['types.NKeys', PartialModelField] = {}
+        fields: Dict['types.NKeys', PartialModelField] = OrderedDict()
 
         try:
             if include:
@@ -732,7 +734,7 @@ class OneOptional(BaseModel):
                 'exclude_relational_fields and relations are mutually exclusive'
             )
 
-        fields: Dict['types.OneOptionalKeys', PartialModelField] = {}
+        fields: Dict['types.OneOptionalKeys', PartialModelField] = OrderedDict()
 
         try:
             if include:
@@ -873,7 +875,7 @@ class ManyRequired(BaseModel):
                 'exclude_relational_fields and relations are mutually exclusive'
             )
 
-        fields: Dict['types.ManyRequiredKeys', PartialModelField] = {}
+        fields: Dict['types.ManyRequiredKeys', PartialModelField] = OrderedDict()
 
         try:
             if include:
@@ -1011,7 +1013,7 @@ class Lists(BaseModel):
                 'exclude_relational_fields and relations are mutually exclusive'
             )
 
-        fields: Dict['types.ListsKeys', PartialModelField] = {}
+        fields: Dict['types.ListsKeys', PartialModelField] = OrderedDict()
 
         try:
             if include:
@@ -1124,7 +1126,7 @@ class A(BaseModel):
                 'exclude_relational_fields and relations are mutually exclusive'
             )
 
-        fields: Dict['types.AKeys', PartialModelField] = {}
+        fields: Dict['types.AKeys', PartialModelField] = OrderedDict()
 
         try:
             if include:
@@ -1233,7 +1235,7 @@ class B(BaseModel):
                 'exclude_relational_fields and relations are mutually exclusive'
             )
 
-        fields: Dict['types.BKeys', PartialModelField] = {}
+        fields: Dict['types.BKeys', PartialModelField] = OrderedDict()
 
         try:
             if include:
@@ -1343,7 +1345,7 @@ class C(BaseModel):
                 'exclude_relational_fields and relations are mutually exclusive'
             )
 
-        fields: Dict['types.CKeys', PartialModelField] = {}
+        fields: Dict['types.CKeys', PartialModelField] = OrderedDict()
 
         try:
             if include:
@@ -1453,7 +1455,7 @@ class D(BaseModel):
                 'exclude_relational_fields and relations are mutually exclusive'
             )
 
-        fields: Dict['types.DKeys', PartialModelField] = {}
+        fields: Dict['types.DKeys', PartialModelField] = OrderedDict()
 
         try:
             if include:
@@ -1561,7 +1563,7 @@ class E(BaseModel):
                 'exclude_relational_fields and relations are mutually exclusive'
             )
 
-        fields: Dict['types.EKeys', PartialModelField] = {}
+        fields: Dict['types.EKeys', PartialModelField] = OrderedDict()
 
         try:
             if include:
@@ -1612,840 +1614,864 @@ class E(BaseModel):
 _Post_relational_fields: Set[str] = {
         'author',
     }
-_Post_fields: Dict['types.PostKeys', PartialModelField] = {
-    'id': {
-        'name': 'id',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'created_at': {
-        'name': 'created_at',
-        'is_list': False,
-        'optional': False,
-        'type': 'datetime.datetime',
-        'documentation': None,
-    },
-    'title': {
-        'name': 'title',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'content': {
-        'name': 'content',
-        'is_list': False,
-        'optional': True,
-        'type': '_str',
-        'documentation': None,
-    },
-    'published': {
-        'name': 'published',
-        'is_list': False,
-        'optional': False,
-        'type': '_bool',
-        'documentation': '''Has the post been made public yet?''',
-    },
-    'author': {
-        'name': 'author',
-        'is_list': False,
-        'optional': True,
-        'type': 'models.User',
-        'documentation': '''Relation to the User model
+_Post_fields: Dict['types.PostKeys', PartialModelField] = OrderedDict(
+    [
+        ('id', {
+            'name': 'id',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('created_at', {
+            'name': 'created_at',
+            'is_list': False,
+            'optional': False,
+            'type': 'datetime.datetime',
+            'documentation': None,
+        }),
+        ('title', {
+            'name': 'title',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('content', {
+            'name': 'content',
+            'is_list': False,
+            'optional': True,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('published', {
+            'name': 'published',
+            'is_list': False,
+            'optional': False,
+            'type': '_bool',
+            'documentation': '''Has the post been made public yet?''',
+        }),
+        ('author', {
+            'name': 'author',
+            'is_list': False,
+            'optional': True,
+            'type': 'models.User',
+            'documentation': '''Relation to the User model
 Second line comment with ' and "''',
-    },
-    'author_id': {
-        'name': 'author_id',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-}
+        }),
+        ('author_id', {
+            'name': 'author_id',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+    ],
+)
 
 _User_relational_fields: Set[str] = {
         'posts',
     }
-_User_fields: Dict['types.UserKeys', PartialModelField] = {
-    'id': {
-        'name': 'id',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'email': {
-        'name': 'email',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'int': {
-        'name': 'int',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'optional_int': {
-        'name': 'optional_int',
-        'is_list': False,
-        'optional': True,
-        'type': '_int',
-        'documentation': None,
-    },
-    'float': {
-        'name': 'float',
-        'is_list': False,
-        'optional': False,
-        'type': '_float',
-        'documentation': None,
-    },
-    'optional_float': {
-        'name': 'optional_float',
-        'is_list': False,
-        'optional': True,
-        'type': '_float',
-        'documentation': None,
-    },
-    'string': {
-        'name': 'string',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'optional_string': {
-        'name': 'optional_string',
-        'is_list': False,
-        'optional': True,
-        'type': '_str',
-        'documentation': None,
-    },
-    'enum': {
-        'name': 'enum',
-        'is_list': False,
-        'optional': False,
-        'type': 'enums.ABeautifulEnum',
-        'documentation': None,
-    },
-    'optional_enum': {
-        'name': 'optional_enum',
-        'is_list': False,
-        'optional': True,
-        'type': 'enums.ABeautifulEnum',
-        'documentation': None,
-    },
-    'boolean': {
-        'name': 'boolean',
-        'is_list': False,
-        'optional': False,
-        'type': '_bool',
-        'documentation': None,
-    },
-    'optional_boolean': {
-        'name': 'optional_boolean',
-        'is_list': False,
-        'optional': True,
-        'type': '_bool',
-        'documentation': None,
-    },
-    'posts': {
-        'name': 'posts',
-        'is_list': True,
-        'optional': True,
-        'type': 'List[\'models.Post\']',
-        'documentation': None,
-    },
-}
+_User_fields: Dict['types.UserKeys', PartialModelField] = OrderedDict(
+    [
+        ('id', {
+            'name': 'id',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('email', {
+            'name': 'email',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('int', {
+            'name': 'int',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('optional_int', {
+            'name': 'optional_int',
+            'is_list': False,
+            'optional': True,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('float', {
+            'name': 'float',
+            'is_list': False,
+            'optional': False,
+            'type': '_float',
+            'documentation': None,
+        }),
+        ('optional_float', {
+            'name': 'optional_float',
+            'is_list': False,
+            'optional': True,
+            'type': '_float',
+            'documentation': None,
+        }),
+        ('string', {
+            'name': 'string',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('optional_string', {
+            'name': 'optional_string',
+            'is_list': False,
+            'optional': True,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('enum', {
+            'name': 'enum',
+            'is_list': False,
+            'optional': False,
+            'type': 'enums.ABeautifulEnum',
+            'documentation': None,
+        }),
+        ('optional_enum', {
+            'name': 'optional_enum',
+            'is_list': False,
+            'optional': True,
+            'type': 'enums.ABeautifulEnum',
+            'documentation': None,
+        }),
+        ('boolean', {
+            'name': 'boolean',
+            'is_list': False,
+            'optional': False,
+            'type': '_bool',
+            'documentation': None,
+        }),
+        ('optional_boolean', {
+            'name': 'optional_boolean',
+            'is_list': False,
+            'optional': True,
+            'type': '_bool',
+            'documentation': None,
+        }),
+        ('posts', {
+            'name': 'posts',
+            'is_list': True,
+            'optional': True,
+            'type': 'List[\'models.Post\']',
+            'documentation': None,
+        }),
+    ],
+)
 
 _M_relational_fields: Set[str] = {
         'n',
     }
-_M_fields: Dict['types.MKeys', PartialModelField] = {
-    'id': {
-        'name': 'id',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'n': {
-        'name': 'n',
-        'is_list': True,
-        'optional': True,
-        'type': 'List[\'models.N\']',
-        'documentation': None,
-    },
-    'int': {
-        'name': 'int',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'optional_int': {
-        'name': 'optional_int',
-        'is_list': False,
-        'optional': True,
-        'type': '_int',
-        'documentation': None,
-    },
-    'float': {
-        'name': 'float',
-        'is_list': False,
-        'optional': False,
-        'type': '_float',
-        'documentation': None,
-    },
-    'optional_float': {
-        'name': 'optional_float',
-        'is_list': False,
-        'optional': True,
-        'type': '_float',
-        'documentation': None,
-    },
-    'string': {
-        'name': 'string',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'optional_string': {
-        'name': 'optional_string',
-        'is_list': False,
-        'optional': True,
-        'type': '_str',
-        'documentation': None,
-    },
-    'enum': {
-        'name': 'enum',
-        'is_list': False,
-        'optional': False,
-        'type': 'enums.ABeautifulEnum',
-        'documentation': None,
-    },
-    'optional_enum': {
-        'name': 'optional_enum',
-        'is_list': False,
-        'optional': True,
-        'type': 'enums.ABeautifulEnum',
-        'documentation': None,
-    },
-    'boolean': {
-        'name': 'boolean',
-        'is_list': False,
-        'optional': False,
-        'type': '_bool',
-        'documentation': None,
-    },
-    'optional_boolean': {
-        'name': 'optional_boolean',
-        'is_list': False,
-        'optional': True,
-        'type': '_bool',
-        'documentation': None,
-    },
-}
+_M_fields: Dict['types.MKeys', PartialModelField] = OrderedDict(
+    [
+        ('id', {
+            'name': 'id',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('n', {
+            'name': 'n',
+            'is_list': True,
+            'optional': True,
+            'type': 'List[\'models.N\']',
+            'documentation': None,
+        }),
+        ('int', {
+            'name': 'int',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('optional_int', {
+            'name': 'optional_int',
+            'is_list': False,
+            'optional': True,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('float', {
+            'name': 'float',
+            'is_list': False,
+            'optional': False,
+            'type': '_float',
+            'documentation': None,
+        }),
+        ('optional_float', {
+            'name': 'optional_float',
+            'is_list': False,
+            'optional': True,
+            'type': '_float',
+            'documentation': None,
+        }),
+        ('string', {
+            'name': 'string',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('optional_string', {
+            'name': 'optional_string',
+            'is_list': False,
+            'optional': True,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('enum', {
+            'name': 'enum',
+            'is_list': False,
+            'optional': False,
+            'type': 'enums.ABeautifulEnum',
+            'documentation': None,
+        }),
+        ('optional_enum', {
+            'name': 'optional_enum',
+            'is_list': False,
+            'optional': True,
+            'type': 'enums.ABeautifulEnum',
+            'documentation': None,
+        }),
+        ('boolean', {
+            'name': 'boolean',
+            'is_list': False,
+            'optional': False,
+            'type': '_bool',
+            'documentation': None,
+        }),
+        ('optional_boolean', {
+            'name': 'optional_boolean',
+            'is_list': False,
+            'optional': True,
+            'type': '_bool',
+            'documentation': None,
+        }),
+    ],
+)
 
 _N_relational_fields: Set[str] = {
         'm',
     }
-_N_fields: Dict['types.NKeys', PartialModelField] = {
-    'id': {
-        'name': 'id',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'm': {
-        'name': 'm',
-        'is_list': True,
-        'optional': True,
-        'type': 'List[\'models.M\']',
-        'documentation': None,
-    },
-    'int': {
-        'name': 'int',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'optional_int': {
-        'name': 'optional_int',
-        'is_list': False,
-        'optional': True,
-        'type': '_int',
-        'documentation': None,
-    },
-    'float': {
-        'name': 'float',
-        'is_list': False,
-        'optional': False,
-        'type': '_float',
-        'documentation': None,
-    },
-    'optional_float': {
-        'name': 'optional_float',
-        'is_list': False,
-        'optional': True,
-        'type': '_float',
-        'documentation': None,
-    },
-    'string': {
-        'name': 'string',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'optional_string': {
-        'name': 'optional_string',
-        'is_list': False,
-        'optional': True,
-        'type': '_str',
-        'documentation': None,
-    },
-    'json_': {
-        'name': 'json_',
-        'is_list': False,
-        'optional': False,
-        'type': 'fields.Json',
-        'documentation': None,
-    },
-    'optional_json': {
-        'name': 'optional_json',
-        'is_list': False,
-        'optional': True,
-        'type': 'fields.Json',
-        'documentation': None,
-    },
-    'enum': {
-        'name': 'enum',
-        'is_list': False,
-        'optional': False,
-        'type': 'enums.ABeautifulEnum',
-        'documentation': None,
-    },
-    'optional_enum': {
-        'name': 'optional_enum',
-        'is_list': False,
-        'optional': True,
-        'type': 'enums.ABeautifulEnum',
-        'documentation': None,
-    },
-    'boolean': {
-        'name': 'boolean',
-        'is_list': False,
-        'optional': False,
-        'type': '_bool',
-        'documentation': None,
-    },
-    'optional_boolean': {
-        'name': 'optional_boolean',
-        'is_list': False,
-        'optional': True,
-        'type': '_bool',
-        'documentation': None,
-    },
-}
+_N_fields: Dict['types.NKeys', PartialModelField] = OrderedDict(
+    [
+        ('id', {
+            'name': 'id',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('m', {
+            'name': 'm',
+            'is_list': True,
+            'optional': True,
+            'type': 'List[\'models.M\']',
+            'documentation': None,
+        }),
+        ('int', {
+            'name': 'int',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('optional_int', {
+            'name': 'optional_int',
+            'is_list': False,
+            'optional': True,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('float', {
+            'name': 'float',
+            'is_list': False,
+            'optional': False,
+            'type': '_float',
+            'documentation': None,
+        }),
+        ('optional_float', {
+            'name': 'optional_float',
+            'is_list': False,
+            'optional': True,
+            'type': '_float',
+            'documentation': None,
+        }),
+        ('string', {
+            'name': 'string',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('optional_string', {
+            'name': 'optional_string',
+            'is_list': False,
+            'optional': True,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('json_', {
+            'name': 'json_',
+            'is_list': False,
+            'optional': False,
+            'type': 'fields.Json',
+            'documentation': None,
+        }),
+        ('optional_json', {
+            'name': 'optional_json',
+            'is_list': False,
+            'optional': True,
+            'type': 'fields.Json',
+            'documentation': None,
+        }),
+        ('enum', {
+            'name': 'enum',
+            'is_list': False,
+            'optional': False,
+            'type': 'enums.ABeautifulEnum',
+            'documentation': None,
+        }),
+        ('optional_enum', {
+            'name': 'optional_enum',
+            'is_list': False,
+            'optional': True,
+            'type': 'enums.ABeautifulEnum',
+            'documentation': None,
+        }),
+        ('boolean', {
+            'name': 'boolean',
+            'is_list': False,
+            'optional': False,
+            'type': '_bool',
+            'documentation': None,
+        }),
+        ('optional_boolean', {
+            'name': 'optional_boolean',
+            'is_list': False,
+            'optional': True,
+            'type': '_bool',
+            'documentation': None,
+        }),
+    ],
+)
 
 _OneOptional_relational_fields: Set[str] = {
         'many',
     }
-_OneOptional_fields: Dict['types.OneOptionalKeys', PartialModelField] = {
-    'id': {
-        'name': 'id',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'many': {
-        'name': 'many',
-        'is_list': True,
-        'optional': True,
-        'type': 'List[\'models.ManyRequired\']',
-        'documentation': None,
-    },
-    'int': {
-        'name': 'int',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'optional_int': {
-        'name': 'optional_int',
-        'is_list': False,
-        'optional': True,
-        'type': '_int',
-        'documentation': None,
-    },
-    'float': {
-        'name': 'float',
-        'is_list': False,
-        'optional': False,
-        'type': '_float',
-        'documentation': None,
-    },
-    'optional_float': {
-        'name': 'optional_float',
-        'is_list': False,
-        'optional': True,
-        'type': '_float',
-        'documentation': None,
-    },
-    'string': {
-        'name': 'string',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'optional_string': {
-        'name': 'optional_string',
-        'is_list': False,
-        'optional': True,
-        'type': '_str',
-        'documentation': None,
-    },
-    'enum': {
-        'name': 'enum',
-        'is_list': False,
-        'optional': False,
-        'type': 'enums.ABeautifulEnum',
-        'documentation': None,
-    },
-    'optional_enum': {
-        'name': 'optional_enum',
-        'is_list': False,
-        'optional': True,
-        'type': 'enums.ABeautifulEnum',
-        'documentation': None,
-    },
-    'boolean': {
-        'name': 'boolean',
-        'is_list': False,
-        'optional': False,
-        'type': '_bool',
-        'documentation': None,
-    },
-    'optional_boolean': {
-        'name': 'optional_boolean',
-        'is_list': False,
-        'optional': True,
-        'type': '_bool',
-        'documentation': None,
-    },
-}
+_OneOptional_fields: Dict['types.OneOptionalKeys', PartialModelField] = OrderedDict(
+    [
+        ('id', {
+            'name': 'id',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('many', {
+            'name': 'many',
+            'is_list': True,
+            'optional': True,
+            'type': 'List[\'models.ManyRequired\']',
+            'documentation': None,
+        }),
+        ('int', {
+            'name': 'int',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('optional_int', {
+            'name': 'optional_int',
+            'is_list': False,
+            'optional': True,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('float', {
+            'name': 'float',
+            'is_list': False,
+            'optional': False,
+            'type': '_float',
+            'documentation': None,
+        }),
+        ('optional_float', {
+            'name': 'optional_float',
+            'is_list': False,
+            'optional': True,
+            'type': '_float',
+            'documentation': None,
+        }),
+        ('string', {
+            'name': 'string',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('optional_string', {
+            'name': 'optional_string',
+            'is_list': False,
+            'optional': True,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('enum', {
+            'name': 'enum',
+            'is_list': False,
+            'optional': False,
+            'type': 'enums.ABeautifulEnum',
+            'documentation': None,
+        }),
+        ('optional_enum', {
+            'name': 'optional_enum',
+            'is_list': False,
+            'optional': True,
+            'type': 'enums.ABeautifulEnum',
+            'documentation': None,
+        }),
+        ('boolean', {
+            'name': 'boolean',
+            'is_list': False,
+            'optional': False,
+            'type': '_bool',
+            'documentation': None,
+        }),
+        ('optional_boolean', {
+            'name': 'optional_boolean',
+            'is_list': False,
+            'optional': True,
+            'type': '_bool',
+            'documentation': None,
+        }),
+    ],
+)
 
 _ManyRequired_relational_fields: Set[str] = {
         'one',
     }
-_ManyRequired_fields: Dict['types.ManyRequiredKeys', PartialModelField] = {
-    'id': {
-        'name': 'id',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'one': {
-        'name': 'one',
-        'is_list': False,
-        'optional': True,
-        'type': 'models.OneOptional',
-        'documentation': None,
-    },
-    'one_optional_id': {
-        'name': 'one_optional_id',
-        'is_list': False,
-        'optional': True,
-        'type': '_int',
-        'documentation': None,
-    },
-    'int': {
-        'name': 'int',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'optional_int': {
-        'name': 'optional_int',
-        'is_list': False,
-        'optional': True,
-        'type': '_int',
-        'documentation': None,
-    },
-    'float': {
-        'name': 'float',
-        'is_list': False,
-        'optional': False,
-        'type': '_float',
-        'documentation': None,
-    },
-    'optional_float': {
-        'name': 'optional_float',
-        'is_list': False,
-        'optional': True,
-        'type': '_float',
-        'documentation': None,
-    },
-    'string': {
-        'name': 'string',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'optional_string': {
-        'name': 'optional_string',
-        'is_list': False,
-        'optional': True,
-        'type': '_str',
-        'documentation': None,
-    },
-    'enum': {
-        'name': 'enum',
-        'is_list': False,
-        'optional': False,
-        'type': 'enums.ABeautifulEnum',
-        'documentation': None,
-    },
-    'optional_enum': {
-        'name': 'optional_enum',
-        'is_list': False,
-        'optional': True,
-        'type': 'enums.ABeautifulEnum',
-        'documentation': None,
-    },
-    'boolean': {
-        'name': 'boolean',
-        'is_list': False,
-        'optional': False,
-        'type': '_bool',
-        'documentation': None,
-    },
-    'optional_boolean': {
-        'name': 'optional_boolean',
-        'is_list': False,
-        'optional': True,
-        'type': '_bool',
-        'documentation': None,
-    },
-}
+_ManyRequired_fields: Dict['types.ManyRequiredKeys', PartialModelField] = OrderedDict(
+    [
+        ('id', {
+            'name': 'id',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('one', {
+            'name': 'one',
+            'is_list': False,
+            'optional': True,
+            'type': 'models.OneOptional',
+            'documentation': None,
+        }),
+        ('one_optional_id', {
+            'name': 'one_optional_id',
+            'is_list': False,
+            'optional': True,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('int', {
+            'name': 'int',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('optional_int', {
+            'name': 'optional_int',
+            'is_list': False,
+            'optional': True,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('float', {
+            'name': 'float',
+            'is_list': False,
+            'optional': False,
+            'type': '_float',
+            'documentation': None,
+        }),
+        ('optional_float', {
+            'name': 'optional_float',
+            'is_list': False,
+            'optional': True,
+            'type': '_float',
+            'documentation': None,
+        }),
+        ('string', {
+            'name': 'string',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('optional_string', {
+            'name': 'optional_string',
+            'is_list': False,
+            'optional': True,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('enum', {
+            'name': 'enum',
+            'is_list': False,
+            'optional': False,
+            'type': 'enums.ABeautifulEnum',
+            'documentation': None,
+        }),
+        ('optional_enum', {
+            'name': 'optional_enum',
+            'is_list': False,
+            'optional': True,
+            'type': 'enums.ABeautifulEnum',
+            'documentation': None,
+        }),
+        ('boolean', {
+            'name': 'boolean',
+            'is_list': False,
+            'optional': False,
+            'type': '_bool',
+            'documentation': None,
+        }),
+        ('optional_boolean', {
+            'name': 'optional_boolean',
+            'is_list': False,
+            'optional': True,
+            'type': '_bool',
+            'documentation': None,
+        }),
+    ],
+)
 
 _Lists_relational_fields: Set[str] = set()  # pyright: ignore[reportUnusedVariable]
-_Lists_fields: Dict['types.ListsKeys', PartialModelField] = {
-    'id': {
-        'name': 'id',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'strings': {
-        'name': 'strings',
-        'is_list': True,
-        'optional': False,
-        'type': 'List[_str]',
-        'documentation': None,
-    },
-    'bytes': {
-        'name': 'bytes',
-        'is_list': True,
-        'optional': False,
-        'type': 'List[\'fields.Base64\']',
-        'documentation': None,
-    },
-    'dates': {
-        'name': 'dates',
-        'is_list': True,
-        'optional': False,
-        'type': 'List[datetime.datetime]',
-        'documentation': None,
-    },
-    'bools': {
-        'name': 'bools',
-        'is_list': True,
-        'optional': False,
-        'type': 'List[_bool]',
-        'documentation': None,
-    },
-    'ints': {
-        'name': 'ints',
-        'is_list': True,
-        'optional': False,
-        'type': 'List[_int]',
-        'documentation': None,
-    },
-    'floats': {
-        'name': 'floats',
-        'is_list': True,
-        'optional': False,
-        'type': 'List[_float]',
-        'documentation': None,
-    },
-    'bigints': {
-        'name': 'bigints',
-        'is_list': True,
-        'optional': False,
-        'type': 'List[_int]',
-        'documentation': None,
-    },
-    'json_objects': {
-        'name': 'json_objects',
-        'is_list': True,
-        'optional': False,
-        'type': 'List[\'fields.Json\']',
-        'documentation': None,
-    },
-    'decimals': {
-        'name': 'decimals',
-        'is_list': True,
-        'optional': False,
-        'type': 'List[decimal.Decimal]',
-        'documentation': None,
-    },
-}
+_Lists_fields: Dict['types.ListsKeys', PartialModelField] = OrderedDict(
+    [
+        ('id', {
+            'name': 'id',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('strings', {
+            'name': 'strings',
+            'is_list': True,
+            'optional': False,
+            'type': 'List[_str]',
+            'documentation': None,
+        }),
+        ('bytes', {
+            'name': 'bytes',
+            'is_list': True,
+            'optional': False,
+            'type': 'List[\'fields.Base64\']',
+            'documentation': None,
+        }),
+        ('dates', {
+            'name': 'dates',
+            'is_list': True,
+            'optional': False,
+            'type': 'List[datetime.datetime]',
+            'documentation': None,
+        }),
+        ('bools', {
+            'name': 'bools',
+            'is_list': True,
+            'optional': False,
+            'type': 'List[_bool]',
+            'documentation': None,
+        }),
+        ('ints', {
+            'name': 'ints',
+            'is_list': True,
+            'optional': False,
+            'type': 'List[_int]',
+            'documentation': None,
+        }),
+        ('floats', {
+            'name': 'floats',
+            'is_list': True,
+            'optional': False,
+            'type': 'List[_float]',
+            'documentation': None,
+        }),
+        ('bigints', {
+            'name': 'bigints',
+            'is_list': True,
+            'optional': False,
+            'type': 'List[_int]',
+            'documentation': None,
+        }),
+        ('json_objects', {
+            'name': 'json_objects',
+            'is_list': True,
+            'optional': False,
+            'type': 'List[\'fields.Json\']',
+            'documentation': None,
+        }),
+        ('decimals', {
+            'name': 'decimals',
+            'is_list': True,
+            'optional': False,
+            'type': 'List[decimal.Decimal]',
+            'documentation': None,
+        }),
+    ],
+)
 
 _A_relational_fields: Set[str] = set()  # pyright: ignore[reportUnusedVariable]
-_A_fields: Dict['types.AKeys', PartialModelField] = {
-    'email': {
-        'name': 'email',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'name': {
-        'name': 'name',
-        'is_list': False,
-        'optional': True,
-        'type': '_str',
-        'documentation': None,
-    },
-    'int': {
-        'name': 'int',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'sInt': {
-        'name': 'sInt',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'inc_int': {
-        'name': 'inc_int',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'inc_sInt': {
-        'name': 'inc_sInt',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'bInt': {
-        'name': 'bInt',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'inc_bInt': {
-        'name': 'inc_bInt',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'enum': {
-        'name': 'enum',
-        'is_list': False,
-        'optional': False,
-        'type': 'enums.ABeautifulEnum',
-        'documentation': None,
-    },
-}
+_A_fields: Dict['types.AKeys', PartialModelField] = OrderedDict(
+    [
+        ('email', {
+            'name': 'email',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('name', {
+            'name': 'name',
+            'is_list': False,
+            'optional': True,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('int', {
+            'name': 'int',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('sInt', {
+            'name': 'sInt',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('inc_int', {
+            'name': 'inc_int',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('inc_sInt', {
+            'name': 'inc_sInt',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('bInt', {
+            'name': 'bInt',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('inc_bInt', {
+            'name': 'inc_bInt',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('enum', {
+            'name': 'enum',
+            'is_list': False,
+            'optional': False,
+            'type': 'enums.ABeautifulEnum',
+            'documentation': None,
+        }),
+    ],
+)
 
 _B_relational_fields: Set[str] = set()  # pyright: ignore[reportUnusedVariable]
-_B_fields: Dict['types.BKeys', PartialModelField] = {
-    'id': {
-        'name': 'id',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'float': {
-        'name': 'float',
-        'is_list': False,
-        'optional': False,
-        'type': '_float',
-        'documentation': None,
-    },
-    'd_float': {
-        'name': 'd_float',
-        'is_list': False,
-        'optional': False,
-        'type': '_float',
-        'documentation': None,
-    },
-    'decFloat': {
-        'name': 'decFloat',
-        'is_list': False,
-        'optional': False,
-        'type': 'decimal.Decimal',
-        'documentation': None,
-    },
-    'numFloat': {
-        'name': 'numFloat',
-        'is_list': False,
-        'optional': False,
-        'type': 'decimal.Decimal',
-        'documentation': None,
-    },
-}
+_B_fields: Dict['types.BKeys', PartialModelField] = OrderedDict(
+    [
+        ('id', {
+            'name': 'id',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('float', {
+            'name': 'float',
+            'is_list': False,
+            'optional': False,
+            'type': '_float',
+            'documentation': None,
+        }),
+        ('d_float', {
+            'name': 'd_float',
+            'is_list': False,
+            'optional': False,
+            'type': '_float',
+            'documentation': None,
+        }),
+        ('decFloat', {
+            'name': 'decFloat',
+            'is_list': False,
+            'optional': False,
+            'type': 'decimal.Decimal',
+            'documentation': None,
+        }),
+        ('numFloat', {
+            'name': 'numFloat',
+            'is_list': False,
+            'optional': False,
+            'type': 'decimal.Decimal',
+            'documentation': None,
+        }),
+    ],
+)
 
 _C_relational_fields: Set[str] = set()  # pyright: ignore[reportUnusedVariable]
-_C_fields: Dict['types.CKeys', PartialModelField] = {
-    'char': {
-        'name': 'char',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'v_char': {
-        'name': 'v_char',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'text': {
-        'name': 'text',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'bit': {
-        'name': 'bit',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'v_bit': {
-        'name': 'v_bit',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'uuid': {
-        'name': 'uuid',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-}
+_C_fields: Dict['types.CKeys', PartialModelField] = OrderedDict(
+    [
+        ('char', {
+            'name': 'char',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('v_char', {
+            'name': 'v_char',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('text', {
+            'name': 'text',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('bit', {
+            'name': 'bit',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('v_bit', {
+            'name': 'v_bit',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('uuid', {
+            'name': 'uuid',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+    ],
+)
 
 _D_relational_fields: Set[str] = set()  # pyright: ignore[reportUnusedVariable]
-_D_fields: Dict['types.DKeys', PartialModelField] = {
-    'id': {
-        'name': 'id',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'bool': {
-        'name': 'bool',
-        'is_list': False,
-        'optional': False,
-        'type': '_bool',
-        'documentation': None,
-    },
-    'xml': {
-        'name': 'xml',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'json_': {
-        'name': 'json_',
-        'is_list': False,
-        'optional': False,
-        'type': 'fields.Json',
-        'documentation': None,
-    },
-    'jsonb': {
-        'name': 'jsonb',
-        'is_list': False,
-        'optional': False,
-        'type': 'fields.Json',
-        'documentation': None,
-    },
-    'binary': {
-        'name': 'binary',
-        'is_list': False,
-        'optional': False,
-        'type': 'fields.Base64',
-        'documentation': None,
-    },
-}
+_D_fields: Dict['types.DKeys', PartialModelField] = OrderedDict(
+    [
+        ('id', {
+            'name': 'id',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('bool', {
+            'name': 'bool',
+            'is_list': False,
+            'optional': False,
+            'type': '_bool',
+            'documentation': None,
+        }),
+        ('xml', {
+            'name': 'xml',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('json_', {
+            'name': 'json_',
+            'is_list': False,
+            'optional': False,
+            'type': 'fields.Json',
+            'documentation': None,
+        }),
+        ('jsonb', {
+            'name': 'jsonb',
+            'is_list': False,
+            'optional': False,
+            'type': 'fields.Json',
+            'documentation': None,
+        }),
+        ('binary', {
+            'name': 'binary',
+            'is_list': False,
+            'optional': False,
+            'type': 'fields.Base64',
+            'documentation': None,
+        }),
+    ],
+)
 
 _E_relational_fields: Set[str] = set()  # pyright: ignore[reportUnusedVariable]
-_E_fields: Dict['types.EKeys', PartialModelField] = {
-    'id': {
-        'name': 'id',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'date': {
-        'name': 'date',
-        'is_list': False,
-        'optional': False,
-        'type': 'datetime.datetime',
-        'documentation': None,
-    },
-    'time': {
-        'name': 'time',
-        'is_list': False,
-        'optional': False,
-        'type': 'datetime.datetime',
-        'documentation': None,
-    },
-    'ts': {
-        'name': 'ts',
-        'is_list': False,
-        'optional': False,
-        'type': 'datetime.datetime',
-        'documentation': None,
-    },
-}
+_E_fields: Dict['types.EKeys', PartialModelField] = OrderedDict(
+    [
+        ('id', {
+            'name': 'id',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('date', {
+            'name': 'date',
+            'is_list': False,
+            'optional': False,
+            'type': 'datetime.datetime',
+            'documentation': None,
+        }),
+        ('time', {
+            'name': 'time',
+            'is_list': False,
+            'optional': False,
+            'type': 'datetime.datetime',
+            'documentation': None,
+        }),
+        ('ts', {
+            'name': 'ts',
+            'is_list': False,
+            'optional': False,
+            'type': 'datetime.datetime',
+            'documentation': None,
+        }),
+    ],
+)
 
 
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[models.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[models.py].raw
@@ -171,28 +171,29 @@ class Post(BaseModel):
         try:
             if include:
                 for field in include:
-                    fields[field] = _Post_fields[field]
+                    fields[field] = _Post_fields[field].copy()
             elif exclude:
                 for field in exclude:
                     if field not in _Post_fields:
                         raise KeyError(field)
 
                 fields = {
-                    key: data
+                    key: data.copy()
                     for key, data in _Post_fields.items()
                     if key not in exclude
                 }
             else:
-                fields = _Post_fields.copy()
+                fields = {
+                    key: data.copy()
+                    for key, data in _Post_fields.items()
+                }
 
             if required:
                 for field in required:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = False
 
             if optional:
                 for field in optional:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = True
 
             if exclude_relational_fields:
@@ -314,28 +315,29 @@ class User(BaseModel):
         try:
             if include:
                 for field in include:
-                    fields[field] = _User_fields[field]
+                    fields[field] = _User_fields[field].copy()
             elif exclude:
                 for field in exclude:
                     if field not in _User_fields:
                         raise KeyError(field)
 
                 fields = {
-                    key: data
+                    key: data.copy()
                     for key, data in _User_fields.items()
                     if key not in exclude
                 }
             else:
-                fields = _User_fields.copy()
+                fields = {
+                    key: data.copy()
+                    for key, data in _User_fields.items()
+                }
 
             if required:
                 for field in required:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = False
 
             if optional:
                 for field in optional:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = True
 
             if exclude_relational_fields:
@@ -453,28 +455,29 @@ class M(BaseModel):
         try:
             if include:
                 for field in include:
-                    fields[field] = _M_fields[field]
+                    fields[field] = _M_fields[field].copy()
             elif exclude:
                 for field in exclude:
                     if field not in _M_fields:
                         raise KeyError(field)
 
                 fields = {
-                    key: data
+                    key: data.copy()
                     for key, data in _M_fields.items()
                     if key not in exclude
                 }
             else:
-                fields = _M_fields.copy()
+                fields = {
+                    key: data.copy()
+                    for key, data in _M_fields.items()
+                }
 
             if required:
                 for field in required:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = False
 
             if optional:
                 for field in optional:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = True
 
             if exclude_relational_fields:
@@ -594,28 +597,29 @@ class N(BaseModel):
         try:
             if include:
                 for field in include:
-                    fields[field] = _N_fields[field]
+                    fields[field] = _N_fields[field].copy()
             elif exclude:
                 for field in exclude:
                     if field not in _N_fields:
                         raise KeyError(field)
 
                 fields = {
-                    key: data
+                    key: data.copy()
                     for key, data in _N_fields.items()
                     if key not in exclude
                 }
             else:
-                fields = _N_fields.copy()
+                fields = {
+                    key: data.copy()
+                    for key, data in _N_fields.items()
+                }
 
             if required:
                 for field in required:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = False
 
             if optional:
                 for field in optional:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = True
 
             if exclude_relational_fields:
@@ -733,28 +737,29 @@ class OneOptional(BaseModel):
         try:
             if include:
                 for field in include:
-                    fields[field] = _OneOptional_fields[field]
+                    fields[field] = _OneOptional_fields[field].copy()
             elif exclude:
                 for field in exclude:
                     if field not in _OneOptional_fields:
                         raise KeyError(field)
 
                 fields = {
-                    key: data
+                    key: data.copy()
                     for key, data in _OneOptional_fields.items()
                     if key not in exclude
                 }
             else:
-                fields = _OneOptional_fields.copy()
+                fields = {
+                    key: data.copy()
+                    for key, data in _OneOptional_fields.items()
+                }
 
             if required:
                 for field in required:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = False
 
             if optional:
                 for field in optional:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = True
 
             if exclude_relational_fields:
@@ -873,28 +878,29 @@ class ManyRequired(BaseModel):
         try:
             if include:
                 for field in include:
-                    fields[field] = _ManyRequired_fields[field]
+                    fields[field] = _ManyRequired_fields[field].copy()
             elif exclude:
                 for field in exclude:
                     if field not in _ManyRequired_fields:
                         raise KeyError(field)
 
                 fields = {
-                    key: data
+                    key: data.copy()
                     for key, data in _ManyRequired_fields.items()
                     if key not in exclude
                 }
             else:
-                fields = _ManyRequired_fields.copy()
+                fields = {
+                    key: data.copy()
+                    for key, data in _ManyRequired_fields.items()
+                }
 
             if required:
                 for field in required:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = False
 
             if optional:
                 for field in optional:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = True
 
             if exclude_relational_fields:
@@ -1010,28 +1016,29 @@ class Lists(BaseModel):
         try:
             if include:
                 for field in include:
-                    fields[field] = _Lists_fields[field]
+                    fields[field] = _Lists_fields[field].copy()
             elif exclude:
                 for field in exclude:
                     if field not in _Lists_fields:
                         raise KeyError(field)
 
                 fields = {
-                    key: data
+                    key: data.copy()
                     for key, data in _Lists_fields.items()
                     if key not in exclude
                 }
             else:
-                fields = _Lists_fields.copy()
+                fields = {
+                    key: data.copy()
+                    for key, data in _Lists_fields.items()
+                }
 
             if required:
                 for field in required:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = False
 
             if optional:
                 for field in optional:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = True
 
 
@@ -1122,28 +1129,29 @@ class A(BaseModel):
         try:
             if include:
                 for field in include:
-                    fields[field] = _A_fields[field]
+                    fields[field] = _A_fields[field].copy()
             elif exclude:
                 for field in exclude:
                     if field not in _A_fields:
                         raise KeyError(field)
 
                 fields = {
-                    key: data
+                    key: data.copy()
                     for key, data in _A_fields.items()
                     if key not in exclude
                 }
             else:
-                fields = _A_fields.copy()
+                fields = {
+                    key: data.copy()
+                    for key, data in _A_fields.items()
+                }
 
             if required:
                 for field in required:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = False
 
             if optional:
                 for field in optional:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = True
 
 
@@ -1230,28 +1238,29 @@ class B(BaseModel):
         try:
             if include:
                 for field in include:
-                    fields[field] = _B_fields[field]
+                    fields[field] = _B_fields[field].copy()
             elif exclude:
                 for field in exclude:
                     if field not in _B_fields:
                         raise KeyError(field)
 
                 fields = {
-                    key: data
+                    key: data.copy()
                     for key, data in _B_fields.items()
                     if key not in exclude
                 }
             else:
-                fields = _B_fields.copy()
+                fields = {
+                    key: data.copy()
+                    for key, data in _B_fields.items()
+                }
 
             if required:
                 for field in required:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = False
 
             if optional:
                 for field in optional:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = True
 
 
@@ -1339,28 +1348,29 @@ class C(BaseModel):
         try:
             if include:
                 for field in include:
-                    fields[field] = _C_fields[field]
+                    fields[field] = _C_fields[field].copy()
             elif exclude:
                 for field in exclude:
                     if field not in _C_fields:
                         raise KeyError(field)
 
                 fields = {
-                    key: data
+                    key: data.copy()
                     for key, data in _C_fields.items()
                     if key not in exclude
                 }
             else:
-                fields = _C_fields.copy()
+                fields = {
+                    key: data.copy()
+                    for key, data in _C_fields.items()
+                }
 
             if required:
                 for field in required:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = False
 
             if optional:
                 for field in optional:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = True
 
 
@@ -1448,28 +1458,29 @@ class D(BaseModel):
         try:
             if include:
                 for field in include:
-                    fields[field] = _D_fields[field]
+                    fields[field] = _D_fields[field].copy()
             elif exclude:
                 for field in exclude:
                     if field not in _D_fields:
                         raise KeyError(field)
 
                 fields = {
-                    key: data
+                    key: data.copy()
                     for key, data in _D_fields.items()
                     if key not in exclude
                 }
             else:
-                fields = _D_fields.copy()
+                fields = {
+                    key: data.copy()
+                    for key, data in _D_fields.items()
+                }
 
             if required:
                 for field in required:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = False
 
             if optional:
                 for field in optional:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = True
 
 
@@ -1555,28 +1566,29 @@ class E(BaseModel):
         try:
             if include:
                 for field in include:
-                    fields[field] = _E_fields[field]
+                    fields[field] = _E_fields[field].copy()
             elif exclude:
                 for field in exclude:
                     if field not in _E_fields:
                         raise KeyError(field)
 
                 fields = {
-                    key: data
+                    key: data.copy()
                     for key, data in _E_fields.items()
                     if key not in exclude
                 }
             else:
-                fields = _E_fields.copy()
+                fields = {
+                    key: data.copy()
+                    for key, data in _E_fields.items()
+                }
 
             if required:
                 for field in required:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = False
 
             if optional:
                 for field in optional:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = True
 
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[partials.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[partials.py].raw
@@ -40,9 +40,9 @@ from . import types, models, fields, enums
 
 
 class PostWithAuthor(BaseModel):
-    author: Optional[models.User]
-    title: _str
     id: _str
+    title: _str
+    author: Optional[models.User]
 
     Config = models.Config
 
@@ -54,9 +54,9 @@ class UserOnlyName(BaseModel):
 
 
 class PostWithCustomAuthor(BaseModel):
-    author: Optional['partials.UserOnlyName']
-    title: _str
     id: _str
+    title: _str
+    author: Optional['partials.UserOnlyName']
 
     Config = models.Config
 
@@ -69,9 +69,9 @@ class UserWithPosts(BaseModel):
 
 
 class PostWithNestedRelations(BaseModel):
-    author: Optional['partials.UserWithPosts']
-    title: _str
     id: _str
+    title: _str
+    author: Optional['partials.UserWithPosts']
 
     Config = models.Config
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[partials.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[partials.py].raw
@@ -39,11 +39,53 @@ from pydantic import BaseModel, Field, validator
 from . import types, models, fields, enums
 
 
+class PostWithAuthor(BaseModel):
+    author: Optional[models.User]
+    title: _str
+    id: _str
+
+    Config = models.Config
+
+
+class UserOnlyName(BaseModel):
+    name: _str
+
+    Config = models.Config
+
+
+class PostWithCustomAuthor(BaseModel):
+    author: Optional['partials.UserOnlyName']
+    title: _str
+    id: _str
+
+    Config = models.Config
+
+
+class UserWithPosts(BaseModel):
+    name: _str
+    posts: Optional[List['models.Post']]
+
+    Config = models.Config
+
+
+class PostWithNestedRelations(BaseModel):
+    author: Optional['partials.UserWithPosts']
+    title: _str
+    id: _str
+
+    Config = models.Config
+
+
 
 # users can modify relational types which are then namespaced to partials.
 # so we have to import ourselves in order to resolve forward references
 from . import partials
 
+PostWithAuthor.update_forward_refs()
+UserOnlyName.update_forward_refs()
+PostWithCustomAuthor.update_forward_refs()
+UserWithPosts.update_forward_refs()
+PostWithNestedRelations.update_forward_refs()
 
 # fmt: on
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[models.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[models.py].raw
@@ -39,6 +39,8 @@ import os
 import logging
 import inspect
 import warnings
+from collections import OrderedDict
+
 from pydantic import BaseConfig, BaseModel, Field, validator
 
 from . import types, enums, errors, fields
@@ -166,7 +168,7 @@ class Post(BaseModel):
                 'exclude_relational_fields and relations are mutually exclusive'
             )
 
-        fields: Dict['types.PostKeys', PartialModelField] = {}
+        fields: Dict['types.PostKeys', PartialModelField] = OrderedDict()
 
         try:
             if include:
@@ -310,7 +312,7 @@ class User(BaseModel):
                 'exclude_relational_fields and relations are mutually exclusive'
             )
 
-        fields: Dict['types.UserKeys', PartialModelField] = {}
+        fields: Dict['types.UserKeys', PartialModelField] = OrderedDict()
 
         try:
             if include:
@@ -450,7 +452,7 @@ class M(BaseModel):
                 'exclude_relational_fields and relations are mutually exclusive'
             )
 
-        fields: Dict['types.MKeys', PartialModelField] = {}
+        fields: Dict['types.MKeys', PartialModelField] = OrderedDict()
 
         try:
             if include:
@@ -592,7 +594,7 @@ class N(BaseModel):
                 'exclude_relational_fields and relations are mutually exclusive'
             )
 
-        fields: Dict['types.NKeys', PartialModelField] = {}
+        fields: Dict['types.NKeys', PartialModelField] = OrderedDict()
 
         try:
             if include:
@@ -732,7 +734,7 @@ class OneOptional(BaseModel):
                 'exclude_relational_fields and relations are mutually exclusive'
             )
 
-        fields: Dict['types.OneOptionalKeys', PartialModelField] = {}
+        fields: Dict['types.OneOptionalKeys', PartialModelField] = OrderedDict()
 
         try:
             if include:
@@ -873,7 +875,7 @@ class ManyRequired(BaseModel):
                 'exclude_relational_fields and relations are mutually exclusive'
             )
 
-        fields: Dict['types.ManyRequiredKeys', PartialModelField] = {}
+        fields: Dict['types.ManyRequiredKeys', PartialModelField] = OrderedDict()
 
         try:
             if include:
@@ -1011,7 +1013,7 @@ class Lists(BaseModel):
                 'exclude_relational_fields and relations are mutually exclusive'
             )
 
-        fields: Dict['types.ListsKeys', PartialModelField] = {}
+        fields: Dict['types.ListsKeys', PartialModelField] = OrderedDict()
 
         try:
             if include:
@@ -1124,7 +1126,7 @@ class A(BaseModel):
                 'exclude_relational_fields and relations are mutually exclusive'
             )
 
-        fields: Dict['types.AKeys', PartialModelField] = {}
+        fields: Dict['types.AKeys', PartialModelField] = OrderedDict()
 
         try:
             if include:
@@ -1233,7 +1235,7 @@ class B(BaseModel):
                 'exclude_relational_fields and relations are mutually exclusive'
             )
 
-        fields: Dict['types.BKeys', PartialModelField] = {}
+        fields: Dict['types.BKeys', PartialModelField] = OrderedDict()
 
         try:
             if include:
@@ -1343,7 +1345,7 @@ class C(BaseModel):
                 'exclude_relational_fields and relations are mutually exclusive'
             )
 
-        fields: Dict['types.CKeys', PartialModelField] = {}
+        fields: Dict['types.CKeys', PartialModelField] = OrderedDict()
 
         try:
             if include:
@@ -1453,7 +1455,7 @@ class D(BaseModel):
                 'exclude_relational_fields and relations are mutually exclusive'
             )
 
-        fields: Dict['types.DKeys', PartialModelField] = {}
+        fields: Dict['types.DKeys', PartialModelField] = OrderedDict()
 
         try:
             if include:
@@ -1561,7 +1563,7 @@ class E(BaseModel):
                 'exclude_relational_fields and relations are mutually exclusive'
             )
 
-        fields: Dict['types.EKeys', PartialModelField] = {}
+        fields: Dict['types.EKeys', PartialModelField] = OrderedDict()
 
         try:
             if include:
@@ -1612,840 +1614,864 @@ class E(BaseModel):
 _Post_relational_fields: Set[str] = {
         'author',
     }
-_Post_fields: Dict['types.PostKeys', PartialModelField] = {
-    'id': {
-        'name': 'id',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'created_at': {
-        'name': 'created_at',
-        'is_list': False,
-        'optional': False,
-        'type': 'datetime.datetime',
-        'documentation': None,
-    },
-    'title': {
-        'name': 'title',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'content': {
-        'name': 'content',
-        'is_list': False,
-        'optional': True,
-        'type': '_str',
-        'documentation': None,
-    },
-    'published': {
-        'name': 'published',
-        'is_list': False,
-        'optional': False,
-        'type': '_bool',
-        'documentation': '''Has the post been made public yet?''',
-    },
-    'author': {
-        'name': 'author',
-        'is_list': False,
-        'optional': True,
-        'type': 'models.User',
-        'documentation': '''Relation to the User model
+_Post_fields: Dict['types.PostKeys', PartialModelField] = OrderedDict(
+    [
+        ('id', {
+            'name': 'id',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('created_at', {
+            'name': 'created_at',
+            'is_list': False,
+            'optional': False,
+            'type': 'datetime.datetime',
+            'documentation': None,
+        }),
+        ('title', {
+            'name': 'title',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('content', {
+            'name': 'content',
+            'is_list': False,
+            'optional': True,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('published', {
+            'name': 'published',
+            'is_list': False,
+            'optional': False,
+            'type': '_bool',
+            'documentation': '''Has the post been made public yet?''',
+        }),
+        ('author', {
+            'name': 'author',
+            'is_list': False,
+            'optional': True,
+            'type': 'models.User',
+            'documentation': '''Relation to the User model
 Second line comment with ' and "''',
-    },
-    'author_id': {
-        'name': 'author_id',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-}
+        }),
+        ('author_id', {
+            'name': 'author_id',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+    ],
+)
 
 _User_relational_fields: Set[str] = {
         'posts',
     }
-_User_fields: Dict['types.UserKeys', PartialModelField] = {
-    'id': {
-        'name': 'id',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'email': {
-        'name': 'email',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'int': {
-        'name': 'int',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'optional_int': {
-        'name': 'optional_int',
-        'is_list': False,
-        'optional': True,
-        'type': '_int',
-        'documentation': None,
-    },
-    'float': {
-        'name': 'float',
-        'is_list': False,
-        'optional': False,
-        'type': '_float',
-        'documentation': None,
-    },
-    'optional_float': {
-        'name': 'optional_float',
-        'is_list': False,
-        'optional': True,
-        'type': '_float',
-        'documentation': None,
-    },
-    'string': {
-        'name': 'string',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'optional_string': {
-        'name': 'optional_string',
-        'is_list': False,
-        'optional': True,
-        'type': '_str',
-        'documentation': None,
-    },
-    'enum': {
-        'name': 'enum',
-        'is_list': False,
-        'optional': False,
-        'type': 'enums.ABeautifulEnum',
-        'documentation': None,
-    },
-    'optional_enum': {
-        'name': 'optional_enum',
-        'is_list': False,
-        'optional': True,
-        'type': 'enums.ABeautifulEnum',
-        'documentation': None,
-    },
-    'boolean': {
-        'name': 'boolean',
-        'is_list': False,
-        'optional': False,
-        'type': '_bool',
-        'documentation': None,
-    },
-    'optional_boolean': {
-        'name': 'optional_boolean',
-        'is_list': False,
-        'optional': True,
-        'type': '_bool',
-        'documentation': None,
-    },
-    'posts': {
-        'name': 'posts',
-        'is_list': True,
-        'optional': True,
-        'type': 'List[\'models.Post\']',
-        'documentation': None,
-    },
-}
+_User_fields: Dict['types.UserKeys', PartialModelField] = OrderedDict(
+    [
+        ('id', {
+            'name': 'id',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('email', {
+            'name': 'email',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('int', {
+            'name': 'int',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('optional_int', {
+            'name': 'optional_int',
+            'is_list': False,
+            'optional': True,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('float', {
+            'name': 'float',
+            'is_list': False,
+            'optional': False,
+            'type': '_float',
+            'documentation': None,
+        }),
+        ('optional_float', {
+            'name': 'optional_float',
+            'is_list': False,
+            'optional': True,
+            'type': '_float',
+            'documentation': None,
+        }),
+        ('string', {
+            'name': 'string',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('optional_string', {
+            'name': 'optional_string',
+            'is_list': False,
+            'optional': True,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('enum', {
+            'name': 'enum',
+            'is_list': False,
+            'optional': False,
+            'type': 'enums.ABeautifulEnum',
+            'documentation': None,
+        }),
+        ('optional_enum', {
+            'name': 'optional_enum',
+            'is_list': False,
+            'optional': True,
+            'type': 'enums.ABeautifulEnum',
+            'documentation': None,
+        }),
+        ('boolean', {
+            'name': 'boolean',
+            'is_list': False,
+            'optional': False,
+            'type': '_bool',
+            'documentation': None,
+        }),
+        ('optional_boolean', {
+            'name': 'optional_boolean',
+            'is_list': False,
+            'optional': True,
+            'type': '_bool',
+            'documentation': None,
+        }),
+        ('posts', {
+            'name': 'posts',
+            'is_list': True,
+            'optional': True,
+            'type': 'List[\'models.Post\']',
+            'documentation': None,
+        }),
+    ],
+)
 
 _M_relational_fields: Set[str] = {
         'n',
     }
-_M_fields: Dict['types.MKeys', PartialModelField] = {
-    'id': {
-        'name': 'id',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'n': {
-        'name': 'n',
-        'is_list': True,
-        'optional': True,
-        'type': 'List[\'models.N\']',
-        'documentation': None,
-    },
-    'int': {
-        'name': 'int',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'optional_int': {
-        'name': 'optional_int',
-        'is_list': False,
-        'optional': True,
-        'type': '_int',
-        'documentation': None,
-    },
-    'float': {
-        'name': 'float',
-        'is_list': False,
-        'optional': False,
-        'type': '_float',
-        'documentation': None,
-    },
-    'optional_float': {
-        'name': 'optional_float',
-        'is_list': False,
-        'optional': True,
-        'type': '_float',
-        'documentation': None,
-    },
-    'string': {
-        'name': 'string',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'optional_string': {
-        'name': 'optional_string',
-        'is_list': False,
-        'optional': True,
-        'type': '_str',
-        'documentation': None,
-    },
-    'enum': {
-        'name': 'enum',
-        'is_list': False,
-        'optional': False,
-        'type': 'enums.ABeautifulEnum',
-        'documentation': None,
-    },
-    'optional_enum': {
-        'name': 'optional_enum',
-        'is_list': False,
-        'optional': True,
-        'type': 'enums.ABeautifulEnum',
-        'documentation': None,
-    },
-    'boolean': {
-        'name': 'boolean',
-        'is_list': False,
-        'optional': False,
-        'type': '_bool',
-        'documentation': None,
-    },
-    'optional_boolean': {
-        'name': 'optional_boolean',
-        'is_list': False,
-        'optional': True,
-        'type': '_bool',
-        'documentation': None,
-    },
-}
+_M_fields: Dict['types.MKeys', PartialModelField] = OrderedDict(
+    [
+        ('id', {
+            'name': 'id',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('n', {
+            'name': 'n',
+            'is_list': True,
+            'optional': True,
+            'type': 'List[\'models.N\']',
+            'documentation': None,
+        }),
+        ('int', {
+            'name': 'int',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('optional_int', {
+            'name': 'optional_int',
+            'is_list': False,
+            'optional': True,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('float', {
+            'name': 'float',
+            'is_list': False,
+            'optional': False,
+            'type': '_float',
+            'documentation': None,
+        }),
+        ('optional_float', {
+            'name': 'optional_float',
+            'is_list': False,
+            'optional': True,
+            'type': '_float',
+            'documentation': None,
+        }),
+        ('string', {
+            'name': 'string',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('optional_string', {
+            'name': 'optional_string',
+            'is_list': False,
+            'optional': True,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('enum', {
+            'name': 'enum',
+            'is_list': False,
+            'optional': False,
+            'type': 'enums.ABeautifulEnum',
+            'documentation': None,
+        }),
+        ('optional_enum', {
+            'name': 'optional_enum',
+            'is_list': False,
+            'optional': True,
+            'type': 'enums.ABeautifulEnum',
+            'documentation': None,
+        }),
+        ('boolean', {
+            'name': 'boolean',
+            'is_list': False,
+            'optional': False,
+            'type': '_bool',
+            'documentation': None,
+        }),
+        ('optional_boolean', {
+            'name': 'optional_boolean',
+            'is_list': False,
+            'optional': True,
+            'type': '_bool',
+            'documentation': None,
+        }),
+    ],
+)
 
 _N_relational_fields: Set[str] = {
         'm',
     }
-_N_fields: Dict['types.NKeys', PartialModelField] = {
-    'id': {
-        'name': 'id',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'm': {
-        'name': 'm',
-        'is_list': True,
-        'optional': True,
-        'type': 'List[\'models.M\']',
-        'documentation': None,
-    },
-    'int': {
-        'name': 'int',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'optional_int': {
-        'name': 'optional_int',
-        'is_list': False,
-        'optional': True,
-        'type': '_int',
-        'documentation': None,
-    },
-    'float': {
-        'name': 'float',
-        'is_list': False,
-        'optional': False,
-        'type': '_float',
-        'documentation': None,
-    },
-    'optional_float': {
-        'name': 'optional_float',
-        'is_list': False,
-        'optional': True,
-        'type': '_float',
-        'documentation': None,
-    },
-    'string': {
-        'name': 'string',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'optional_string': {
-        'name': 'optional_string',
-        'is_list': False,
-        'optional': True,
-        'type': '_str',
-        'documentation': None,
-    },
-    'json_': {
-        'name': 'json_',
-        'is_list': False,
-        'optional': False,
-        'type': 'fields.Json',
-        'documentation': None,
-    },
-    'optional_json': {
-        'name': 'optional_json',
-        'is_list': False,
-        'optional': True,
-        'type': 'fields.Json',
-        'documentation': None,
-    },
-    'enum': {
-        'name': 'enum',
-        'is_list': False,
-        'optional': False,
-        'type': 'enums.ABeautifulEnum',
-        'documentation': None,
-    },
-    'optional_enum': {
-        'name': 'optional_enum',
-        'is_list': False,
-        'optional': True,
-        'type': 'enums.ABeautifulEnum',
-        'documentation': None,
-    },
-    'boolean': {
-        'name': 'boolean',
-        'is_list': False,
-        'optional': False,
-        'type': '_bool',
-        'documentation': None,
-    },
-    'optional_boolean': {
-        'name': 'optional_boolean',
-        'is_list': False,
-        'optional': True,
-        'type': '_bool',
-        'documentation': None,
-    },
-}
+_N_fields: Dict['types.NKeys', PartialModelField] = OrderedDict(
+    [
+        ('id', {
+            'name': 'id',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('m', {
+            'name': 'm',
+            'is_list': True,
+            'optional': True,
+            'type': 'List[\'models.M\']',
+            'documentation': None,
+        }),
+        ('int', {
+            'name': 'int',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('optional_int', {
+            'name': 'optional_int',
+            'is_list': False,
+            'optional': True,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('float', {
+            'name': 'float',
+            'is_list': False,
+            'optional': False,
+            'type': '_float',
+            'documentation': None,
+        }),
+        ('optional_float', {
+            'name': 'optional_float',
+            'is_list': False,
+            'optional': True,
+            'type': '_float',
+            'documentation': None,
+        }),
+        ('string', {
+            'name': 'string',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('optional_string', {
+            'name': 'optional_string',
+            'is_list': False,
+            'optional': True,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('json_', {
+            'name': 'json_',
+            'is_list': False,
+            'optional': False,
+            'type': 'fields.Json',
+            'documentation': None,
+        }),
+        ('optional_json', {
+            'name': 'optional_json',
+            'is_list': False,
+            'optional': True,
+            'type': 'fields.Json',
+            'documentation': None,
+        }),
+        ('enum', {
+            'name': 'enum',
+            'is_list': False,
+            'optional': False,
+            'type': 'enums.ABeautifulEnum',
+            'documentation': None,
+        }),
+        ('optional_enum', {
+            'name': 'optional_enum',
+            'is_list': False,
+            'optional': True,
+            'type': 'enums.ABeautifulEnum',
+            'documentation': None,
+        }),
+        ('boolean', {
+            'name': 'boolean',
+            'is_list': False,
+            'optional': False,
+            'type': '_bool',
+            'documentation': None,
+        }),
+        ('optional_boolean', {
+            'name': 'optional_boolean',
+            'is_list': False,
+            'optional': True,
+            'type': '_bool',
+            'documentation': None,
+        }),
+    ],
+)
 
 _OneOptional_relational_fields: Set[str] = {
         'many',
     }
-_OneOptional_fields: Dict['types.OneOptionalKeys', PartialModelField] = {
-    'id': {
-        'name': 'id',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'many': {
-        'name': 'many',
-        'is_list': True,
-        'optional': True,
-        'type': 'List[\'models.ManyRequired\']',
-        'documentation': None,
-    },
-    'int': {
-        'name': 'int',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'optional_int': {
-        'name': 'optional_int',
-        'is_list': False,
-        'optional': True,
-        'type': '_int',
-        'documentation': None,
-    },
-    'float': {
-        'name': 'float',
-        'is_list': False,
-        'optional': False,
-        'type': '_float',
-        'documentation': None,
-    },
-    'optional_float': {
-        'name': 'optional_float',
-        'is_list': False,
-        'optional': True,
-        'type': '_float',
-        'documentation': None,
-    },
-    'string': {
-        'name': 'string',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'optional_string': {
-        'name': 'optional_string',
-        'is_list': False,
-        'optional': True,
-        'type': '_str',
-        'documentation': None,
-    },
-    'enum': {
-        'name': 'enum',
-        'is_list': False,
-        'optional': False,
-        'type': 'enums.ABeautifulEnum',
-        'documentation': None,
-    },
-    'optional_enum': {
-        'name': 'optional_enum',
-        'is_list': False,
-        'optional': True,
-        'type': 'enums.ABeautifulEnum',
-        'documentation': None,
-    },
-    'boolean': {
-        'name': 'boolean',
-        'is_list': False,
-        'optional': False,
-        'type': '_bool',
-        'documentation': None,
-    },
-    'optional_boolean': {
-        'name': 'optional_boolean',
-        'is_list': False,
-        'optional': True,
-        'type': '_bool',
-        'documentation': None,
-    },
-}
+_OneOptional_fields: Dict['types.OneOptionalKeys', PartialModelField] = OrderedDict(
+    [
+        ('id', {
+            'name': 'id',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('many', {
+            'name': 'many',
+            'is_list': True,
+            'optional': True,
+            'type': 'List[\'models.ManyRequired\']',
+            'documentation': None,
+        }),
+        ('int', {
+            'name': 'int',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('optional_int', {
+            'name': 'optional_int',
+            'is_list': False,
+            'optional': True,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('float', {
+            'name': 'float',
+            'is_list': False,
+            'optional': False,
+            'type': '_float',
+            'documentation': None,
+        }),
+        ('optional_float', {
+            'name': 'optional_float',
+            'is_list': False,
+            'optional': True,
+            'type': '_float',
+            'documentation': None,
+        }),
+        ('string', {
+            'name': 'string',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('optional_string', {
+            'name': 'optional_string',
+            'is_list': False,
+            'optional': True,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('enum', {
+            'name': 'enum',
+            'is_list': False,
+            'optional': False,
+            'type': 'enums.ABeautifulEnum',
+            'documentation': None,
+        }),
+        ('optional_enum', {
+            'name': 'optional_enum',
+            'is_list': False,
+            'optional': True,
+            'type': 'enums.ABeautifulEnum',
+            'documentation': None,
+        }),
+        ('boolean', {
+            'name': 'boolean',
+            'is_list': False,
+            'optional': False,
+            'type': '_bool',
+            'documentation': None,
+        }),
+        ('optional_boolean', {
+            'name': 'optional_boolean',
+            'is_list': False,
+            'optional': True,
+            'type': '_bool',
+            'documentation': None,
+        }),
+    ],
+)
 
 _ManyRequired_relational_fields: Set[str] = {
         'one',
     }
-_ManyRequired_fields: Dict['types.ManyRequiredKeys', PartialModelField] = {
-    'id': {
-        'name': 'id',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'one': {
-        'name': 'one',
-        'is_list': False,
-        'optional': True,
-        'type': 'models.OneOptional',
-        'documentation': None,
-    },
-    'one_optional_id': {
-        'name': 'one_optional_id',
-        'is_list': False,
-        'optional': True,
-        'type': '_int',
-        'documentation': None,
-    },
-    'int': {
-        'name': 'int',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'optional_int': {
-        'name': 'optional_int',
-        'is_list': False,
-        'optional': True,
-        'type': '_int',
-        'documentation': None,
-    },
-    'float': {
-        'name': 'float',
-        'is_list': False,
-        'optional': False,
-        'type': '_float',
-        'documentation': None,
-    },
-    'optional_float': {
-        'name': 'optional_float',
-        'is_list': False,
-        'optional': True,
-        'type': '_float',
-        'documentation': None,
-    },
-    'string': {
-        'name': 'string',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'optional_string': {
-        'name': 'optional_string',
-        'is_list': False,
-        'optional': True,
-        'type': '_str',
-        'documentation': None,
-    },
-    'enum': {
-        'name': 'enum',
-        'is_list': False,
-        'optional': False,
-        'type': 'enums.ABeautifulEnum',
-        'documentation': None,
-    },
-    'optional_enum': {
-        'name': 'optional_enum',
-        'is_list': False,
-        'optional': True,
-        'type': 'enums.ABeautifulEnum',
-        'documentation': None,
-    },
-    'boolean': {
-        'name': 'boolean',
-        'is_list': False,
-        'optional': False,
-        'type': '_bool',
-        'documentation': None,
-    },
-    'optional_boolean': {
-        'name': 'optional_boolean',
-        'is_list': False,
-        'optional': True,
-        'type': '_bool',
-        'documentation': None,
-    },
-}
+_ManyRequired_fields: Dict['types.ManyRequiredKeys', PartialModelField] = OrderedDict(
+    [
+        ('id', {
+            'name': 'id',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('one', {
+            'name': 'one',
+            'is_list': False,
+            'optional': True,
+            'type': 'models.OneOptional',
+            'documentation': None,
+        }),
+        ('one_optional_id', {
+            'name': 'one_optional_id',
+            'is_list': False,
+            'optional': True,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('int', {
+            'name': 'int',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('optional_int', {
+            'name': 'optional_int',
+            'is_list': False,
+            'optional': True,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('float', {
+            'name': 'float',
+            'is_list': False,
+            'optional': False,
+            'type': '_float',
+            'documentation': None,
+        }),
+        ('optional_float', {
+            'name': 'optional_float',
+            'is_list': False,
+            'optional': True,
+            'type': '_float',
+            'documentation': None,
+        }),
+        ('string', {
+            'name': 'string',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('optional_string', {
+            'name': 'optional_string',
+            'is_list': False,
+            'optional': True,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('enum', {
+            'name': 'enum',
+            'is_list': False,
+            'optional': False,
+            'type': 'enums.ABeautifulEnum',
+            'documentation': None,
+        }),
+        ('optional_enum', {
+            'name': 'optional_enum',
+            'is_list': False,
+            'optional': True,
+            'type': 'enums.ABeautifulEnum',
+            'documentation': None,
+        }),
+        ('boolean', {
+            'name': 'boolean',
+            'is_list': False,
+            'optional': False,
+            'type': '_bool',
+            'documentation': None,
+        }),
+        ('optional_boolean', {
+            'name': 'optional_boolean',
+            'is_list': False,
+            'optional': True,
+            'type': '_bool',
+            'documentation': None,
+        }),
+    ],
+)
 
 _Lists_relational_fields: Set[str] = set()  # pyright: ignore[reportUnusedVariable]
-_Lists_fields: Dict['types.ListsKeys', PartialModelField] = {
-    'id': {
-        'name': 'id',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'strings': {
-        'name': 'strings',
-        'is_list': True,
-        'optional': False,
-        'type': 'List[_str]',
-        'documentation': None,
-    },
-    'bytes': {
-        'name': 'bytes',
-        'is_list': True,
-        'optional': False,
-        'type': 'List[\'fields.Base64\']',
-        'documentation': None,
-    },
-    'dates': {
-        'name': 'dates',
-        'is_list': True,
-        'optional': False,
-        'type': 'List[datetime.datetime]',
-        'documentation': None,
-    },
-    'bools': {
-        'name': 'bools',
-        'is_list': True,
-        'optional': False,
-        'type': 'List[_bool]',
-        'documentation': None,
-    },
-    'ints': {
-        'name': 'ints',
-        'is_list': True,
-        'optional': False,
-        'type': 'List[_int]',
-        'documentation': None,
-    },
-    'floats': {
-        'name': 'floats',
-        'is_list': True,
-        'optional': False,
-        'type': 'List[_float]',
-        'documentation': None,
-    },
-    'bigints': {
-        'name': 'bigints',
-        'is_list': True,
-        'optional': False,
-        'type': 'List[_int]',
-        'documentation': None,
-    },
-    'json_objects': {
-        'name': 'json_objects',
-        'is_list': True,
-        'optional': False,
-        'type': 'List[\'fields.Json\']',
-        'documentation': None,
-    },
-    'decimals': {
-        'name': 'decimals',
-        'is_list': True,
-        'optional': False,
-        'type': 'List[decimal.Decimal]',
-        'documentation': None,
-    },
-}
+_Lists_fields: Dict['types.ListsKeys', PartialModelField] = OrderedDict(
+    [
+        ('id', {
+            'name': 'id',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('strings', {
+            'name': 'strings',
+            'is_list': True,
+            'optional': False,
+            'type': 'List[_str]',
+            'documentation': None,
+        }),
+        ('bytes', {
+            'name': 'bytes',
+            'is_list': True,
+            'optional': False,
+            'type': 'List[\'fields.Base64\']',
+            'documentation': None,
+        }),
+        ('dates', {
+            'name': 'dates',
+            'is_list': True,
+            'optional': False,
+            'type': 'List[datetime.datetime]',
+            'documentation': None,
+        }),
+        ('bools', {
+            'name': 'bools',
+            'is_list': True,
+            'optional': False,
+            'type': 'List[_bool]',
+            'documentation': None,
+        }),
+        ('ints', {
+            'name': 'ints',
+            'is_list': True,
+            'optional': False,
+            'type': 'List[_int]',
+            'documentation': None,
+        }),
+        ('floats', {
+            'name': 'floats',
+            'is_list': True,
+            'optional': False,
+            'type': 'List[_float]',
+            'documentation': None,
+        }),
+        ('bigints', {
+            'name': 'bigints',
+            'is_list': True,
+            'optional': False,
+            'type': 'List[_int]',
+            'documentation': None,
+        }),
+        ('json_objects', {
+            'name': 'json_objects',
+            'is_list': True,
+            'optional': False,
+            'type': 'List[\'fields.Json\']',
+            'documentation': None,
+        }),
+        ('decimals', {
+            'name': 'decimals',
+            'is_list': True,
+            'optional': False,
+            'type': 'List[decimal.Decimal]',
+            'documentation': None,
+        }),
+    ],
+)
 
 _A_relational_fields: Set[str] = set()  # pyright: ignore[reportUnusedVariable]
-_A_fields: Dict['types.AKeys', PartialModelField] = {
-    'email': {
-        'name': 'email',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'name': {
-        'name': 'name',
-        'is_list': False,
-        'optional': True,
-        'type': '_str',
-        'documentation': None,
-    },
-    'int': {
-        'name': 'int',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'sInt': {
-        'name': 'sInt',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'inc_int': {
-        'name': 'inc_int',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'inc_sInt': {
-        'name': 'inc_sInt',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'bInt': {
-        'name': 'bInt',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'inc_bInt': {
-        'name': 'inc_bInt',
-        'is_list': False,
-        'optional': False,
-        'type': '_int',
-        'documentation': None,
-    },
-    'enum': {
-        'name': 'enum',
-        'is_list': False,
-        'optional': False,
-        'type': 'enums.ABeautifulEnum',
-        'documentation': None,
-    },
-}
+_A_fields: Dict['types.AKeys', PartialModelField] = OrderedDict(
+    [
+        ('email', {
+            'name': 'email',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('name', {
+            'name': 'name',
+            'is_list': False,
+            'optional': True,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('int', {
+            'name': 'int',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('sInt', {
+            'name': 'sInt',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('inc_int', {
+            'name': 'inc_int',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('inc_sInt', {
+            'name': 'inc_sInt',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('bInt', {
+            'name': 'bInt',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('inc_bInt', {
+            'name': 'inc_bInt',
+            'is_list': False,
+            'optional': False,
+            'type': '_int',
+            'documentation': None,
+        }),
+        ('enum', {
+            'name': 'enum',
+            'is_list': False,
+            'optional': False,
+            'type': 'enums.ABeautifulEnum',
+            'documentation': None,
+        }),
+    ],
+)
 
 _B_relational_fields: Set[str] = set()  # pyright: ignore[reportUnusedVariable]
-_B_fields: Dict['types.BKeys', PartialModelField] = {
-    'id': {
-        'name': 'id',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'float': {
-        'name': 'float',
-        'is_list': False,
-        'optional': False,
-        'type': '_float',
-        'documentation': None,
-    },
-    'd_float': {
-        'name': 'd_float',
-        'is_list': False,
-        'optional': False,
-        'type': '_float',
-        'documentation': None,
-    },
-    'decFloat': {
-        'name': 'decFloat',
-        'is_list': False,
-        'optional': False,
-        'type': 'decimal.Decimal',
-        'documentation': None,
-    },
-    'numFloat': {
-        'name': 'numFloat',
-        'is_list': False,
-        'optional': False,
-        'type': 'decimal.Decimal',
-        'documentation': None,
-    },
-}
+_B_fields: Dict['types.BKeys', PartialModelField] = OrderedDict(
+    [
+        ('id', {
+            'name': 'id',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('float', {
+            'name': 'float',
+            'is_list': False,
+            'optional': False,
+            'type': '_float',
+            'documentation': None,
+        }),
+        ('d_float', {
+            'name': 'd_float',
+            'is_list': False,
+            'optional': False,
+            'type': '_float',
+            'documentation': None,
+        }),
+        ('decFloat', {
+            'name': 'decFloat',
+            'is_list': False,
+            'optional': False,
+            'type': 'decimal.Decimal',
+            'documentation': None,
+        }),
+        ('numFloat', {
+            'name': 'numFloat',
+            'is_list': False,
+            'optional': False,
+            'type': 'decimal.Decimal',
+            'documentation': None,
+        }),
+    ],
+)
 
 _C_relational_fields: Set[str] = set()  # pyright: ignore[reportUnusedVariable]
-_C_fields: Dict['types.CKeys', PartialModelField] = {
-    'char': {
-        'name': 'char',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'v_char': {
-        'name': 'v_char',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'text': {
-        'name': 'text',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'bit': {
-        'name': 'bit',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'v_bit': {
-        'name': 'v_bit',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'uuid': {
-        'name': 'uuid',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-}
+_C_fields: Dict['types.CKeys', PartialModelField] = OrderedDict(
+    [
+        ('char', {
+            'name': 'char',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('v_char', {
+            'name': 'v_char',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('text', {
+            'name': 'text',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('bit', {
+            'name': 'bit',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('v_bit', {
+            'name': 'v_bit',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('uuid', {
+            'name': 'uuid',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+    ],
+)
 
 _D_relational_fields: Set[str] = set()  # pyright: ignore[reportUnusedVariable]
-_D_fields: Dict['types.DKeys', PartialModelField] = {
-    'id': {
-        'name': 'id',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'bool': {
-        'name': 'bool',
-        'is_list': False,
-        'optional': False,
-        'type': '_bool',
-        'documentation': None,
-    },
-    'xml': {
-        'name': 'xml',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'json_': {
-        'name': 'json_',
-        'is_list': False,
-        'optional': False,
-        'type': 'fields.Json',
-        'documentation': None,
-    },
-    'jsonb': {
-        'name': 'jsonb',
-        'is_list': False,
-        'optional': False,
-        'type': 'fields.Json',
-        'documentation': None,
-    },
-    'binary': {
-        'name': 'binary',
-        'is_list': False,
-        'optional': False,
-        'type': 'fields.Base64',
-        'documentation': None,
-    },
-}
+_D_fields: Dict['types.DKeys', PartialModelField] = OrderedDict(
+    [
+        ('id', {
+            'name': 'id',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('bool', {
+            'name': 'bool',
+            'is_list': False,
+            'optional': False,
+            'type': '_bool',
+            'documentation': None,
+        }),
+        ('xml', {
+            'name': 'xml',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('json_', {
+            'name': 'json_',
+            'is_list': False,
+            'optional': False,
+            'type': 'fields.Json',
+            'documentation': None,
+        }),
+        ('jsonb', {
+            'name': 'jsonb',
+            'is_list': False,
+            'optional': False,
+            'type': 'fields.Json',
+            'documentation': None,
+        }),
+        ('binary', {
+            'name': 'binary',
+            'is_list': False,
+            'optional': False,
+            'type': 'fields.Base64',
+            'documentation': None,
+        }),
+    ],
+)
 
 _E_relational_fields: Set[str] = set()  # pyright: ignore[reportUnusedVariable]
-_E_fields: Dict['types.EKeys', PartialModelField] = {
-    'id': {
-        'name': 'id',
-        'is_list': False,
-        'optional': False,
-        'type': '_str',
-        'documentation': None,
-    },
-    'date': {
-        'name': 'date',
-        'is_list': False,
-        'optional': False,
-        'type': 'datetime.datetime',
-        'documentation': None,
-    },
-    'time': {
-        'name': 'time',
-        'is_list': False,
-        'optional': False,
-        'type': 'datetime.datetime',
-        'documentation': None,
-    },
-    'ts': {
-        'name': 'ts',
-        'is_list': False,
-        'optional': False,
-        'type': 'datetime.datetime',
-        'documentation': None,
-    },
-}
+_E_fields: Dict['types.EKeys', PartialModelField] = OrderedDict(
+    [
+        ('id', {
+            'name': 'id',
+            'is_list': False,
+            'optional': False,
+            'type': '_str',
+            'documentation': None,
+        }),
+        ('date', {
+            'name': 'date',
+            'is_list': False,
+            'optional': False,
+            'type': 'datetime.datetime',
+            'documentation': None,
+        }),
+        ('time', {
+            'name': 'time',
+            'is_list': False,
+            'optional': False,
+            'type': 'datetime.datetime',
+            'documentation': None,
+        }),
+        ('ts', {
+            'name': 'ts',
+            'is_list': False,
+            'optional': False,
+            'type': 'datetime.datetime',
+            'documentation': None,
+        }),
+    ],
+)
 
 
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[models.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[models.py].raw
@@ -171,28 +171,29 @@ class Post(BaseModel):
         try:
             if include:
                 for field in include:
-                    fields[field] = _Post_fields[field]
+                    fields[field] = _Post_fields[field].copy()
             elif exclude:
                 for field in exclude:
                     if field not in _Post_fields:
                         raise KeyError(field)
 
                 fields = {
-                    key: data
+                    key: data.copy()
                     for key, data in _Post_fields.items()
                     if key not in exclude
                 }
             else:
-                fields = _Post_fields.copy()
+                fields = {
+                    key: data.copy()
+                    for key, data in _Post_fields.items()
+                }
 
             if required:
                 for field in required:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = False
 
             if optional:
                 for field in optional:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = True
 
             if exclude_relational_fields:
@@ -314,28 +315,29 @@ class User(BaseModel):
         try:
             if include:
                 for field in include:
-                    fields[field] = _User_fields[field]
+                    fields[field] = _User_fields[field].copy()
             elif exclude:
                 for field in exclude:
                     if field not in _User_fields:
                         raise KeyError(field)
 
                 fields = {
-                    key: data
+                    key: data.copy()
                     for key, data in _User_fields.items()
                     if key not in exclude
                 }
             else:
-                fields = _User_fields.copy()
+                fields = {
+                    key: data.copy()
+                    for key, data in _User_fields.items()
+                }
 
             if required:
                 for field in required:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = False
 
             if optional:
                 for field in optional:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = True
 
             if exclude_relational_fields:
@@ -453,28 +455,29 @@ class M(BaseModel):
         try:
             if include:
                 for field in include:
-                    fields[field] = _M_fields[field]
+                    fields[field] = _M_fields[field].copy()
             elif exclude:
                 for field in exclude:
                     if field not in _M_fields:
                         raise KeyError(field)
 
                 fields = {
-                    key: data
+                    key: data.copy()
                     for key, data in _M_fields.items()
                     if key not in exclude
                 }
             else:
-                fields = _M_fields.copy()
+                fields = {
+                    key: data.copy()
+                    for key, data in _M_fields.items()
+                }
 
             if required:
                 for field in required:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = False
 
             if optional:
                 for field in optional:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = True
 
             if exclude_relational_fields:
@@ -594,28 +597,29 @@ class N(BaseModel):
         try:
             if include:
                 for field in include:
-                    fields[field] = _N_fields[field]
+                    fields[field] = _N_fields[field].copy()
             elif exclude:
                 for field in exclude:
                     if field not in _N_fields:
                         raise KeyError(field)
 
                 fields = {
-                    key: data
+                    key: data.copy()
                     for key, data in _N_fields.items()
                     if key not in exclude
                 }
             else:
-                fields = _N_fields.copy()
+                fields = {
+                    key: data.copy()
+                    for key, data in _N_fields.items()
+                }
 
             if required:
                 for field in required:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = False
 
             if optional:
                 for field in optional:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = True
 
             if exclude_relational_fields:
@@ -733,28 +737,29 @@ class OneOptional(BaseModel):
         try:
             if include:
                 for field in include:
-                    fields[field] = _OneOptional_fields[field]
+                    fields[field] = _OneOptional_fields[field].copy()
             elif exclude:
                 for field in exclude:
                     if field not in _OneOptional_fields:
                         raise KeyError(field)
 
                 fields = {
-                    key: data
+                    key: data.copy()
                     for key, data in _OneOptional_fields.items()
                     if key not in exclude
                 }
             else:
-                fields = _OneOptional_fields.copy()
+                fields = {
+                    key: data.copy()
+                    for key, data in _OneOptional_fields.items()
+                }
 
             if required:
                 for field in required:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = False
 
             if optional:
                 for field in optional:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = True
 
             if exclude_relational_fields:
@@ -873,28 +878,29 @@ class ManyRequired(BaseModel):
         try:
             if include:
                 for field in include:
-                    fields[field] = _ManyRequired_fields[field]
+                    fields[field] = _ManyRequired_fields[field].copy()
             elif exclude:
                 for field in exclude:
                     if field not in _ManyRequired_fields:
                         raise KeyError(field)
 
                 fields = {
-                    key: data
+                    key: data.copy()
                     for key, data in _ManyRequired_fields.items()
                     if key not in exclude
                 }
             else:
-                fields = _ManyRequired_fields.copy()
+                fields = {
+                    key: data.copy()
+                    for key, data in _ManyRequired_fields.items()
+                }
 
             if required:
                 for field in required:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = False
 
             if optional:
                 for field in optional:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = True
 
             if exclude_relational_fields:
@@ -1010,28 +1016,29 @@ class Lists(BaseModel):
         try:
             if include:
                 for field in include:
-                    fields[field] = _Lists_fields[field]
+                    fields[field] = _Lists_fields[field].copy()
             elif exclude:
                 for field in exclude:
                     if field not in _Lists_fields:
                         raise KeyError(field)
 
                 fields = {
-                    key: data
+                    key: data.copy()
                     for key, data in _Lists_fields.items()
                     if key not in exclude
                 }
             else:
-                fields = _Lists_fields.copy()
+                fields = {
+                    key: data.copy()
+                    for key, data in _Lists_fields.items()
+                }
 
             if required:
                 for field in required:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = False
 
             if optional:
                 for field in optional:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = True
 
 
@@ -1122,28 +1129,29 @@ class A(BaseModel):
         try:
             if include:
                 for field in include:
-                    fields[field] = _A_fields[field]
+                    fields[field] = _A_fields[field].copy()
             elif exclude:
                 for field in exclude:
                     if field not in _A_fields:
                         raise KeyError(field)
 
                 fields = {
-                    key: data
+                    key: data.copy()
                     for key, data in _A_fields.items()
                     if key not in exclude
                 }
             else:
-                fields = _A_fields.copy()
+                fields = {
+                    key: data.copy()
+                    for key, data in _A_fields.items()
+                }
 
             if required:
                 for field in required:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = False
 
             if optional:
                 for field in optional:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = True
 
 
@@ -1230,28 +1238,29 @@ class B(BaseModel):
         try:
             if include:
                 for field in include:
-                    fields[field] = _B_fields[field]
+                    fields[field] = _B_fields[field].copy()
             elif exclude:
                 for field in exclude:
                     if field not in _B_fields:
                         raise KeyError(field)
 
                 fields = {
-                    key: data
+                    key: data.copy()
                     for key, data in _B_fields.items()
                     if key not in exclude
                 }
             else:
-                fields = _B_fields.copy()
+                fields = {
+                    key: data.copy()
+                    for key, data in _B_fields.items()
+                }
 
             if required:
                 for field in required:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = False
 
             if optional:
                 for field in optional:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = True
 
 
@@ -1339,28 +1348,29 @@ class C(BaseModel):
         try:
             if include:
                 for field in include:
-                    fields[field] = _C_fields[field]
+                    fields[field] = _C_fields[field].copy()
             elif exclude:
                 for field in exclude:
                     if field not in _C_fields:
                         raise KeyError(field)
 
                 fields = {
-                    key: data
+                    key: data.copy()
                     for key, data in _C_fields.items()
                     if key not in exclude
                 }
             else:
-                fields = _C_fields.copy()
+                fields = {
+                    key: data.copy()
+                    for key, data in _C_fields.items()
+                }
 
             if required:
                 for field in required:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = False
 
             if optional:
                 for field in optional:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = True
 
 
@@ -1448,28 +1458,29 @@ class D(BaseModel):
         try:
             if include:
                 for field in include:
-                    fields[field] = _D_fields[field]
+                    fields[field] = _D_fields[field].copy()
             elif exclude:
                 for field in exclude:
                     if field not in _D_fields:
                         raise KeyError(field)
 
                 fields = {
-                    key: data
+                    key: data.copy()
                     for key, data in _D_fields.items()
                     if key not in exclude
                 }
             else:
-                fields = _D_fields.copy()
+                fields = {
+                    key: data.copy()
+                    for key, data in _D_fields.items()
+                }
 
             if required:
                 for field in required:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = False
 
             if optional:
                 for field in optional:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = True
 
 
@@ -1555,28 +1566,29 @@ class E(BaseModel):
         try:
             if include:
                 for field in include:
-                    fields[field] = _E_fields[field]
+                    fields[field] = _E_fields[field].copy()
             elif exclude:
                 for field in exclude:
                     if field not in _E_fields:
                         raise KeyError(field)
 
                 fields = {
-                    key: data
+                    key: data.copy()
                     for key, data in _E_fields.items()
                     if key not in exclude
                 }
             else:
-                fields = _E_fields.copy()
+                fields = {
+                    key: data.copy()
+                    for key, data in _E_fields.items()
+                }
 
             if required:
                 for field in required:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = False
 
             if optional:
                 for field in optional:
-                    fields[field] = fields[field].copy()
                     fields[field]['optional'] = True
 
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[partials.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[partials.py].raw
@@ -41,8 +41,8 @@ from . import types, models, fields, enums
 
 class PostWithAuthor(BaseModel):
     id: _str
-    author: Optional[models.User]
     title: _str
+    author: Optional[models.User]
 
     Config = models.Config
 
@@ -55,23 +55,23 @@ class UserOnlyName(BaseModel):
 
 class PostWithCustomAuthor(BaseModel):
     id: _str
-    author: Optional['partials.UserOnlyName']
     title: _str
+    author: Optional['partials.UserOnlyName']
 
     Config = models.Config
 
 
 class UserWithPosts(BaseModel):
-    posts: Optional[List['models.Post']]
     name: _str
+    posts: Optional[List['models.Post']]
 
     Config = models.Config
 
 
 class PostWithNestedRelations(BaseModel):
     id: _str
-    author: Optional['partials.UserWithPosts']
     title: _str
+    author: Optional['partials.UserWithPosts']
 
     Config = models.Config
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[partials.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[partials.py].raw
@@ -40,8 +40,8 @@ from . import types, models, fields, enums
 
 
 class PostWithAuthor(BaseModel):
-    author: Optional[models.User]
     id: _str
+    author: Optional[models.User]
     title: _str
 
     Config = models.Config
@@ -54,23 +54,23 @@ class UserOnlyName(BaseModel):
 
 
 class PostWithCustomAuthor(BaseModel):
-    author: Optional['partials.UserOnlyName']
     id: _str
+    author: Optional['partials.UserOnlyName']
     title: _str
 
     Config = models.Config
 
 
 class UserWithPosts(BaseModel):
-    name: _str
     posts: Optional[List['models.Post']]
+    name: _str
 
     Config = models.Config
 
 
 class PostWithNestedRelations(BaseModel):
-    author: Optional['partials.UserWithPosts']
     id: _str
+    author: Optional['partials.UserWithPosts']
     title: _str
 
     Config = models.Config

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[partials.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[partials.py].raw
@@ -39,11 +39,53 @@ from pydantic import BaseModel, Field, validator
 from . import types, models, fields, enums
 
 
+class PostWithAuthor(BaseModel):
+    author: Optional[models.User]
+    id: _str
+    title: _str
+
+    Config = models.Config
+
+
+class UserOnlyName(BaseModel):
+    name: _str
+
+    Config = models.Config
+
+
+class PostWithCustomAuthor(BaseModel):
+    author: Optional['partials.UserOnlyName']
+    id: _str
+    title: _str
+
+    Config = models.Config
+
+
+class UserWithPosts(BaseModel):
+    name: _str
+    posts: Optional[List['models.Post']]
+
+    Config = models.Config
+
+
+class PostWithNestedRelations(BaseModel):
+    author: Optional['partials.UserWithPosts']
+    id: _str
+    title: _str
+
+    Config = models.Config
+
+
 
 # users can modify relational types which are then namespaced to partials.
 # so we have to import ourselves in order to resolve forward references
 from . import partials
 
+PostWithAuthor.update_forward_refs()
+UserOnlyName.update_forward_refs()
+PostWithCustomAuthor.update_forward_refs()
+UserWithPosts.update_forward_refs()
+PostWithNestedRelations.update_forward_refs()
 
 # fmt: on
 

--- a/tests/test_generation/exhaustive/async.schema.prisma
+++ b/tests/test_generation/exhaustive/async.schema.prisma
@@ -11,6 +11,7 @@ generator db {
   recursive_type_depth        = 3
   output                      = "../../../.tests_cache/generation/exhaustive/__prisma_async_output__/prisma"
   enable_experimental_decimal = true
+  partial_type_generator      = "tests/test_generation/exhaustive/partials.py"
 }
 
 /// Post model documentation

--- a/tests/test_generation/exhaustive/partials.py
+++ b/tests/test_generation/exhaustive/partials.py
@@ -1,21 +1,21 @@
 from prisma.models import Post, User
 
 
-Post.create_partial('PostWithAuthor', include={'id', 'title', 'author'})
+Post.create_partial('PostWithAuthor', include=['id', 'title', 'author'])
 
-User.create_partial('UserOnlyName', include={'name'})
+User.create_partial('UserOnlyName', include=['name'])
 Post.create_partial(
     'PostWithCustomAuthor',
-    include={'id', 'title', 'author'},
+    include=['id', 'title', 'author'],
     relations={
         'author': 'UserOnlyName',
     },
 )
 
-User.create_partial('UserWithPosts', include={'name', 'posts'})
+User.create_partial('UserWithPosts', include=['name', 'posts'])
 Post.create_partial(
     'PostWithNestedRelations',
-    include={'id', 'title', 'author'},
+    include=['id', 'title', 'author'],
     relations={
         'author': 'UserWithPosts',
     },

--- a/tests/test_generation/exhaustive/partials.py
+++ b/tests/test_generation/exhaustive/partials.py
@@ -1,0 +1,22 @@
+from prisma.models import Post, User
+
+
+Post.create_partial('PostWithAuthor', include={'id', 'title', 'author'})
+
+User.create_partial('UserOnlyName', include={'name'})
+Post.create_partial(
+    'PostWithCustomAuthor',
+    include={'id', 'title', 'author'},
+    relations={
+        'author': 'UserOnlyName',
+    },
+)
+
+User.create_partial('UserWithPosts', include={'name', 'posts'})
+Post.create_partial(
+    'PostWithNestedRelations',
+    include={'id', 'title', 'author'},
+    relations={
+        'author': 'UserWithPosts',
+    },
+)

--- a/tests/test_generation/exhaustive/sync.schema.prisma
+++ b/tests/test_generation/exhaustive/sync.schema.prisma
@@ -11,6 +11,7 @@ generator db {
   recursive_type_depth        = 3
   output                      = "../../../.tests_cache/generation/exhaustive/__prisma_sync_output__/prisma"
   enable_experimental_decimal = true
+  partial_type_generator      = "tests/test_generation/exhaustive/partials.py"
 }
 
 /// Post model documentation


### PR DESCRIPTION
## Change Summary

Under certain conditions the generation of a partial type may use an incorrect type if another partial type was then generated that modified a relational type.

For example given this partial type generator:

```py
from prisma.models import Post, User

Post.create_partial('PostWithAuthor', include={'id', 'title', 'author'})

User.create_partial('UserOnlyName', include={'name'})
Post.create_partial(
    'PostWithCustomAuthor',
    include={'id', 'title', 'author'},
    relations={
        'author': 'UserOnlyName',
    },
)

User.create_partial('UserWithPosts', include={'name', 'posts'})
Post.create_partial(
    'PostWithNestedRelations',
    include={'id', 'title', 'author'},
    relations={
        'author': 'UserWithPosts',
    },
)
```

Would generate this partial type:

```py
class PostWithAuthor(BaseModel):
    title: _str
    author: Optional['partials.UserWithPosts']
    id: _str
```

This is obviously wrong as we haven't modified the relational types for the `PostWithAuthor` type.

This PR fixes partial type generation such that the correct type is generated in this case:

```py
class PostWithAuthor(BaseModel):
    id: _str
    title: _str
    author: Optional[models.User]
```

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
