### PR TITLE
feat(client): add support for CockroachDB

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -208,10 +208,10 @@ jobs:
             url: postgresql://postgres:prisma@localhost:5438/postgres
 
           # Temporarily disabled due to https://github.com/RobertCraigie/prisma-client-py/issues/636
-          # - name: CockroachDB
-          #   version: '22'
-          #   env: COCKROACHDB_URL
-          #   url: postgresql://prisma@localhost:26257/postgres
+          - name: CockroachDB
+            version: '22'
+            env: COCKROACHDB_URL
+            url: postgresql://prisma@localhost:26257/postgres
 
           - name: MariaDB
             version: '10.0'

--- a/databases/constants.py
+++ b/databases/constants.py
@@ -37,6 +37,7 @@ CONFIG_MAPPING: DatabaseMapping[DatabaseConfig] = {
         autoincrement_id='BigInt @id @default(sequence())',
         unsupported_features={
             'json_arrays',
+            'array_push',
         },
     ),
     'sqlite': DatabaseConfig(
@@ -98,9 +99,10 @@ FEATURES_MAPPING: dict[DatabaseFeature, list[str]] = {
         'types/raw_queries/test_json.py',
     ],
     'arrays': [*_fromdir('arrays'), *_fromdir('types/raw_queries/arrays')],
+    'array_push': _fromdir('arrays/push'),
+    'json_arrays': ['arrays/test_json.py', 'arrays/push/test_json.py'],
     # not yet implemented
     'date': [],
-    'json_arrays': ['arrays/test_json.py'],
     'create_many': ['test_create_many.py'],
     'raw_queries': ['test_raw_queries.py', *_fromdir('types/raw_queries')],
     'case_sensitivity': ['test_case_sensitivity.py'],

--- a/databases/tests/arrays/push/test_bigint.py
+++ b/databases/tests/arrays/push/test_bigint.py
@@ -1,0 +1,45 @@
+import pytest
+from prisma import Prisma
+
+
+@pytest.mark.asyncio
+async def test_pushing_bigints(client: Prisma) -> None:
+    """Pushing values to a BigInt[] field"""
+    models = [
+        await client.lists.create({}),
+        await client.lists.create(
+            data={
+                'bigints': [539506179039297536, 281454500584095754],
+            },
+        ),
+    ]
+
+    model = await client.lists.update(
+        where={
+            'id': models[0].id,
+        },
+        data={
+            'bigints': {
+                'push': [538075535121842179],
+            },
+        },
+    )
+    assert model is not None
+    assert model.bigints == [538075535121842179]
+
+    model = await client.lists.update(
+        where={
+            'id': models[1].id,
+        },
+        data={
+            'bigints': {
+                'push': [186214420957888512],
+            },
+        },
+    )
+    assert model is not None
+    assert model.bigints == [
+        539506179039297536,
+        281454500584095754,
+        186214420957888512,
+    ]

--- a/databases/tests/arrays/push/test_bool.py
+++ b/databases/tests/arrays/push/test_bool.py
@@ -1,0 +1,41 @@
+import pytest
+from prisma import Prisma
+
+
+@pytest.mark.asyncio
+async def test_pushing_boolean(client: Prisma) -> None:
+    """Pushing values to a Boolean[] field"""
+    models = [
+        await client.lists.create({}),
+        await client.lists.create(
+            data={
+                'bools': [False, True],
+            },
+        ),
+    ]
+
+    model = await client.lists.update(
+        where={
+            'id': models[0].id,
+        },
+        data={
+            'bools': {
+                'push': [True, False, True],
+            },
+        },
+    )
+    assert model is not None
+    assert model.bools == [True, False, True]
+
+    model = await client.lists.update(
+        where={
+            'id': models[1].id,
+        },
+        data={
+            'bools': {
+                'push': [False],
+            },
+        },
+    )
+    assert model is not None
+    assert model.bools == [False, True, False]

--- a/databases/tests/arrays/push/test_bytes.py
+++ b/databases/tests/arrays/push/test_bytes.py
@@ -1,0 +1,45 @@
+import pytest
+from prisma import Prisma, Base64
+
+
+@pytest.mark.asyncio
+async def test_pushing_byte(client: Prisma) -> None:
+    """Pushing values to a Bytes[] field"""
+    models = [
+        await client.lists.create({}),
+        await client.lists.create(
+            data={
+                'bytes': [Base64.encode(b'foo'), Base64.encode(b'bar')],
+            },
+        ),
+    ]
+
+    model = await client.lists.update(
+        where={
+            'id': models[0].id,
+        },
+        data={
+            'bytes': {
+                'push': [Base64.encode(b'a'), Base64.encode(b'b')],
+            },
+        },
+    )
+    assert model is not None
+    assert model.bytes == [Base64.encode(b'a'), Base64.encode(b'b')]
+
+    model = await client.lists.update(
+        where={
+            'id': models[1].id,
+        },
+        data={
+            'bytes': {
+                'push': [Base64.encode(b'baz')],
+            },
+        },
+    )
+    assert model is not None
+    assert model.bytes == [
+        Base64.encode(b'foo'),
+        Base64.encode(b'bar'),
+        Base64.encode(b'baz'),
+    ]

--- a/databases/tests/arrays/push/test_datetime.py
+++ b/databases/tests/arrays/push/test_datetime.py
@@ -1,0 +1,61 @@
+from datetime import datetime, timedelta
+from typing import List
+
+import pytest
+from prisma import Prisma
+
+
+def _utcnow() -> datetime:
+    # workaround for https://github.com/RobertCraigie/prisma-client-py/issues/129
+    now = datetime.utcnow()
+    return now.replace(microsecond=int(now.microsecond / 1000) * 1000)
+
+
+def _assert_datelist_equal(
+    actual: List[datetime], expected: List[datetime]
+) -> None:
+    actual = [dt.replace(tzinfo=None) for dt in actual]
+    expected = [dt.replace(tzinfo=None) for dt in expected]
+    assert actual == expected
+
+
+@pytest.mark.asyncio
+async def test_pushing_datetime(client: Prisma) -> None:
+    """Pushing a DateTime[] value"""
+    now = _utcnow()
+    models = [
+        await client.lists.create({}),
+        await client.lists.create(
+            data={
+                'dates': [now, now + timedelta(hours=3)],
+            },
+        ),
+    ]
+
+    model = await client.lists.update(
+        where={
+            'id': models[0].id,
+        },
+        data={
+            'dates': {
+                'push': [now, now + timedelta(days=5)],
+            },
+        },
+    )
+    assert model is not None
+    _assert_datelist_equal(model.dates, [now, now + timedelta(days=5)])
+
+    model = await client.lists.update(
+        where={
+            'id': models[1].id,
+        },
+        data={
+            'dates': {
+                'push': [now + timedelta(hours=7)],
+            },
+        },
+    )
+    assert model is not None
+    _assert_datelist_equal(
+        model.dates, [now, now + timedelta(hours=3), now + timedelta(hours=7)]
+    )

--- a/databases/tests/arrays/push/test_decimal.py
+++ b/databases/tests/arrays/push/test_decimal.py
@@ -1,0 +1,44 @@
+from decimal import Decimal
+
+import pytest
+
+from prisma import Prisma
+
+
+@pytest.mark.asyncio
+async def test_pushing_decimal(client: Prisma) -> None:
+    """Pushing a Decimal[] value"""
+    models = [
+        await client.lists.create({}),
+        await client.lists.create(
+            data={
+                'decimals': [Decimal('22.99'), Decimal('30.01')],
+            },
+        ),
+    ]
+
+    model = await client.lists.update(
+        where={
+            'id': models[0].id,
+        },
+        data={
+            'decimals': {
+                'push': [Decimal('22.99'), Decimal('31')],
+            },
+        },
+    )
+    assert model is not None
+    assert model.decimals == [Decimal('22.99'), Decimal('31')]
+
+    model = await client.lists.update(
+        where={
+            'id': models[1].id,
+        },
+        data={
+            'decimals': {
+                'push': [Decimal('5')],
+            },
+        },
+    )
+    assert model is not None
+    assert model.decimals == [Decimal('22.99'), Decimal('30.01'), Decimal('5')]

--- a/databases/tests/arrays/push/test_enum.py
+++ b/databases/tests/arrays/push/test_enum.py
@@ -1,0 +1,42 @@
+import pytest
+from prisma import Prisma
+from prisma.enums import Role
+
+
+@pytest.mark.asyncio
+async def test_pushing_enum(client: Prisma) -> None:
+    """Pushing a Role[] enum value"""
+    models = [
+        await client.lists.create({}),
+        await client.lists.create(
+            data={
+                'roles': [Role.USER, Role.ADMIN],
+            },
+        ),
+    ]
+
+    model = await client.lists.update(
+        where={
+            'id': models[0].id,
+        },
+        data={
+            'roles': {
+                'push': [Role.ADMIN, Role.USER],
+            },
+        },
+    )
+    assert model is not None
+    assert model.roles == [Role.ADMIN, Role.USER]
+
+    model = await client.lists.update(
+        where={
+            'id': models[1].id,
+        },
+        data={
+            'roles': {
+                'push': [Role.EDITOR],
+            },
+        },
+    )
+    assert model is not None
+    assert model.roles == [Role.USER, Role.ADMIN, Role.EDITOR]

--- a/databases/tests/arrays/push/test_float.py
+++ b/databases/tests/arrays/push/test_float.py
@@ -1,0 +1,41 @@
+import pytest
+from prisma import Prisma
+
+
+@pytest.mark.asyncio
+async def test_pushing_floats(client: Prisma) -> None:
+    """Pushing a Float[] value"""
+    models = [
+        await client.lists.create({}),
+        await client.lists.create(
+            data={
+                'floats': [3.4, 6.8, 12.4],
+            },
+        ),
+    ]
+
+    model = await client.lists.update(
+        where={
+            'id': models[0].id,
+        },
+        data={
+            'floats': {
+                'push': [102.3, 500.7],
+            },
+        },
+    )
+    assert model is not None
+    assert model.floats == [102.3, 500.7]
+
+    model = await client.lists.update(
+        where={
+            'id': models[1].id,
+        },
+        data={
+            'floats': {
+                'push': [20],
+            },
+        },
+    )
+    assert model is not None
+    assert model.floats == [3.4, 6.8, 12.4, 20]

--- a/databases/tests/arrays/push/test_int.py
+++ b/databases/tests/arrays/push/test_int.py
@@ -1,0 +1,41 @@
+import pytest
+from prisma import Prisma
+
+
+@pytest.mark.asyncio
+async def test_pushing_ints(client: Prisma) -> None:
+    """Pushing an Int[] value"""
+    models = [
+        await client.lists.create({}),
+        await client.lists.create(
+            data={
+                'ints': [1, 2, 3],
+            },
+        ),
+    ]
+
+    model = await client.lists.update(
+        where={
+            'id': models[0].id,
+        },
+        data={
+            'ints': {
+                'push': [1023023, 999],
+            },
+        },
+    )
+    assert model is not None
+    assert model.ints == [1023023, 999]
+
+    model = await client.lists.update(
+        where={
+            'id': models[1].id,
+        },
+        data={
+            'ints': {
+                'push': [4],
+            },
+        },
+    )
+    assert model is not None
+    assert model.ints == [1, 2, 3, 4]

--- a/databases/tests/arrays/push/test_json.py
+++ b/databases/tests/arrays/push/test_json.py
@@ -1,0 +1,41 @@
+import pytest
+from prisma import Prisma, Json
+
+
+@pytest.mark.asyncio
+async def test_pushing_json(client: Prisma) -> None:
+    """Pushing a Json[] value"""
+    models = [
+        await client.lists.create({}),
+        await client.lists.create(
+            data={
+                'json_objects': [Json('foo'), Json(['foo', 'bar'])],
+            },
+        ),
+    ]
+
+    model = await client.lists.update(
+        where={
+            'id': models[0].id,
+        },
+        data={
+            'json_objects': {
+                'push': [Json.keys(foo='bar'), Json(True)],
+            },
+        },
+    )
+    assert model is not None
+    assert model.json_objects == [{'foo': 'bar'}, True]
+
+    model = await client.lists.update(
+        where={
+            'id': models[1].id,
+        },
+        data={
+            'json_objects': {
+                'push': [Json('Baz')],
+            },
+        },
+    )
+    assert model is not None
+    assert model.json_objects == ['foo', ['foo', 'bar'], 'Baz']

--- a/databases/tests/arrays/push/test_string.py
+++ b/databases/tests/arrays/push/test_string.py
@@ -1,0 +1,41 @@
+import pytest
+from prisma import Prisma
+
+
+@pytest.mark.asyncio
+async def test_pushing_strings(client: Prisma) -> None:
+    """Pushing a String[] value"""
+    models = [
+        await client.lists.create({}),
+        await client.lists.create(
+            data={
+                'strings': ['a', 'b', 'c'],
+            },
+        ),
+    ]
+
+    model = await client.lists.update(
+        where={
+            'id': models[0].id,
+        },
+        data={
+            'strings': {
+                'push': ['a', 'B'],
+            },
+        },
+    )
+    assert model is not None
+    assert model.strings == ['a', 'B']
+
+    model = await client.lists.update(
+        where={
+            'id': models[1].id,
+        },
+        data={
+            'strings': {
+                'push': ['d'],
+            },
+        },
+    )
+    assert model is not None
+    assert model.strings == ['a', 'b', 'c', 'd']

--- a/databases/tests/arrays/test_bigint.py
+++ b/databases/tests/arrays/test_bigint.py
@@ -16,36 +16,6 @@ async def test_updating_bigints(client: Prisma) -> None:
 
     model = await client.lists.update(
         where={
-            'id': models[0].id,
-        },
-        data={
-            'bigints': {
-                'push': [538075535121842179],
-            },
-        },
-    )
-    assert model is not None
-    assert model.bigints == [538075535121842179]
-
-    model = await client.lists.update(
-        where={
-            'id': models[1].id,
-        },
-        data={
-            'bigints': {
-                'push': [186214420957888512],
-            },
-        },
-    )
-    assert model is not None
-    assert model.bigints == [
-        539506179039297536,
-        281454500584095754,
-        186214420957888512,
-    ]
-
-    model = await client.lists.update(
-        where={
             'id': models[1].id,
         },
         data={

--- a/databases/tests/arrays/test_bool.py
+++ b/databases/tests/arrays/test_bool.py
@@ -16,32 +16,6 @@ async def test_updating_boolean(client: Prisma) -> None:
 
     model = await client.lists.update(
         where={
-            'id': models[0].id,
-        },
-        data={
-            'bools': {
-                'push': [True, False, True],
-            },
-        },
-    )
-    assert model is not None
-    assert model.bools == [True, False, True]
-
-    model = await client.lists.update(
-        where={
-            'id': models[1].id,
-        },
-        data={
-            'bools': {
-                'push': [False],
-            },
-        },
-    )
-    assert model is not None
-    assert model.bools == [False, True, False]
-
-    model = await client.lists.update(
-        where={
             'id': models[1].id,
         },
         data={

--- a/databases/tests/arrays/test_bytes.py
+++ b/databases/tests/arrays/test_bytes.py
@@ -17,36 +17,6 @@ async def test_updating_bytes(client: Prisma) -> None:
 
     model = await client.lists.update(
         where={
-            'id': models[0].id,
-        },
-        data={
-            'bytes': {
-                'push': [Base64.encode(b'a'), Base64.encode(b'b')],
-            },
-        },
-    )
-    assert model is not None
-    assert model.bytes == [Base64.encode(b'a'), Base64.encode(b'b')]
-
-    model = await client.lists.update(
-        where={
-            'id': models[1].id,
-        },
-        data={
-            'bytes': {
-                'push': [Base64.encode(b'baz')],
-            },
-        },
-    )
-    assert model is not None
-    assert model.bytes == [
-        Base64.encode(b'foo'),
-        Base64.encode(b'bar'),
-        Base64.encode(b'baz'),
-    ]
-
-    model = await client.lists.update(
-        where={
             'id': models[1].id,
         },
         data={

--- a/databases/tests/arrays/test_datetime.py
+++ b/databases/tests/arrays/test_datetime.py
@@ -34,34 +34,6 @@ async def test_updating_datetime(client: Prisma) -> None:
 
     model = await client.lists.update(
         where={
-            'id': models[0].id,
-        },
-        data={
-            'dates': {
-                'push': [now, now + timedelta(days=5)],
-            },
-        },
-    )
-    assert model is not None
-    _assert_datelist_equal(model.dates, [now, now + timedelta(days=5)])
-
-    model = await client.lists.update(
-        where={
-            'id': models[1].id,
-        },
-        data={
-            'dates': {
-                'push': [now + timedelta(hours=7)],
-            },
-        },
-    )
-    assert model is not None
-    _assert_datelist_equal(
-        model.dates, [now, now + timedelta(hours=3), now + timedelta(hours=7)]
-    )
-
-    model = await client.lists.update(
-        where={
             'id': models[1].id,
         },
         data={

--- a/databases/tests/arrays/test_decimal.py
+++ b/databases/tests/arrays/test_decimal.py
@@ -19,32 +19,6 @@ async def test_updating_decimal(client: Prisma) -> None:
 
     model = await client.lists.update(
         where={
-            'id': models[0].id,
-        },
-        data={
-            'decimals': {
-                'push': [Decimal('22.99'), Decimal('31')],
-            },
-        },
-    )
-    assert model is not None
-    assert model.decimals == [Decimal('22.99'), Decimal('31')]
-
-    model = await client.lists.update(
-        where={
-            'id': models[1].id,
-        },
-        data={
-            'decimals': {
-                'push': [Decimal('5')],
-            },
-        },
-    )
-    assert model is not None
-    assert model.decimals == [Decimal('22.99'), Decimal('30.01'), Decimal('5')]
-
-    model = await client.lists.update(
-        where={
             'id': models[1].id,
         },
         data={

--- a/databases/tests/arrays/test_enum.py
+++ b/databases/tests/arrays/test_enum.py
@@ -100,10 +100,6 @@ async def test_filtering_enums(client: Prisma) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(
-    CURRENT_DATABASE == 'cockroachdb',
-    reason='https://github.com/prisma/prisma/issues/16511',
-)
 async def test_updating_enum(client: Prisma) -> None:
     """Updating a Role[] enum value"""
     models = [
@@ -114,32 +110,6 @@ async def test_updating_enum(client: Prisma) -> None:
             },
         ),
     ]
-
-    model = await client.lists.update(
-        where={
-            'id': models[0].id,
-        },
-        data={
-            'roles': {
-                'push': [Role.ADMIN, Role.USER],
-            },
-        },
-    )
-    assert model is not None
-    assert model.roles == [Role.ADMIN, Role.USER]
-
-    model = await client.lists.update(
-        where={
-            'id': models[1].id,
-        },
-        data={
-            'roles': {
-                'push': [Role.EDITOR],
-            },
-        },
-    )
-    assert model is not None
-    assert model.roles == [Role.USER, Role.ADMIN, Role.EDITOR]
 
     model = await client.lists.update(
         where={

--- a/databases/tests/arrays/test_enum.py
+++ b/databases/tests/arrays/test_enum.py
@@ -2,8 +2,6 @@ import pytest
 from prisma import Prisma
 from prisma.enums import Role
 
-from ..utils import CURRENT_DATABASE
-
 
 @pytest.mark.asyncio
 async def test_filtering_enums(client: Prisma) -> None:

--- a/databases/tests/arrays/test_float.py
+++ b/databases/tests/arrays/test_float.py
@@ -16,32 +16,6 @@ async def test_updating_floats(client: Prisma) -> None:
 
     model = await client.lists.update(
         where={
-            'id': models[0].id,
-        },
-        data={
-            'floats': {
-                'push': [102.3, 500.7],
-            },
-        },
-    )
-    assert model is not None
-    assert model.floats == [102.3, 500.7]
-
-    model = await client.lists.update(
-        where={
-            'id': models[1].id,
-        },
-        data={
-            'floats': {
-                'push': [20],
-            },
-        },
-    )
-    assert model is not None
-    assert model.floats == [3.4, 6.8, 12.4, 20]
-
-    model = await client.lists.update(
-        where={
             'id': models[1].id,
         },
         data={

--- a/databases/tests/arrays/test_int.py
+++ b/databases/tests/arrays/test_int.py
@@ -16,32 +16,6 @@ async def test_updating_ints(client: Prisma) -> None:
 
     model = await client.lists.update(
         where={
-            'id': models[0].id,
-        },
-        data={
-            'ints': {
-                'push': [1023023, 999],
-            },
-        },
-    )
-    assert model is not None
-    assert model.ints == [1023023, 999]
-
-    model = await client.lists.update(
-        where={
-            'id': models[1].id,
-        },
-        data={
-            'ints': {
-                'push': [4],
-            },
-        },
-    )
-    assert model is not None
-    assert model.ints == [1, 2, 3, 4]
-
-    model = await client.lists.update(
-        where={
             'id': models[1].id,
         },
         data={

--- a/databases/tests/arrays/test_json.py
+++ b/databases/tests/arrays/test_json.py
@@ -16,32 +16,6 @@ async def test_updating_json(client: Prisma) -> None:
 
     model = await client.lists.update(
         where={
-            'id': models[0].id,
-        },
-        data={
-            'json_objects': {
-                'push': [Json.keys(foo='bar'), Json(True)],
-            },
-        },
-    )
-    assert model is not None
-    assert model.json_objects == [{'foo': 'bar'}, True]
-
-    model = await client.lists.update(
-        where={
-            'id': models[1].id,
-        },
-        data={
-            'json_objects': {
-                'push': [Json('Baz')],
-            },
-        },
-    )
-    assert model is not None
-    assert model.json_objects == ['foo', ['foo', 'bar'], 'Baz']
-
-    model = await client.lists.update(
-        where={
             'id': models[1].id,
         },
         data={

--- a/databases/tests/arrays/test_string.py
+++ b/databases/tests/arrays/test_string.py
@@ -16,32 +16,6 @@ async def test_updating_strings(client: Prisma) -> None:
 
     model = await client.lists.update(
         where={
-            'id': models[0].id,
-        },
-        data={
-            'strings': {
-                'push': ['a', 'B'],
-            },
-        },
-    )
-    assert model is not None
-    assert model.strings == ['a', 'B']
-
-    model = await client.lists.update(
-        where={
-            'id': models[1].id,
-        },
-        data={
-            'strings': {
-                'push': ['d'],
-            },
-        },
-    )
-    assert model is not None
-    assert model.strings == ['a', 'b', 'c', 'd']
-
-    model = await client.lists.update(
-        where={
             'id': models[1].id,
         },
         data={

--- a/databases/tests/test_update.py
+++ b/databases/tests/test_update.py
@@ -4,6 +4,7 @@ from prisma import Prisma
 from prisma.models import Unique2, User, Types
 
 from lib.testing import async_fixture
+from .utils import CURRENT_DATABASE
 
 
 @async_fixture(name='user_id')
@@ -194,6 +195,10 @@ async def test_update_id_field() -> None:
 
 @pytest.mark.prisma
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    CURRENT_DATABASE == 'cockroachdb',
+    reason='https://github.com/prisma/prisma/issues/16612',
+)
 async def test_update_id_field_atomic() -> None:
     """Setting an ID field atomically"""
     record = await Types.prisma().create({})

--- a/databases/utils.py
+++ b/databases/utils.py
@@ -9,6 +9,7 @@ DatabaseFeature = Literal[
     'json',
     'date',
     'arrays',
+    'array_push',
     'json_arrays',
     'raw_queries',
     'create_many',

--- a/src/prisma/generator/templates/types.py.jinja
+++ b/src/prisma/generator/templates/types.py.jinja
@@ -145,7 +145,7 @@ Serializable = Union[
         {%+ if next != '' -%}
             'not': Union[str, '{{ next }}'],
         {% endif %}
-        {%+ if active_provider in ['postgresql', 'mongodb'] -%}
+        {%+ if active_provider in ['postgresql', 'cockroachdb', 'mongodb'] -%}
             'mode': SortMode,
         {% endif %}
     },
@@ -430,15 +430,17 @@ class _{{ type }}ListFilterIsEmptyInput(TypedDict):
 class _{{ type }}ListUpdateSet(TypedDict):
     set: List[{{ python_type }}]
 
-
+{% if active_provider != 'cockroachdb' %}
 class _{{ type }}ListUpdatePush(TypedDict):
     push: List[{{ python_type }}]
-
+{% endif %}
 
 {{ type }}ListUpdate = Union[
     List[{{ python_type }}],
     _{{ type }}ListUpdateSet,
+    {% if active_provider != 'cockroachdb' %}
     _{{ type }}ListUpdatePush,
+    {% endif %}
 ]
 
 {% endfor %}

--- a/src/prisma/generator/templates/types.py.jinja
+++ b/src/prisma/generator/templates/types.py.jinja
@@ -430,10 +430,12 @@ class _{{ type }}ListFilterIsEmptyInput(TypedDict):
 class _{{ type }}ListUpdateSet(TypedDict):
     set: List[{{ python_type }}]
 
+
 {% if active_provider != 'cockroachdb' %}
 class _{{ type }}ListUpdatePush(TypedDict):
     push: List[{{ python_type }}]
 {% endif %}
+
 
 {{ type }}ListUpdate = Union[
     List[{{ python_type }}],


### PR DESCRIPTION
## Change Summary

This PR:

- Adds CockroachDB back to the list of tested databases in CI
- Disables generating the array `push` operation for CockroachDB
- Adds CockroachDB to the list of whitelisted databases for case sensitivity

closes #636

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
