### PR TITLE
feat(databases): add inverse tests for unsupported features

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -248,6 +248,14 @@ jobs:
           ${{ matrix.env }}: ${{ matrix.url }}
           COVERAGE_FILE: .cache/.coverage.databases
 
+      # these tests ensure that unsupported features, e.g. enums on SQLite actually fail
+      - name: Run inverse tests
+        run: |
+          coverage run -m nox -s databases -- test-inverse --coverage --databases=${{ matrix.name }}
+        env:
+          ${{ matrix.env }}: ${{ matrix.url }}
+          COVERAGE_FILE: .cache/.coverage.databases
+
       - name: Upload coverage
         uses: actions/upload-artifact@v3
         with:

--- a/databases/main.py
+++ b/databases/main.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
 import os
+import re
 import json
 import shlex
 import shutil
+import contextlib
 from pathlib import Path
 from copy import deepcopy
 from contextvars import ContextVar, copy_context
 from typing import (
     Iterable,
     Optional,
+    Iterator,
     cast,
 )
 
@@ -18,6 +21,7 @@ import yaml
 import click
 import rtoml
 import typer
+from nox.command import CommandFailed
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 
 from lib.utils import flatten, escape_path
@@ -70,17 +74,7 @@ def test(
     databases = validate_databases(databases)
 
     with session.chdir(DATABASES_DIR):
-        # setup env
-        session.install('-r', 'requirements.txt')
-        maybe_install_nodejs_bin(session)
-
-        if inplace:  # pragma: no cover
-            # useful for updating the generated code so that Pylance picks it up
-            session.install('-U', '-e', '..')
-        else:
-            session.install('-U', '..')
-
-        session.run('python', '-m', 'prisma', 'py', 'version')
+        _setup_test_env(session, inplace=inplace)
 
         for database in databases:
             print(title(CONFIG_MAPPING[database].name))
@@ -107,6 +101,127 @@ def serve(database: str, *, version: Optional[str] = None) -> None:
     start_database(database, version=version, session=session_ctx.get())
 
 
+@cli.command(name='test-inverse')
+def test_inverse(
+    *,
+    databases: list[str] = SUPPORTED_DATABASES,
+    coverage: bool = False,
+    inplace: bool = False,
+    pytest_args: Optional[str] = None,
+) -> None:
+    """Ensure unsupported features actually result in either:
+
+    - Prisma Schema validation failing
+    - Our unit tests & linters fail
+    """
+    session = session_ctx.get()
+    databases = validate_databases(databases)
+
+    with session.chdir(DATABASES_DIR):
+        _setup_test_env(session, inplace=inplace)
+
+        for database in databases:
+            config = CONFIG_MAPPING[database]
+            print(title(config.name))
+
+            if not config.unsupported_features:
+                print(f'There are no unsupported features for {database}.')
+                continue
+
+            # point coverage to store data in a database specific location
+            # as to not overwrite any existing data from other database tests
+            if coverage:  # pragma: no branch
+                setup_coverage(session, identifier=database)
+
+            # TODO: support for tesing a given list of unsupported features
+            for feature in config.unsupported_features:
+                print(title(f'Testing {feature} feature'))
+
+                new_config = config.copy(deep=True)
+                new_config.unsupported_features.remove(feature)
+
+                runner = Runner(
+                    database=database,
+                    config=new_config,
+                    track_coverage=coverage,
+                )
+
+                with raises_command({1}) as result:
+                    runner.setup()
+
+                if result.did_raise:
+                    print(
+                        'Test setup failed (expectedly); Skipping pytest & pyright checks'
+                    )
+                    continue
+
+                with raises_command({1}):
+                    runner.test(pytest_args=pytest_args)
+
+                with raises_command({1}):
+                    runner.lint()
+
+            click.echo(
+                click.style(
+                    f'✅ All tests successfully failed for {database}',
+                    fg='green',
+                )
+            )
+
+
+def _setup_test_env(session: nox.Session, *, inplace: bool) -> None:
+    session.install('-r', 'requirements.txt')
+    maybe_install_nodejs_bin(session)
+
+    if inplace:  # pragma: no cover
+        # useful for updating the generated code so that Pylance picks it up
+        session.install('-U', '-e', '..')
+    else:
+        session.install('-U', '..')
+
+    session.run('python', '-m', 'prisma', 'py', 'version')
+
+
+class RaisesCommandResult:
+    did_raise: bool
+
+    def __init__(self) -> None:
+        self.did_raise = False
+
+
+# matches nox's CommandFailed exception message
+COMMAND_FAILED_RE = re.compile(r'Returned code (\d+)')
+
+
+@contextlib.contextmanager
+def raises_command(
+    allowed_exit_codes: set[int],
+) -> Iterator[RaisesCommandResult]:
+    """Context manager that intercepts and ignores `nox.CommandFailed` exceptions
+    that are raised due to known exit codes. All other exceptions are passed through.
+    """
+    result = RaisesCommandResult()
+
+    try:
+        yield result
+    except CommandFailed as exc:
+        match = COMMAND_FAILED_RE.match(exc.reason or '')
+        if match is None:
+            raise RuntimeError(
+                f'Could not extract exit code from exception {exc}'
+            )
+
+        exit_code = int(match.group(1))
+        if exit_code not in allowed_exit_codes:
+            raise RuntimeError(
+                f'Unknown code: {exit_code}; Something may have gone wrong '
+                + 'or this exit code must be added to the list of known exit codes; '
+                + f'Allowed exit codes: {allowed_exit_codes}'
+            )
+
+        result.did_raise = True
+
+
 class Runner:
     database: SupportedDatabase
     session: nox.Session
@@ -119,11 +234,12 @@ class Runner:
         *,
         database: SupportedDatabase,
         track_coverage: bool,
+        config: DatabaseConfig | None = None,
     ) -> None:
         self.database = database
         self.session = session_ctx.get()
         self.track_coverage = track_coverage
-        self.config = CONFIG_MAPPING[database]
+        self.config = config or CONFIG_MAPPING[database]
         self.cache_dir = ROOT_DIR / '.tests_cache' / 'databases' / database
 
     def _create_cache_dir(self) -> None:

--- a/databases/tests/test_create_many.py
+++ b/databases/tests/test_create_many.py
@@ -1,22 +1,19 @@
 import pytest
 import prisma
 from prisma import Prisma
-from prisma.enums import Role
 
 
 @pytest.mark.asyncio
 async def test_create_many(client: Prisma) -> None:
     """Standard usage"""
-    # TODO: this should work without Role
     total = await client.user.create_many(
-        [{'name': 'Robert', 'role': Role.ADMIN}, {'name': 'Tegan'}]
+        [{'name': 'Robert'}, {'name': 'Tegan'}]
     )
     assert total == 2
 
     user = await client.user.find_first(where={'name': 'Robert'})
     assert user is not None
     assert user.name == 'Robert'
-    assert user.role == Role.ADMIN
 
     assert await client.user.count() == 2
 


### PR DESCRIPTION
## Change Summary

This PR adds inverse tests to our database testing suite to ensure that unsupported features are actually unsupported and trying to use them will result in either a Prisma Schema validation fail or type checking to fail & runtime tests to fail.

This currently just checks that running these commands fail but in the future we'll probably want more fine grained checks to ensure that the exact right things are failing.

closes #561

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
