### PR TITLE
feat(client): add distinct filter to find_first and find_many

### DIFF
--- a/databases/tests/test_find_many.py
+++ b/databases/tests/test_find_many.py
@@ -118,8 +118,6 @@ async def test_filtering_one_to_one_relation(client: Prisma) -> None:
         )
         batcher.user.create({'name': 'Callum'})
 
-    # TODO: replacing description with anything else does not cause
-    # pyright to report an error
     users = await client.user.find_many(
         where={
             'profile': {
@@ -308,3 +306,89 @@ async def test_order_field_not_nullable(client: Prisma) -> None:
         await client.post.find_many(order={'desc': None})  # type: ignore
 
     assert exc.match(r'desc')
+
+
+@pytest.mark.asyncio
+async def test_distinct(client: Prisma) -> None:
+    """Filtering by distinct combinations of fields"""
+    users = [
+        await client.user.create(
+            data={
+                'name': 'Robert',
+            },
+        ),
+        await client.user.create(
+            data={
+                'name': 'Tegan',
+            },
+        ),
+        await client.user.create(
+            data={
+                'name': 'Patrick',
+            },
+        ),
+    ]
+    async with client.batch_() as batcher:
+        batcher.profile.create(
+            {
+                'city': 'Paris',
+                'country': 'France',
+                'description': 'Foo',
+                'user_id': users[0].id,
+            }
+        )
+        batcher.profile.create(
+            {
+                'city': 'Lyon',
+                'country': 'France',
+                'description': 'Foo',
+                'user_id': users[1].id,
+            }
+        )
+        batcher.profile.create(
+            {
+                'city': 'Paris',
+                'country': 'Denmark',
+                'description': 'Foo',
+                'user_id': users[2].id,
+            }
+        )
+
+    results = await client.profile.find_many(
+        distinct=['country'],
+        order={
+            'country': 'asc',
+        },
+    )
+    assert len(results) == 2
+    assert results[0].country == 'Denmark'
+    assert results[1].country == 'France'
+
+    results = await client.profile.find_many(
+        distinct=['city'],
+        order={
+            'city': 'asc',
+        },
+    )
+    assert len(results) == 2
+    assert results[0].city == 'Lyon'
+    assert results[1].city == 'Paris'
+
+    results = await client.profile.find_many(
+        distinct=['city', 'country'],
+        order=[
+            {
+                'city': 'asc',
+            },
+            {
+                'country': 'asc',
+            },
+        ],
+    )
+    assert len(results) == 3
+    assert results[0].city == 'Lyon'
+    assert results[0].country == 'France'
+    assert results[1].city == 'Paris'
+    assert results[1].country == 'Denmark'
+    assert results[2].city == 'Paris'
+    assert results[2].country == 'France'

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -160,6 +160,35 @@ posts = await db.post.find_many(
 )
 ```
 
+### Distinct Records
+
+The following query will find all `Profile` records that have a distinct `city` field.
+
+```py
+profiles = await db.profiles.find_many(
+    distinct=['city'],
+)
+# [
+#  { city: 'Paris' },
+#  { city: 'Lyon' },
+# ]
+```
+
+You can also filter by distinct combinations, for example the following query will return all records that have a distinct `city` *and* `country` combination.
+
+```py
+profiles = await db.profiles.find_many(
+    distinct=['city', 'country'],
+)
+# [
+#  { city: 'Paris', country: 'France' },
+#  { city: 'Paris', country: 'Denmark' },
+#  { city: 'Lyon', country: 'France' },
+# ]
+```
+
+You can currently only use `distinct` with `find_many()` and `find_first()` queries.
+
 ### Filtering by Relational Fields
 
 Within the filter you can query for everything you would normally query for, like it was a `find_first()` call on the relational field, for example:

--- a/src/prisma/generator/templates/actions.py.jinja
+++ b/src/prisma/generator/templates/actions.py.jinja
@@ -378,6 +378,8 @@ class {{ model.name }}Actions:
             {{ include_doc }}
         order
             Order the returned {{ model.name }} records by any field
+        distinct
+            Filter {{ model.name }} records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -443,6 +445,8 @@ class {{ model.name }}Actions:
             {{ include_doc }}
         order
             Order the returned {{ model.name }} records by any field
+        distinct
+            Filter {{ model.name }} records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------

--- a/src/prisma/generator/templates/actions.py.jinja
+++ b/src/prisma/generator/templates/actions.py.jinja
@@ -358,6 +358,7 @@ class {{ model.name }}Actions:
         cursor: Optional[types.{{ model.name }}WhereUniqueInput] = None,
         include: Optional[types.{{ model.name }}Include] = None,
         order: Optional[Union[types.{{ model.name }}OrderByInput, List[types.{{ model.name }}OrderByInput]]] = None,
+        distinct: Optional[List[types.{{ model.name }}ScalarFieldKeys]] = None,
     ) -> List[{{ ModelType }}]:
         """Find multiple {{ model.name }} records.
 
@@ -414,6 +415,7 @@ class {{ model.name }}Actions:
                 'order_by': order,
                 'cursor': cursor,
                 'include': include,
+                'distinct': distinct,
             },
         )
         return [self._model.parse_obj(r) for r in resp['data']['result']]
@@ -425,6 +427,7 @@ class {{ model.name }}Actions:
         cursor: Optional[types.{{ model.name }}WhereUniqueInput] = None,
         include: Optional[types.{{ model.name }}Include] = None,
         order: Optional[Union[types.{{ model.name }}OrderByInput, List[types.{{ model.name }}OrderByInput]]] = None,
+        distinct: Optional[List[types.{{ model.name }}ScalarFieldKeys]] = None,
     ) -> Optional[{{ ModelType }}]:
         """Find a single {{ model.name }} record.
 
@@ -474,7 +477,8 @@ class {{ model.name }}Actions:
                 'where': where,
                 'order_by': order,
                 'cursor': cursor,
-                'include': include
+                'include': include,
+                'distinct': distinct,
             },
         )
         result = resp['data']['result']

--- a/src/prisma/generator/templates/types.py.jinja
+++ b/src/prisma/generator/templates/types.py.jinja
@@ -618,6 +618,7 @@ class {{ name }}(TypedDict, total=False):
     order_by: Union['{{ related.name }}OrderByInput', List['{{ related.name }}OrderByInput']]
     where: '{{ related.name }}WhereInput'
     cursor: '{{ related.name }}WhereUniqueInput'
+    distinct: List['{{ related.name }}ScalarFieldKeys']
     {%+ if next != '' -%}
         include: '{{ related.name }}IncludeFrom{{ related.name + iteration}}'
     {% endif %}

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[actions.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[actions.py].raw
@@ -366,6 +366,7 @@ class PostActions:
         cursor: Optional[types.PostWhereUniqueInput] = None,
         include: Optional[types.PostInclude] = None,
         order: Optional[Union[types.PostOrderByInput, List[types.PostOrderByInput]]] = None,
+        distinct: Optional[List[types.PostScalarFieldKeys]] = None,
     ) -> List['models.Post']:
         """Find multiple Post records.
 
@@ -422,6 +423,7 @@ class PostActions:
                 'order_by': order,
                 'cursor': cursor,
                 'include': include,
+                'distinct': distinct,
             },
         )
         return [self._model.parse_obj(r) for r in resp['data']['result']]
@@ -433,6 +435,7 @@ class PostActions:
         cursor: Optional[types.PostWhereUniqueInput] = None,
         include: Optional[types.PostInclude] = None,
         order: Optional[Union[types.PostOrderByInput, List[types.PostOrderByInput]]] = None,
+        distinct: Optional[List[types.PostScalarFieldKeys]] = None,
     ) -> Optional['models.Post']:
         """Find a single Post record.
 
@@ -482,7 +485,8 @@ class PostActions:
                 'where': where,
                 'order_by': order,
                 'cursor': cursor,
-                'include': include
+                'include': include,
+                'distinct': distinct,
             },
         )
         result = resp['data']['result']
@@ -1297,6 +1301,7 @@ class UserActions:
         cursor: Optional[types.UserWhereUniqueInput] = None,
         include: Optional[types.UserInclude] = None,
         order: Optional[Union[types.UserOrderByInput, List[types.UserOrderByInput]]] = None,
+        distinct: Optional[List[types.UserScalarFieldKeys]] = None,
     ) -> List['models.User']:
         """Find multiple User records.
 
@@ -1353,6 +1358,7 @@ class UserActions:
                 'order_by': order,
                 'cursor': cursor,
                 'include': include,
+                'distinct': distinct,
             },
         )
         return [self._model.parse_obj(r) for r in resp['data']['result']]
@@ -1364,6 +1370,7 @@ class UserActions:
         cursor: Optional[types.UserWhereUniqueInput] = None,
         include: Optional[types.UserInclude] = None,
         order: Optional[Union[types.UserOrderByInput, List[types.UserOrderByInput]]] = None,
+        distinct: Optional[List[types.UserScalarFieldKeys]] = None,
     ) -> Optional['models.User']:
         """Find a single User record.
 
@@ -1413,7 +1420,8 @@ class UserActions:
                 'where': where,
                 'order_by': order,
                 'cursor': cursor,
-                'include': include
+                'include': include,
+                'distinct': distinct,
             },
         )
         result = resp['data']['result']
@@ -2233,6 +2241,7 @@ class MActions:
         cursor: Optional[types.MWhereUniqueInput] = None,
         include: Optional[types.MInclude] = None,
         order: Optional[Union[types.MOrderByInput, List[types.MOrderByInput]]] = None,
+        distinct: Optional[List[types.MScalarFieldKeys]] = None,
     ) -> List['models.M']:
         """Find multiple M records.
 
@@ -2289,6 +2298,7 @@ class MActions:
                 'order_by': order,
                 'cursor': cursor,
                 'include': include,
+                'distinct': distinct,
             },
         )
         return [self._model.parse_obj(r) for r in resp['data']['result']]
@@ -2300,6 +2310,7 @@ class MActions:
         cursor: Optional[types.MWhereUniqueInput] = None,
         include: Optional[types.MInclude] = None,
         order: Optional[Union[types.MOrderByInput, List[types.MOrderByInput]]] = None,
+        distinct: Optional[List[types.MScalarFieldKeys]] = None,
     ) -> Optional['models.M']:
         """Find a single M record.
 
@@ -2349,7 +2360,8 @@ class MActions:
                 'where': where,
                 'order_by': order,
                 'cursor': cursor,
-                'include': include
+                'include': include,
+                'distinct': distinct,
             },
         )
         result = resp['data']['result']
@@ -3170,6 +3182,7 @@ class NActions:
         cursor: Optional[types.NWhereUniqueInput] = None,
         include: Optional[types.NInclude] = None,
         order: Optional[Union[types.NOrderByInput, List[types.NOrderByInput]]] = None,
+        distinct: Optional[List[types.NScalarFieldKeys]] = None,
     ) -> List['models.N']:
         """Find multiple N records.
 
@@ -3226,6 +3239,7 @@ class NActions:
                 'order_by': order,
                 'cursor': cursor,
                 'include': include,
+                'distinct': distinct,
             },
         )
         return [self._model.parse_obj(r) for r in resp['data']['result']]
@@ -3237,6 +3251,7 @@ class NActions:
         cursor: Optional[types.NWhereUniqueInput] = None,
         include: Optional[types.NInclude] = None,
         order: Optional[Union[types.NOrderByInput, List[types.NOrderByInput]]] = None,
+        distinct: Optional[List[types.NScalarFieldKeys]] = None,
     ) -> Optional['models.N']:
         """Find a single N record.
 
@@ -3286,7 +3301,8 @@ class NActions:
                 'where': where,
                 'order_by': order,
                 'cursor': cursor,
-                'include': include
+                'include': include,
+                'distinct': distinct,
             },
         )
         result = resp['data']['result']
@@ -4106,6 +4122,7 @@ class OneOptionalActions:
         cursor: Optional[types.OneOptionalWhereUniqueInput] = None,
         include: Optional[types.OneOptionalInclude] = None,
         order: Optional[Union[types.OneOptionalOrderByInput, List[types.OneOptionalOrderByInput]]] = None,
+        distinct: Optional[List[types.OneOptionalScalarFieldKeys]] = None,
     ) -> List['models.OneOptional']:
         """Find multiple OneOptional records.
 
@@ -4162,6 +4179,7 @@ class OneOptionalActions:
                 'order_by': order,
                 'cursor': cursor,
                 'include': include,
+                'distinct': distinct,
             },
         )
         return [self._model.parse_obj(r) for r in resp['data']['result']]
@@ -4173,6 +4191,7 @@ class OneOptionalActions:
         cursor: Optional[types.OneOptionalWhereUniqueInput] = None,
         include: Optional[types.OneOptionalInclude] = None,
         order: Optional[Union[types.OneOptionalOrderByInput, List[types.OneOptionalOrderByInput]]] = None,
+        distinct: Optional[List[types.OneOptionalScalarFieldKeys]] = None,
     ) -> Optional['models.OneOptional']:
         """Find a single OneOptional record.
 
@@ -4222,7 +4241,8 @@ class OneOptionalActions:
                 'where': where,
                 'order_by': order,
                 'cursor': cursor,
-                'include': include
+                'include': include,
+                'distinct': distinct,
             },
         )
         result = resp['data']['result']
@@ -5040,6 +5060,7 @@ class ManyRequiredActions:
         cursor: Optional[types.ManyRequiredWhereUniqueInput] = None,
         include: Optional[types.ManyRequiredInclude] = None,
         order: Optional[Union[types.ManyRequiredOrderByInput, List[types.ManyRequiredOrderByInput]]] = None,
+        distinct: Optional[List[types.ManyRequiredScalarFieldKeys]] = None,
     ) -> List['models.ManyRequired']:
         """Find multiple ManyRequired records.
 
@@ -5096,6 +5117,7 @@ class ManyRequiredActions:
                 'order_by': order,
                 'cursor': cursor,
                 'include': include,
+                'distinct': distinct,
             },
         )
         return [self._model.parse_obj(r) for r in resp['data']['result']]
@@ -5107,6 +5129,7 @@ class ManyRequiredActions:
         cursor: Optional[types.ManyRequiredWhereUniqueInput] = None,
         include: Optional[types.ManyRequiredInclude] = None,
         order: Optional[Union[types.ManyRequiredOrderByInput, List[types.ManyRequiredOrderByInput]]] = None,
+        distinct: Optional[List[types.ManyRequiredScalarFieldKeys]] = None,
     ) -> Optional['models.ManyRequired']:
         """Find a single ManyRequired record.
 
@@ -5156,7 +5179,8 @@ class ManyRequiredActions:
                 'where': where,
                 'order_by': order,
                 'cursor': cursor,
-                'include': include
+                'include': include,
+                'distinct': distinct,
             },
         )
         result = resp['data']['result']
@@ -5959,6 +5983,7 @@ class ListsActions:
         cursor: Optional[types.ListsWhereUniqueInput] = None,
         include: Optional[types.ListsInclude] = None,
         order: Optional[Union[types.ListsOrderByInput, List[types.ListsOrderByInput]]] = None,
+        distinct: Optional[List[types.ListsScalarFieldKeys]] = None,
     ) -> List['models.Lists']:
         """Find multiple Lists records.
 
@@ -6015,6 +6040,7 @@ class ListsActions:
                 'order_by': order,
                 'cursor': cursor,
                 'include': include,
+                'distinct': distinct,
             },
         )
         return [self._model.parse_obj(r) for r in resp['data']['result']]
@@ -6026,6 +6052,7 @@ class ListsActions:
         cursor: Optional[types.ListsWhereUniqueInput] = None,
         include: Optional[types.ListsInclude] = None,
         order: Optional[Union[types.ListsOrderByInput, List[types.ListsOrderByInput]]] = None,
+        distinct: Optional[List[types.ListsScalarFieldKeys]] = None,
     ) -> Optional['models.Lists']:
         """Find a single Lists record.
 
@@ -6075,7 +6102,8 @@ class ListsActions:
                 'where': where,
                 'order_by': order,
                 'cursor': cursor,
-                'include': include
+                'include': include,
+                'distinct': distinct,
             },
         )
         result = resp['data']['result']
@@ -6880,6 +6908,7 @@ class AActions:
         cursor: Optional[types.AWhereUniqueInput] = None,
         include: Optional[types.AInclude] = None,
         order: Optional[Union[types.AOrderByInput, List[types.AOrderByInput]]] = None,
+        distinct: Optional[List[types.AScalarFieldKeys]] = None,
     ) -> List['models.A']:
         """Find multiple A records.
 
@@ -6936,6 +6965,7 @@ class AActions:
                 'order_by': order,
                 'cursor': cursor,
                 'include': include,
+                'distinct': distinct,
             },
         )
         return [self._model.parse_obj(r) for r in resp['data']['result']]
@@ -6947,6 +6977,7 @@ class AActions:
         cursor: Optional[types.AWhereUniqueInput] = None,
         include: Optional[types.AInclude] = None,
         order: Optional[Union[types.AOrderByInput, List[types.AOrderByInput]]] = None,
+        distinct: Optional[List[types.AScalarFieldKeys]] = None,
     ) -> Optional['models.A']:
         """Find a single A record.
 
@@ -6996,7 +7027,8 @@ class AActions:
                 'where': where,
                 'order_by': order,
                 'cursor': cursor,
-                'include': include
+                'include': include,
+                'distinct': distinct,
             },
         )
         result = resp['data']['result']
@@ -7807,6 +7839,7 @@ class BActions:
         cursor: Optional[types.BWhereUniqueInput] = None,
         include: Optional[types.BInclude] = None,
         order: Optional[Union[types.BOrderByInput, List[types.BOrderByInput]]] = None,
+        distinct: Optional[List[types.BScalarFieldKeys]] = None,
     ) -> List['models.B']:
         """Find multiple B records.
 
@@ -7863,6 +7896,7 @@ class BActions:
                 'order_by': order,
                 'cursor': cursor,
                 'include': include,
+                'distinct': distinct,
             },
         )
         return [self._model.parse_obj(r) for r in resp['data']['result']]
@@ -7874,6 +7908,7 @@ class BActions:
         cursor: Optional[types.BWhereUniqueInput] = None,
         include: Optional[types.BInclude] = None,
         order: Optional[Union[types.BOrderByInput, List[types.BOrderByInput]]] = None,
+        distinct: Optional[List[types.BScalarFieldKeys]] = None,
     ) -> Optional['models.B']:
         """Find a single B record.
 
@@ -7923,7 +7958,8 @@ class BActions:
                 'where': where,
                 'order_by': order,
                 'cursor': cursor,
-                'include': include
+                'include': include,
+                'distinct': distinct,
             },
         )
         result = resp['data']['result']
@@ -8744,6 +8780,7 @@ class CActions:
         cursor: Optional[types.CWhereUniqueInput] = None,
         include: Optional[types.CInclude] = None,
         order: Optional[Union[types.COrderByInput, List[types.COrderByInput]]] = None,
+        distinct: Optional[List[types.CScalarFieldKeys]] = None,
     ) -> List['models.C']:
         """Find multiple C records.
 
@@ -8800,6 +8837,7 @@ class CActions:
                 'order_by': order,
                 'cursor': cursor,
                 'include': include,
+                'distinct': distinct,
             },
         )
         return [self._model.parse_obj(r) for r in resp['data']['result']]
@@ -8811,6 +8849,7 @@ class CActions:
         cursor: Optional[types.CWhereUniqueInput] = None,
         include: Optional[types.CInclude] = None,
         order: Optional[Union[types.COrderByInput, List[types.COrderByInput]]] = None,
+        distinct: Optional[List[types.CScalarFieldKeys]] = None,
     ) -> Optional['models.C']:
         """Find a single C record.
 
@@ -8860,7 +8899,8 @@ class CActions:
                 'where': where,
                 'order_by': order,
                 'cursor': cursor,
-                'include': include
+                'include': include,
+                'distinct': distinct,
             },
         )
         result = resp['data']['result']
@@ -9670,6 +9710,7 @@ class DActions:
         cursor: Optional[types.DWhereUniqueInput] = None,
         include: Optional[types.DInclude] = None,
         order: Optional[Union[types.DOrderByInput, List[types.DOrderByInput]]] = None,
+        distinct: Optional[List[types.DScalarFieldKeys]] = None,
     ) -> List['models.D']:
         """Find multiple D records.
 
@@ -9726,6 +9767,7 @@ class DActions:
                 'order_by': order,
                 'cursor': cursor,
                 'include': include,
+                'distinct': distinct,
             },
         )
         return [self._model.parse_obj(r) for r in resp['data']['result']]
@@ -9737,6 +9779,7 @@ class DActions:
         cursor: Optional[types.DWhereUniqueInput] = None,
         include: Optional[types.DInclude] = None,
         order: Optional[Union[types.DOrderByInput, List[types.DOrderByInput]]] = None,
+        distinct: Optional[List[types.DScalarFieldKeys]] = None,
     ) -> Optional['models.D']:
         """Find a single D record.
 
@@ -9786,7 +9829,8 @@ class DActions:
                 'where': where,
                 'order_by': order,
                 'cursor': cursor,
-                'include': include
+                'include': include,
+                'distinct': distinct,
             },
         )
         result = resp['data']['result']
@@ -10598,6 +10642,7 @@ class EActions:
         cursor: Optional[types.EWhereUniqueInput] = None,
         include: Optional[types.EInclude] = None,
         order: Optional[Union[types.EOrderByInput, List[types.EOrderByInput]]] = None,
+        distinct: Optional[List[types.EScalarFieldKeys]] = None,
     ) -> List['models.E']:
         """Find multiple E records.
 
@@ -10654,6 +10699,7 @@ class EActions:
                 'order_by': order,
                 'cursor': cursor,
                 'include': include,
+                'distinct': distinct,
             },
         )
         return [self._model.parse_obj(r) for r in resp['data']['result']]
@@ -10665,6 +10711,7 @@ class EActions:
         cursor: Optional[types.EWhereUniqueInput] = None,
         include: Optional[types.EInclude] = None,
         order: Optional[Union[types.EOrderByInput, List[types.EOrderByInput]]] = None,
+        distinct: Optional[List[types.EScalarFieldKeys]] = None,
     ) -> Optional['models.E']:
         """Find a single E record.
 
@@ -10714,7 +10761,8 @@ class EActions:
                 'where': where,
                 'order_by': order,
                 'cursor': cursor,
-                'include': include
+                'include': include,
+                'distinct': distinct,
             },
         )
         result = resp['data']['result']

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[actions.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[actions.py].raw
@@ -386,6 +386,8 @@ class PostActions:
             Specifies which relations should be loaded on the returned Post model
         order
             Order the returned Post records by any field
+        distinct
+            Filter Post records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -451,6 +453,8 @@ class PostActions:
             Specifies which relations should be loaded on the returned Post model
         order
             Order the returned Post records by any field
+        distinct
+            Filter Post records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -1321,6 +1325,8 @@ class UserActions:
             Specifies which relations should be loaded on the returned User model
         order
             Order the returned User records by any field
+        distinct
+            Filter User records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -1386,6 +1392,8 @@ class UserActions:
             Specifies which relations should be loaded on the returned User model
         order
             Order the returned User records by any field
+        distinct
+            Filter User records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -2261,6 +2269,8 @@ class MActions:
             Specifies which relations should be loaded on the returned M model
         order
             Order the returned M records by any field
+        distinct
+            Filter M records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -2326,6 +2336,8 @@ class MActions:
             Specifies which relations should be loaded on the returned M model
         order
             Order the returned M records by any field
+        distinct
+            Filter M records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -3202,6 +3214,8 @@ class NActions:
             Specifies which relations should be loaded on the returned N model
         order
             Order the returned N records by any field
+        distinct
+            Filter N records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -3267,6 +3281,8 @@ class NActions:
             Specifies which relations should be loaded on the returned N model
         order
             Order the returned N records by any field
+        distinct
+            Filter N records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -4142,6 +4158,8 @@ class OneOptionalActions:
             Specifies which relations should be loaded on the returned OneOptional model
         order
             Order the returned OneOptional records by any field
+        distinct
+            Filter OneOptional records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -4207,6 +4225,8 @@ class OneOptionalActions:
             Specifies which relations should be loaded on the returned OneOptional model
         order
             Order the returned OneOptional records by any field
+        distinct
+            Filter OneOptional records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -5080,6 +5100,8 @@ class ManyRequiredActions:
             Specifies which relations should be loaded on the returned ManyRequired model
         order
             Order the returned ManyRequired records by any field
+        distinct
+            Filter ManyRequired records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -5145,6 +5167,8 @@ class ManyRequiredActions:
             Specifies which relations should be loaded on the returned ManyRequired model
         order
             Order the returned ManyRequired records by any field
+        distinct
+            Filter ManyRequired records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -6003,6 +6027,8 @@ class ListsActions:
             Specifies which relations should be loaded on the returned Lists model
         order
             Order the returned Lists records by any field
+        distinct
+            Filter Lists records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -6068,6 +6094,8 @@ class ListsActions:
             Specifies which relations should be loaded on the returned Lists model
         order
             Order the returned Lists records by any field
+        distinct
+            Filter Lists records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -6928,6 +6956,8 @@ class AActions:
             Specifies which relations should be loaded on the returned A model
         order
             Order the returned A records by any field
+        distinct
+            Filter A records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -6993,6 +7023,8 @@ class AActions:
             Specifies which relations should be loaded on the returned A model
         order
             Order the returned A records by any field
+        distinct
+            Filter A records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -7859,6 +7891,8 @@ class BActions:
             Specifies which relations should be loaded on the returned B model
         order
             Order the returned B records by any field
+        distinct
+            Filter B records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -7924,6 +7958,8 @@ class BActions:
             Specifies which relations should be loaded on the returned B model
         order
             Order the returned B records by any field
+        distinct
+            Filter B records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -8800,6 +8836,8 @@ class CActions:
             Specifies which relations should be loaded on the returned C model
         order
             Order the returned C records by any field
+        distinct
+            Filter C records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -8865,6 +8903,8 @@ class CActions:
             Specifies which relations should be loaded on the returned C model
         order
             Order the returned C records by any field
+        distinct
+            Filter C records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -9730,6 +9770,8 @@ class DActions:
             Specifies which relations should be loaded on the returned D model
         order
             Order the returned D records by any field
+        distinct
+            Filter D records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -9795,6 +9837,8 @@ class DActions:
             Specifies which relations should be loaded on the returned D model
         order
             Order the returned D records by any field
+        distinct
+            Filter D records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -10662,6 +10706,8 @@ class EActions:
             Specifies which relations should be loaded on the returned E model
         order
             Order the returned E records by any field
+        distinct
+            Filter E records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -10727,6 +10773,8 @@ class EActions:
             Specifies which relations should be loaded on the returned E model
         order
             Order the returned E records by any field
+        distinct
+            Filter E records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[types.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[types.py].raw
@@ -1212,6 +1212,7 @@ class FindManyPostArgsFromPost(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive1'
 
 
@@ -1222,6 +1223,7 @@ class FindManyPostArgsFromPostRecursive1(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive2'
 
 
@@ -1232,6 +1234,7 @@ class FindManyPostArgsFromPostRecursive2(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     
     
 
@@ -1272,6 +1275,7 @@ class FindManyUserArgsFromPost(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive1'
 
 
@@ -1282,6 +1286,7 @@ class FindManyUserArgsFromPostRecursive1(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive2'
 
 
@@ -1292,6 +1297,7 @@ class FindManyUserArgsFromPostRecursive2(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     
     
 
@@ -1332,6 +1338,7 @@ class FindManyMArgsFromPost(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive1'
 
 
@@ -1342,6 +1349,7 @@ class FindManyMArgsFromPostRecursive1(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive2'
 
 
@@ -1352,6 +1360,7 @@ class FindManyMArgsFromPostRecursive2(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     
     
 
@@ -1392,6 +1401,7 @@ class FindManyNArgsFromPost(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive1'
 
 
@@ -1402,6 +1412,7 @@ class FindManyNArgsFromPostRecursive1(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive2'
 
 
@@ -1412,6 +1423,7 @@ class FindManyNArgsFromPostRecursive2(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     
     
 
@@ -1452,6 +1464,7 @@ class FindManyOneOptionalArgsFromPost(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive1'
 
 
@@ -1462,6 +1475,7 @@ class FindManyOneOptionalArgsFromPostRecursive1(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive2'
 
 
@@ -1472,6 +1486,7 @@ class FindManyOneOptionalArgsFromPostRecursive2(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     
     
 
@@ -1512,6 +1527,7 @@ class FindManyManyRequiredArgsFromPost(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive1'
 
 
@@ -1522,6 +1538,7 @@ class FindManyManyRequiredArgsFromPostRecursive1(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive2'
 
 
@@ -1532,6 +1549,7 @@ class FindManyManyRequiredArgsFromPostRecursive2(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     
     
 
@@ -1570,6 +1588,7 @@ class FindManyListsArgsFromPost(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive1'
 
 
@@ -1580,6 +1599,7 @@ class FindManyListsArgsFromPostRecursive1(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive2'
 
 
@@ -1590,6 +1610,7 @@ class FindManyListsArgsFromPostRecursive2(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     
     
 
@@ -1628,6 +1649,7 @@ class FindManyAArgsFromPost(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive1'
 
 
@@ -1638,6 +1660,7 @@ class FindManyAArgsFromPostRecursive1(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive2'
 
 
@@ -1648,6 +1671,7 @@ class FindManyAArgsFromPostRecursive2(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     
     
 
@@ -1686,6 +1710,7 @@ class FindManyBArgsFromPost(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive1'
 
 
@@ -1696,6 +1721,7 @@ class FindManyBArgsFromPostRecursive1(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive2'
 
 
@@ -1706,6 +1732,7 @@ class FindManyBArgsFromPostRecursive2(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     
     
 
@@ -1744,6 +1771,7 @@ class FindManyCArgsFromPost(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive1'
 
 
@@ -1754,6 +1782,7 @@ class FindManyCArgsFromPostRecursive1(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive2'
 
 
@@ -1764,6 +1793,7 @@ class FindManyCArgsFromPostRecursive2(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     
     
 
@@ -1802,6 +1832,7 @@ class FindManyDArgsFromPost(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive1'
 
 
@@ -1812,6 +1843,7 @@ class FindManyDArgsFromPostRecursive1(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive2'
 
 
@@ -1822,6 +1854,7 @@ class FindManyDArgsFromPostRecursive2(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     
     
 
@@ -1860,6 +1893,7 @@ class FindManyEArgsFromPost(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive1'
 
 
@@ -1870,6 +1904,7 @@ class FindManyEArgsFromPostRecursive1(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive2'
 
 
@@ -1880,6 +1915,7 @@ class FindManyEArgsFromPostRecursive2(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     
 
 
@@ -2425,6 +2461,7 @@ class FindManyPostArgsFromUser(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive1'
 
 
@@ -2435,6 +2472,7 @@ class FindManyPostArgsFromUserRecursive1(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive2'
 
 
@@ -2445,6 +2483,7 @@ class FindManyPostArgsFromUserRecursive2(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     
     
 
@@ -2485,6 +2524,7 @@ class FindManyUserArgsFromUser(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive1'
 
 
@@ -2495,6 +2535,7 @@ class FindManyUserArgsFromUserRecursive1(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive2'
 
 
@@ -2505,6 +2546,7 @@ class FindManyUserArgsFromUserRecursive2(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     
     
 
@@ -2545,6 +2587,7 @@ class FindManyMArgsFromUser(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive1'
 
 
@@ -2555,6 +2598,7 @@ class FindManyMArgsFromUserRecursive1(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive2'
 
 
@@ -2565,6 +2609,7 @@ class FindManyMArgsFromUserRecursive2(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     
     
 
@@ -2605,6 +2650,7 @@ class FindManyNArgsFromUser(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive1'
 
 
@@ -2615,6 +2661,7 @@ class FindManyNArgsFromUserRecursive1(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive2'
 
 
@@ -2625,6 +2672,7 @@ class FindManyNArgsFromUserRecursive2(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     
     
 
@@ -2665,6 +2713,7 @@ class FindManyOneOptionalArgsFromUser(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive1'
 
 
@@ -2675,6 +2724,7 @@ class FindManyOneOptionalArgsFromUserRecursive1(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive2'
 
 
@@ -2685,6 +2735,7 @@ class FindManyOneOptionalArgsFromUserRecursive2(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     
     
 
@@ -2725,6 +2776,7 @@ class FindManyManyRequiredArgsFromUser(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive1'
 
 
@@ -2735,6 +2787,7 @@ class FindManyManyRequiredArgsFromUserRecursive1(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive2'
 
 
@@ -2745,6 +2798,7 @@ class FindManyManyRequiredArgsFromUserRecursive2(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     
     
 
@@ -2783,6 +2837,7 @@ class FindManyListsArgsFromUser(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive1'
 
 
@@ -2793,6 +2848,7 @@ class FindManyListsArgsFromUserRecursive1(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive2'
 
 
@@ -2803,6 +2859,7 @@ class FindManyListsArgsFromUserRecursive2(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     
     
 
@@ -2841,6 +2898,7 @@ class FindManyAArgsFromUser(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive1'
 
 
@@ -2851,6 +2909,7 @@ class FindManyAArgsFromUserRecursive1(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive2'
 
 
@@ -2861,6 +2920,7 @@ class FindManyAArgsFromUserRecursive2(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     
     
 
@@ -2899,6 +2959,7 @@ class FindManyBArgsFromUser(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive1'
 
 
@@ -2909,6 +2970,7 @@ class FindManyBArgsFromUserRecursive1(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive2'
 
 
@@ -2919,6 +2981,7 @@ class FindManyBArgsFromUserRecursive2(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     
     
 
@@ -2957,6 +3020,7 @@ class FindManyCArgsFromUser(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive1'
 
 
@@ -2967,6 +3031,7 @@ class FindManyCArgsFromUserRecursive1(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive2'
 
 
@@ -2977,6 +3042,7 @@ class FindManyCArgsFromUserRecursive2(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     
     
 
@@ -3015,6 +3081,7 @@ class FindManyDArgsFromUser(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive1'
 
 
@@ -3025,6 +3092,7 @@ class FindManyDArgsFromUserRecursive1(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive2'
 
 
@@ -3035,6 +3103,7 @@ class FindManyDArgsFromUserRecursive2(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     
     
 
@@ -3073,6 +3142,7 @@ class FindManyEArgsFromUser(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive1'
 
 
@@ -3083,6 +3153,7 @@ class FindManyEArgsFromUserRecursive1(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive2'
 
 
@@ -3093,6 +3164,7 @@ class FindManyEArgsFromUserRecursive2(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     
 
 
@@ -3707,6 +3779,7 @@ class FindManyPostArgsFromM(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive1'
 
 
@@ -3717,6 +3790,7 @@ class FindManyPostArgsFromMRecursive1(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive2'
 
 
@@ -3727,6 +3801,7 @@ class FindManyPostArgsFromMRecursive2(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     
     
 
@@ -3767,6 +3842,7 @@ class FindManyUserArgsFromM(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive1'
 
 
@@ -3777,6 +3853,7 @@ class FindManyUserArgsFromMRecursive1(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive2'
 
 
@@ -3787,6 +3864,7 @@ class FindManyUserArgsFromMRecursive2(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     
     
 
@@ -3827,6 +3905,7 @@ class FindManyMArgsFromM(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive1'
 
 
@@ -3837,6 +3916,7 @@ class FindManyMArgsFromMRecursive1(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive2'
 
 
@@ -3847,6 +3927,7 @@ class FindManyMArgsFromMRecursive2(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     
     
 
@@ -3887,6 +3968,7 @@ class FindManyNArgsFromM(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive1'
 
 
@@ -3897,6 +3979,7 @@ class FindManyNArgsFromMRecursive1(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive2'
 
 
@@ -3907,6 +3990,7 @@ class FindManyNArgsFromMRecursive2(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     
     
 
@@ -3947,6 +4031,7 @@ class FindManyOneOptionalArgsFromM(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive1'
 
 
@@ -3957,6 +4042,7 @@ class FindManyOneOptionalArgsFromMRecursive1(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive2'
 
 
@@ -3967,6 +4053,7 @@ class FindManyOneOptionalArgsFromMRecursive2(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     
     
 
@@ -4007,6 +4094,7 @@ class FindManyManyRequiredArgsFromM(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive1'
 
 
@@ -4017,6 +4105,7 @@ class FindManyManyRequiredArgsFromMRecursive1(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive2'
 
 
@@ -4027,6 +4116,7 @@ class FindManyManyRequiredArgsFromMRecursive2(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     
     
 
@@ -4065,6 +4155,7 @@ class FindManyListsArgsFromM(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive1'
 
 
@@ -4075,6 +4166,7 @@ class FindManyListsArgsFromMRecursive1(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive2'
 
 
@@ -4085,6 +4177,7 @@ class FindManyListsArgsFromMRecursive2(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     
     
 
@@ -4123,6 +4216,7 @@ class FindManyAArgsFromM(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive1'
 
 
@@ -4133,6 +4227,7 @@ class FindManyAArgsFromMRecursive1(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive2'
 
 
@@ -4143,6 +4238,7 @@ class FindManyAArgsFromMRecursive2(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     
     
 
@@ -4181,6 +4277,7 @@ class FindManyBArgsFromM(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive1'
 
 
@@ -4191,6 +4288,7 @@ class FindManyBArgsFromMRecursive1(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive2'
 
 
@@ -4201,6 +4299,7 @@ class FindManyBArgsFromMRecursive2(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     
     
 
@@ -4239,6 +4338,7 @@ class FindManyCArgsFromM(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive1'
 
 
@@ -4249,6 +4349,7 @@ class FindManyCArgsFromMRecursive1(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive2'
 
 
@@ -4259,6 +4360,7 @@ class FindManyCArgsFromMRecursive2(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     
     
 
@@ -4297,6 +4399,7 @@ class FindManyDArgsFromM(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive1'
 
 
@@ -4307,6 +4410,7 @@ class FindManyDArgsFromMRecursive1(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive2'
 
 
@@ -4317,6 +4421,7 @@ class FindManyDArgsFromMRecursive2(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     
     
 
@@ -4355,6 +4460,7 @@ class FindManyEArgsFromM(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive1'
 
 
@@ -4365,6 +4471,7 @@ class FindManyEArgsFromMRecursive1(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive2'
 
 
@@ -4375,6 +4482,7 @@ class FindManyEArgsFromMRecursive2(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     
 
 
@@ -5001,6 +5109,7 @@ class FindManyPostArgsFromN(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive1'
 
 
@@ -5011,6 +5120,7 @@ class FindManyPostArgsFromNRecursive1(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive2'
 
 
@@ -5021,6 +5131,7 @@ class FindManyPostArgsFromNRecursive2(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     
     
 
@@ -5061,6 +5172,7 @@ class FindManyUserArgsFromN(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive1'
 
 
@@ -5071,6 +5183,7 @@ class FindManyUserArgsFromNRecursive1(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive2'
 
 
@@ -5081,6 +5194,7 @@ class FindManyUserArgsFromNRecursive2(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     
     
 
@@ -5121,6 +5235,7 @@ class FindManyMArgsFromN(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive1'
 
 
@@ -5131,6 +5246,7 @@ class FindManyMArgsFromNRecursive1(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive2'
 
 
@@ -5141,6 +5257,7 @@ class FindManyMArgsFromNRecursive2(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     
     
 
@@ -5181,6 +5298,7 @@ class FindManyNArgsFromN(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive1'
 
 
@@ -5191,6 +5309,7 @@ class FindManyNArgsFromNRecursive1(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive2'
 
 
@@ -5201,6 +5320,7 @@ class FindManyNArgsFromNRecursive2(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     
     
 
@@ -5241,6 +5361,7 @@ class FindManyOneOptionalArgsFromN(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive1'
 
 
@@ -5251,6 +5372,7 @@ class FindManyOneOptionalArgsFromNRecursive1(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive2'
 
 
@@ -5261,6 +5383,7 @@ class FindManyOneOptionalArgsFromNRecursive2(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     
     
 
@@ -5301,6 +5424,7 @@ class FindManyManyRequiredArgsFromN(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive1'
 
 
@@ -5311,6 +5435,7 @@ class FindManyManyRequiredArgsFromNRecursive1(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive2'
 
 
@@ -5321,6 +5446,7 @@ class FindManyManyRequiredArgsFromNRecursive2(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     
     
 
@@ -5359,6 +5485,7 @@ class FindManyListsArgsFromN(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive1'
 
 
@@ -5369,6 +5496,7 @@ class FindManyListsArgsFromNRecursive1(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive2'
 
 
@@ -5379,6 +5507,7 @@ class FindManyListsArgsFromNRecursive2(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     
     
 
@@ -5417,6 +5546,7 @@ class FindManyAArgsFromN(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive1'
 
 
@@ -5427,6 +5557,7 @@ class FindManyAArgsFromNRecursive1(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive2'
 
 
@@ -5437,6 +5568,7 @@ class FindManyAArgsFromNRecursive2(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     
     
 
@@ -5475,6 +5607,7 @@ class FindManyBArgsFromN(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive1'
 
 
@@ -5485,6 +5618,7 @@ class FindManyBArgsFromNRecursive1(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive2'
 
 
@@ -5495,6 +5629,7 @@ class FindManyBArgsFromNRecursive2(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     
     
 
@@ -5533,6 +5668,7 @@ class FindManyCArgsFromN(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive1'
 
 
@@ -5543,6 +5679,7 @@ class FindManyCArgsFromNRecursive1(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive2'
 
 
@@ -5553,6 +5690,7 @@ class FindManyCArgsFromNRecursive2(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     
     
 
@@ -5591,6 +5729,7 @@ class FindManyDArgsFromN(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive1'
 
 
@@ -5601,6 +5740,7 @@ class FindManyDArgsFromNRecursive1(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive2'
 
 
@@ -5611,6 +5751,7 @@ class FindManyDArgsFromNRecursive2(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     
     
 
@@ -5649,6 +5790,7 @@ class FindManyEArgsFromN(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive1'
 
 
@@ -5659,6 +5801,7 @@ class FindManyEArgsFromNRecursive1(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive2'
 
 
@@ -5669,6 +5812,7 @@ class FindManyEArgsFromNRecursive2(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     
 
 
@@ -6297,6 +6441,7 @@ class FindManyPostArgsFromOneOptional(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive1'
 
 
@@ -6307,6 +6452,7 @@ class FindManyPostArgsFromOneOptionalRecursive1(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive2'
 
 
@@ -6317,6 +6463,7 @@ class FindManyPostArgsFromOneOptionalRecursive2(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     
     
 
@@ -6357,6 +6504,7 @@ class FindManyUserArgsFromOneOptional(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive1'
 
 
@@ -6367,6 +6515,7 @@ class FindManyUserArgsFromOneOptionalRecursive1(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive2'
 
 
@@ -6377,6 +6526,7 @@ class FindManyUserArgsFromOneOptionalRecursive2(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     
     
 
@@ -6417,6 +6567,7 @@ class FindManyMArgsFromOneOptional(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive1'
 
 
@@ -6427,6 +6578,7 @@ class FindManyMArgsFromOneOptionalRecursive1(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive2'
 
 
@@ -6437,6 +6589,7 @@ class FindManyMArgsFromOneOptionalRecursive2(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     
     
 
@@ -6477,6 +6630,7 @@ class FindManyNArgsFromOneOptional(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive1'
 
 
@@ -6487,6 +6641,7 @@ class FindManyNArgsFromOneOptionalRecursive1(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive2'
 
 
@@ -6497,6 +6652,7 @@ class FindManyNArgsFromOneOptionalRecursive2(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     
     
 
@@ -6537,6 +6693,7 @@ class FindManyOneOptionalArgsFromOneOptional(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive1'
 
 
@@ -6547,6 +6704,7 @@ class FindManyOneOptionalArgsFromOneOptionalRecursive1(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive2'
 
 
@@ -6557,6 +6715,7 @@ class FindManyOneOptionalArgsFromOneOptionalRecursive2(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     
     
 
@@ -6597,6 +6756,7 @@ class FindManyManyRequiredArgsFromOneOptional(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive1'
 
 
@@ -6607,6 +6767,7 @@ class FindManyManyRequiredArgsFromOneOptionalRecursive1(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive2'
 
 
@@ -6617,6 +6778,7 @@ class FindManyManyRequiredArgsFromOneOptionalRecursive2(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     
     
 
@@ -6655,6 +6817,7 @@ class FindManyListsArgsFromOneOptional(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive1'
 
 
@@ -6665,6 +6828,7 @@ class FindManyListsArgsFromOneOptionalRecursive1(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive2'
 
 
@@ -6675,6 +6839,7 @@ class FindManyListsArgsFromOneOptionalRecursive2(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     
     
 
@@ -6713,6 +6878,7 @@ class FindManyAArgsFromOneOptional(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive1'
 
 
@@ -6723,6 +6889,7 @@ class FindManyAArgsFromOneOptionalRecursive1(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive2'
 
 
@@ -6733,6 +6900,7 @@ class FindManyAArgsFromOneOptionalRecursive2(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     
     
 
@@ -6771,6 +6939,7 @@ class FindManyBArgsFromOneOptional(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive1'
 
 
@@ -6781,6 +6950,7 @@ class FindManyBArgsFromOneOptionalRecursive1(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive2'
 
 
@@ -6791,6 +6961,7 @@ class FindManyBArgsFromOneOptionalRecursive2(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     
     
 
@@ -6829,6 +7000,7 @@ class FindManyCArgsFromOneOptional(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive1'
 
 
@@ -6839,6 +7011,7 @@ class FindManyCArgsFromOneOptionalRecursive1(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive2'
 
 
@@ -6849,6 +7022,7 @@ class FindManyCArgsFromOneOptionalRecursive2(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     
     
 
@@ -6887,6 +7061,7 @@ class FindManyDArgsFromOneOptional(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive1'
 
 
@@ -6897,6 +7072,7 @@ class FindManyDArgsFromOneOptionalRecursive1(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive2'
 
 
@@ -6907,6 +7083,7 @@ class FindManyDArgsFromOneOptionalRecursive2(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     
     
 
@@ -6945,6 +7122,7 @@ class FindManyEArgsFromOneOptional(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive1'
 
 
@@ -6955,6 +7133,7 @@ class FindManyEArgsFromOneOptionalRecursive1(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive2'
 
 
@@ -6965,6 +7144,7 @@ class FindManyEArgsFromOneOptionalRecursive2(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     
 
 
@@ -7576,6 +7756,7 @@ class FindManyPostArgsFromManyRequired(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive1'
 
 
@@ -7586,6 +7767,7 @@ class FindManyPostArgsFromManyRequiredRecursive1(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive2'
 
 
@@ -7596,6 +7778,7 @@ class FindManyPostArgsFromManyRequiredRecursive2(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     
     
 
@@ -7636,6 +7819,7 @@ class FindManyUserArgsFromManyRequired(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive1'
 
 
@@ -7646,6 +7830,7 @@ class FindManyUserArgsFromManyRequiredRecursive1(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive2'
 
 
@@ -7656,6 +7841,7 @@ class FindManyUserArgsFromManyRequiredRecursive2(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     
     
 
@@ -7696,6 +7882,7 @@ class FindManyMArgsFromManyRequired(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive1'
 
 
@@ -7706,6 +7893,7 @@ class FindManyMArgsFromManyRequiredRecursive1(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive2'
 
 
@@ -7716,6 +7904,7 @@ class FindManyMArgsFromManyRequiredRecursive2(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     
     
 
@@ -7756,6 +7945,7 @@ class FindManyNArgsFromManyRequired(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive1'
 
 
@@ -7766,6 +7956,7 @@ class FindManyNArgsFromManyRequiredRecursive1(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive2'
 
 
@@ -7776,6 +7967,7 @@ class FindManyNArgsFromManyRequiredRecursive2(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     
     
 
@@ -7816,6 +8008,7 @@ class FindManyOneOptionalArgsFromManyRequired(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive1'
 
 
@@ -7826,6 +8019,7 @@ class FindManyOneOptionalArgsFromManyRequiredRecursive1(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive2'
 
 
@@ -7836,6 +8030,7 @@ class FindManyOneOptionalArgsFromManyRequiredRecursive2(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     
     
 
@@ -7876,6 +8071,7 @@ class FindManyManyRequiredArgsFromManyRequired(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive1'
 
 
@@ -7886,6 +8082,7 @@ class FindManyManyRequiredArgsFromManyRequiredRecursive1(TypedDict, total=False)
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive2'
 
 
@@ -7896,6 +8093,7 @@ class FindManyManyRequiredArgsFromManyRequiredRecursive2(TypedDict, total=False)
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     
     
 
@@ -7934,6 +8132,7 @@ class FindManyListsArgsFromManyRequired(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive1'
 
 
@@ -7944,6 +8143,7 @@ class FindManyListsArgsFromManyRequiredRecursive1(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive2'
 
 
@@ -7954,6 +8154,7 @@ class FindManyListsArgsFromManyRequiredRecursive2(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     
     
 
@@ -7992,6 +8193,7 @@ class FindManyAArgsFromManyRequired(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive1'
 
 
@@ -8002,6 +8204,7 @@ class FindManyAArgsFromManyRequiredRecursive1(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive2'
 
 
@@ -8012,6 +8215,7 @@ class FindManyAArgsFromManyRequiredRecursive2(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     
     
 
@@ -8050,6 +8254,7 @@ class FindManyBArgsFromManyRequired(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive1'
 
 
@@ -8060,6 +8265,7 @@ class FindManyBArgsFromManyRequiredRecursive1(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive2'
 
 
@@ -8070,6 +8276,7 @@ class FindManyBArgsFromManyRequiredRecursive2(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     
     
 
@@ -8108,6 +8315,7 @@ class FindManyCArgsFromManyRequired(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive1'
 
 
@@ -8118,6 +8326,7 @@ class FindManyCArgsFromManyRequiredRecursive1(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive2'
 
 
@@ -8128,6 +8337,7 @@ class FindManyCArgsFromManyRequiredRecursive2(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     
     
 
@@ -8166,6 +8376,7 @@ class FindManyDArgsFromManyRequired(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive1'
 
 
@@ -8176,6 +8387,7 @@ class FindManyDArgsFromManyRequiredRecursive1(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive2'
 
 
@@ -8186,6 +8398,7 @@ class FindManyDArgsFromManyRequiredRecursive2(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     
     
 
@@ -8224,6 +8437,7 @@ class FindManyEArgsFromManyRequired(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive1'
 
 
@@ -8234,6 +8448,7 @@ class FindManyEArgsFromManyRequiredRecursive1(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive2'
 
 
@@ -8244,6 +8459,7 @@ class FindManyEArgsFromManyRequiredRecursive2(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     
 
 
@@ -8845,6 +9061,7 @@ class FindManyPostArgsFromLists(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive1'
 
 
@@ -8855,6 +9072,7 @@ class FindManyPostArgsFromListsRecursive1(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive2'
 
 
@@ -8865,6 +9083,7 @@ class FindManyPostArgsFromListsRecursive2(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     
     
 
@@ -8905,6 +9124,7 @@ class FindManyUserArgsFromLists(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive1'
 
 
@@ -8915,6 +9135,7 @@ class FindManyUserArgsFromListsRecursive1(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive2'
 
 
@@ -8925,6 +9146,7 @@ class FindManyUserArgsFromListsRecursive2(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     
     
 
@@ -8965,6 +9187,7 @@ class FindManyMArgsFromLists(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive1'
 
 
@@ -8975,6 +9198,7 @@ class FindManyMArgsFromListsRecursive1(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive2'
 
 
@@ -8985,6 +9209,7 @@ class FindManyMArgsFromListsRecursive2(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     
     
 
@@ -9025,6 +9250,7 @@ class FindManyNArgsFromLists(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive1'
 
 
@@ -9035,6 +9261,7 @@ class FindManyNArgsFromListsRecursive1(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive2'
 
 
@@ -9045,6 +9272,7 @@ class FindManyNArgsFromListsRecursive2(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     
     
 
@@ -9085,6 +9313,7 @@ class FindManyOneOptionalArgsFromLists(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive1'
 
 
@@ -9095,6 +9324,7 @@ class FindManyOneOptionalArgsFromListsRecursive1(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive2'
 
 
@@ -9105,6 +9335,7 @@ class FindManyOneOptionalArgsFromListsRecursive2(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     
     
 
@@ -9145,6 +9376,7 @@ class FindManyManyRequiredArgsFromLists(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive1'
 
 
@@ -9155,6 +9387,7 @@ class FindManyManyRequiredArgsFromListsRecursive1(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive2'
 
 
@@ -9165,6 +9398,7 @@ class FindManyManyRequiredArgsFromListsRecursive2(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     
     
 
@@ -9203,6 +9437,7 @@ class FindManyListsArgsFromLists(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive1'
 
 
@@ -9213,6 +9448,7 @@ class FindManyListsArgsFromListsRecursive1(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive2'
 
 
@@ -9223,6 +9459,7 @@ class FindManyListsArgsFromListsRecursive2(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     
     
 
@@ -9261,6 +9498,7 @@ class FindManyAArgsFromLists(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive1'
 
 
@@ -9271,6 +9509,7 @@ class FindManyAArgsFromListsRecursive1(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive2'
 
 
@@ -9281,6 +9520,7 @@ class FindManyAArgsFromListsRecursive2(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     
     
 
@@ -9319,6 +9559,7 @@ class FindManyBArgsFromLists(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive1'
 
 
@@ -9329,6 +9570,7 @@ class FindManyBArgsFromListsRecursive1(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive2'
 
 
@@ -9339,6 +9581,7 @@ class FindManyBArgsFromListsRecursive2(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     
     
 
@@ -9377,6 +9620,7 @@ class FindManyCArgsFromLists(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive1'
 
 
@@ -9387,6 +9631,7 @@ class FindManyCArgsFromListsRecursive1(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive2'
 
 
@@ -9397,6 +9642,7 @@ class FindManyCArgsFromListsRecursive2(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     
     
 
@@ -9435,6 +9681,7 @@ class FindManyDArgsFromLists(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive1'
 
 
@@ -9445,6 +9692,7 @@ class FindManyDArgsFromListsRecursive1(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive2'
 
 
@@ -9455,6 +9703,7 @@ class FindManyDArgsFromListsRecursive2(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     
     
 
@@ -9493,6 +9742,7 @@ class FindManyEArgsFromLists(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive1'
 
 
@@ -9503,6 +9753,7 @@ class FindManyEArgsFromListsRecursive1(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive2'
 
 
@@ -9513,6 +9764,7 @@ class FindManyEArgsFromListsRecursive2(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     
 
 
@@ -10079,6 +10331,7 @@ class FindManyPostArgsFromA(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive1'
 
 
@@ -10089,6 +10342,7 @@ class FindManyPostArgsFromARecursive1(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive2'
 
 
@@ -10099,6 +10353,7 @@ class FindManyPostArgsFromARecursive2(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     
     
 
@@ -10139,6 +10394,7 @@ class FindManyUserArgsFromA(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive1'
 
 
@@ -10149,6 +10405,7 @@ class FindManyUserArgsFromARecursive1(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive2'
 
 
@@ -10159,6 +10416,7 @@ class FindManyUserArgsFromARecursive2(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     
     
 
@@ -10199,6 +10457,7 @@ class FindManyMArgsFromA(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive1'
 
 
@@ -10209,6 +10468,7 @@ class FindManyMArgsFromARecursive1(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive2'
 
 
@@ -10219,6 +10479,7 @@ class FindManyMArgsFromARecursive2(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     
     
 
@@ -10259,6 +10520,7 @@ class FindManyNArgsFromA(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive1'
 
 
@@ -10269,6 +10531,7 @@ class FindManyNArgsFromARecursive1(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive2'
 
 
@@ -10279,6 +10542,7 @@ class FindManyNArgsFromARecursive2(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     
     
 
@@ -10319,6 +10583,7 @@ class FindManyOneOptionalArgsFromA(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive1'
 
 
@@ -10329,6 +10594,7 @@ class FindManyOneOptionalArgsFromARecursive1(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive2'
 
 
@@ -10339,6 +10605,7 @@ class FindManyOneOptionalArgsFromARecursive2(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     
     
 
@@ -10379,6 +10646,7 @@ class FindManyManyRequiredArgsFromA(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive1'
 
 
@@ -10389,6 +10657,7 @@ class FindManyManyRequiredArgsFromARecursive1(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive2'
 
 
@@ -10399,6 +10668,7 @@ class FindManyManyRequiredArgsFromARecursive2(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     
     
 
@@ -10437,6 +10707,7 @@ class FindManyListsArgsFromA(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive1'
 
 
@@ -10447,6 +10718,7 @@ class FindManyListsArgsFromARecursive1(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive2'
 
 
@@ -10457,6 +10729,7 @@ class FindManyListsArgsFromARecursive2(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     
     
 
@@ -10495,6 +10768,7 @@ class FindManyAArgsFromA(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive1'
 
 
@@ -10505,6 +10779,7 @@ class FindManyAArgsFromARecursive1(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive2'
 
 
@@ -10515,6 +10790,7 @@ class FindManyAArgsFromARecursive2(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     
     
 
@@ -10553,6 +10829,7 @@ class FindManyBArgsFromA(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive1'
 
 
@@ -10563,6 +10840,7 @@ class FindManyBArgsFromARecursive1(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive2'
 
 
@@ -10573,6 +10851,7 @@ class FindManyBArgsFromARecursive2(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     
     
 
@@ -10611,6 +10890,7 @@ class FindManyCArgsFromA(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive1'
 
 
@@ -10621,6 +10901,7 @@ class FindManyCArgsFromARecursive1(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive2'
 
 
@@ -10631,6 +10912,7 @@ class FindManyCArgsFromARecursive2(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     
     
 
@@ -10669,6 +10951,7 @@ class FindManyDArgsFromA(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive1'
 
 
@@ -10679,6 +10962,7 @@ class FindManyDArgsFromARecursive1(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive2'
 
 
@@ -10689,6 +10973,7 @@ class FindManyDArgsFromARecursive2(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     
     
 
@@ -10727,6 +11012,7 @@ class FindManyEArgsFromA(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive1'
 
 
@@ -10737,6 +11023,7 @@ class FindManyEArgsFromARecursive1(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive2'
 
 
@@ -10747,6 +11034,7 @@ class FindManyEArgsFromARecursive2(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     
 
 
@@ -11255,6 +11543,7 @@ class FindManyPostArgsFromB(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive1'
 
 
@@ -11265,6 +11554,7 @@ class FindManyPostArgsFromBRecursive1(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive2'
 
 
@@ -11275,6 +11565,7 @@ class FindManyPostArgsFromBRecursive2(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     
     
 
@@ -11315,6 +11606,7 @@ class FindManyUserArgsFromB(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive1'
 
 
@@ -11325,6 +11617,7 @@ class FindManyUserArgsFromBRecursive1(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive2'
 
 
@@ -11335,6 +11628,7 @@ class FindManyUserArgsFromBRecursive2(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     
     
 
@@ -11375,6 +11669,7 @@ class FindManyMArgsFromB(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive1'
 
 
@@ -11385,6 +11680,7 @@ class FindManyMArgsFromBRecursive1(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive2'
 
 
@@ -11395,6 +11691,7 @@ class FindManyMArgsFromBRecursive2(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     
     
 
@@ -11435,6 +11732,7 @@ class FindManyNArgsFromB(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive1'
 
 
@@ -11445,6 +11743,7 @@ class FindManyNArgsFromBRecursive1(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive2'
 
 
@@ -11455,6 +11754,7 @@ class FindManyNArgsFromBRecursive2(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     
     
 
@@ -11495,6 +11795,7 @@ class FindManyOneOptionalArgsFromB(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive1'
 
 
@@ -11505,6 +11806,7 @@ class FindManyOneOptionalArgsFromBRecursive1(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive2'
 
 
@@ -11515,6 +11817,7 @@ class FindManyOneOptionalArgsFromBRecursive2(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     
     
 
@@ -11555,6 +11858,7 @@ class FindManyManyRequiredArgsFromB(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive1'
 
 
@@ -11565,6 +11869,7 @@ class FindManyManyRequiredArgsFromBRecursive1(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive2'
 
 
@@ -11575,6 +11880,7 @@ class FindManyManyRequiredArgsFromBRecursive2(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     
     
 
@@ -11613,6 +11919,7 @@ class FindManyListsArgsFromB(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive1'
 
 
@@ -11623,6 +11930,7 @@ class FindManyListsArgsFromBRecursive1(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive2'
 
 
@@ -11633,6 +11941,7 @@ class FindManyListsArgsFromBRecursive2(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     
     
 
@@ -11671,6 +11980,7 @@ class FindManyAArgsFromB(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive1'
 
 
@@ -11681,6 +11991,7 @@ class FindManyAArgsFromBRecursive1(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive2'
 
 
@@ -11691,6 +12002,7 @@ class FindManyAArgsFromBRecursive2(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     
     
 
@@ -11729,6 +12041,7 @@ class FindManyBArgsFromB(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive1'
 
 
@@ -11739,6 +12052,7 @@ class FindManyBArgsFromBRecursive1(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive2'
 
 
@@ -11749,6 +12063,7 @@ class FindManyBArgsFromBRecursive2(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     
     
 
@@ -11787,6 +12102,7 @@ class FindManyCArgsFromB(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive1'
 
 
@@ -11797,6 +12113,7 @@ class FindManyCArgsFromBRecursive1(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive2'
 
 
@@ -11807,6 +12124,7 @@ class FindManyCArgsFromBRecursive2(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     
     
 
@@ -11845,6 +12163,7 @@ class FindManyDArgsFromB(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive1'
 
 
@@ -11855,6 +12174,7 @@ class FindManyDArgsFromBRecursive1(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive2'
 
 
@@ -11865,6 +12185,7 @@ class FindManyDArgsFromBRecursive2(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     
     
 
@@ -11903,6 +12224,7 @@ class FindManyEArgsFromB(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive1'
 
 
@@ -11913,6 +12235,7 @@ class FindManyEArgsFromBRecursive1(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive2'
 
 
@@ -11923,6 +12246,7 @@ class FindManyEArgsFromBRecursive2(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     
 
 
@@ -12365,6 +12689,7 @@ class FindManyPostArgsFromC(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive1'
 
 
@@ -12375,6 +12700,7 @@ class FindManyPostArgsFromCRecursive1(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive2'
 
 
@@ -12385,6 +12711,7 @@ class FindManyPostArgsFromCRecursive2(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     
     
 
@@ -12425,6 +12752,7 @@ class FindManyUserArgsFromC(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive1'
 
 
@@ -12435,6 +12763,7 @@ class FindManyUserArgsFromCRecursive1(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive2'
 
 
@@ -12445,6 +12774,7 @@ class FindManyUserArgsFromCRecursive2(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     
     
 
@@ -12485,6 +12815,7 @@ class FindManyMArgsFromC(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive1'
 
 
@@ -12495,6 +12826,7 @@ class FindManyMArgsFromCRecursive1(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive2'
 
 
@@ -12505,6 +12837,7 @@ class FindManyMArgsFromCRecursive2(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     
     
 
@@ -12545,6 +12878,7 @@ class FindManyNArgsFromC(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive1'
 
 
@@ -12555,6 +12889,7 @@ class FindManyNArgsFromCRecursive1(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive2'
 
 
@@ -12565,6 +12900,7 @@ class FindManyNArgsFromCRecursive2(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     
     
 
@@ -12605,6 +12941,7 @@ class FindManyOneOptionalArgsFromC(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive1'
 
 
@@ -12615,6 +12952,7 @@ class FindManyOneOptionalArgsFromCRecursive1(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive2'
 
 
@@ -12625,6 +12963,7 @@ class FindManyOneOptionalArgsFromCRecursive2(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     
     
 
@@ -12665,6 +13004,7 @@ class FindManyManyRequiredArgsFromC(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive1'
 
 
@@ -12675,6 +13015,7 @@ class FindManyManyRequiredArgsFromCRecursive1(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive2'
 
 
@@ -12685,6 +13026,7 @@ class FindManyManyRequiredArgsFromCRecursive2(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     
     
 
@@ -12723,6 +13065,7 @@ class FindManyListsArgsFromC(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive1'
 
 
@@ -12733,6 +13076,7 @@ class FindManyListsArgsFromCRecursive1(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive2'
 
 
@@ -12743,6 +13087,7 @@ class FindManyListsArgsFromCRecursive2(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     
     
 
@@ -12781,6 +13126,7 @@ class FindManyAArgsFromC(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive1'
 
 
@@ -12791,6 +13137,7 @@ class FindManyAArgsFromCRecursive1(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive2'
 
 
@@ -12801,6 +13148,7 @@ class FindManyAArgsFromCRecursive2(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     
     
 
@@ -12839,6 +13187,7 @@ class FindManyBArgsFromC(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive1'
 
 
@@ -12849,6 +13198,7 @@ class FindManyBArgsFromCRecursive1(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive2'
 
 
@@ -12859,6 +13209,7 @@ class FindManyBArgsFromCRecursive2(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     
     
 
@@ -12897,6 +13248,7 @@ class FindManyCArgsFromC(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive1'
 
 
@@ -12907,6 +13259,7 @@ class FindManyCArgsFromCRecursive1(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive2'
 
 
@@ -12917,6 +13270,7 @@ class FindManyCArgsFromCRecursive2(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     
     
 
@@ -12955,6 +13309,7 @@ class FindManyDArgsFromC(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive1'
 
 
@@ -12965,6 +13320,7 @@ class FindManyDArgsFromCRecursive1(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive2'
 
 
@@ -12975,6 +13331,7 @@ class FindManyDArgsFromCRecursive2(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     
     
 
@@ -13013,6 +13370,7 @@ class FindManyEArgsFromC(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive1'
 
 
@@ -13023,6 +13381,7 @@ class FindManyEArgsFromCRecursive1(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive2'
 
 
@@ -13033,6 +13392,7 @@ class FindManyEArgsFromCRecursive2(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     
 
 
@@ -13474,6 +13834,7 @@ class FindManyPostArgsFromD(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive1'
 
 
@@ -13484,6 +13845,7 @@ class FindManyPostArgsFromDRecursive1(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive2'
 
 
@@ -13494,6 +13856,7 @@ class FindManyPostArgsFromDRecursive2(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     
     
 
@@ -13534,6 +13897,7 @@ class FindManyUserArgsFromD(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive1'
 
 
@@ -13544,6 +13908,7 @@ class FindManyUserArgsFromDRecursive1(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive2'
 
 
@@ -13554,6 +13919,7 @@ class FindManyUserArgsFromDRecursive2(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     
     
 
@@ -13594,6 +13960,7 @@ class FindManyMArgsFromD(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive1'
 
 
@@ -13604,6 +13971,7 @@ class FindManyMArgsFromDRecursive1(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive2'
 
 
@@ -13614,6 +13982,7 @@ class FindManyMArgsFromDRecursive2(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     
     
 
@@ -13654,6 +14023,7 @@ class FindManyNArgsFromD(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive1'
 
 
@@ -13664,6 +14034,7 @@ class FindManyNArgsFromDRecursive1(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive2'
 
 
@@ -13674,6 +14045,7 @@ class FindManyNArgsFromDRecursive2(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     
     
 
@@ -13714,6 +14086,7 @@ class FindManyOneOptionalArgsFromD(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive1'
 
 
@@ -13724,6 +14097,7 @@ class FindManyOneOptionalArgsFromDRecursive1(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive2'
 
 
@@ -13734,6 +14108,7 @@ class FindManyOneOptionalArgsFromDRecursive2(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     
     
 
@@ -13774,6 +14149,7 @@ class FindManyManyRequiredArgsFromD(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive1'
 
 
@@ -13784,6 +14160,7 @@ class FindManyManyRequiredArgsFromDRecursive1(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive2'
 
 
@@ -13794,6 +14171,7 @@ class FindManyManyRequiredArgsFromDRecursive2(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     
     
 
@@ -13832,6 +14210,7 @@ class FindManyListsArgsFromD(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive1'
 
 
@@ -13842,6 +14221,7 @@ class FindManyListsArgsFromDRecursive1(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive2'
 
 
@@ -13852,6 +14232,7 @@ class FindManyListsArgsFromDRecursive2(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     
     
 
@@ -13890,6 +14271,7 @@ class FindManyAArgsFromD(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive1'
 
 
@@ -13900,6 +14282,7 @@ class FindManyAArgsFromDRecursive1(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive2'
 
 
@@ -13910,6 +14293,7 @@ class FindManyAArgsFromDRecursive2(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     
     
 
@@ -13948,6 +14332,7 @@ class FindManyBArgsFromD(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive1'
 
 
@@ -13958,6 +14343,7 @@ class FindManyBArgsFromDRecursive1(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive2'
 
 
@@ -13968,6 +14354,7 @@ class FindManyBArgsFromDRecursive2(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     
     
 
@@ -14006,6 +14393,7 @@ class FindManyCArgsFromD(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive1'
 
 
@@ -14016,6 +14404,7 @@ class FindManyCArgsFromDRecursive1(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive2'
 
 
@@ -14026,6 +14415,7 @@ class FindManyCArgsFromDRecursive2(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     
     
 
@@ -14064,6 +14454,7 @@ class FindManyDArgsFromD(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive1'
 
 
@@ -14074,6 +14465,7 @@ class FindManyDArgsFromDRecursive1(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive2'
 
 
@@ -14084,6 +14476,7 @@ class FindManyDArgsFromDRecursive2(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     
     
 
@@ -14122,6 +14515,7 @@ class FindManyEArgsFromD(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive1'
 
 
@@ -14132,6 +14526,7 @@ class FindManyEArgsFromDRecursive1(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive2'
 
 
@@ -14142,6 +14537,7 @@ class FindManyEArgsFromDRecursive2(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     
 
 
@@ -14557,6 +14953,7 @@ class FindManyPostArgsFromE(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive1'
 
 
@@ -14567,6 +14964,7 @@ class FindManyPostArgsFromERecursive1(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive2'
 
 
@@ -14577,6 +14975,7 @@ class FindManyPostArgsFromERecursive2(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     
     
 
@@ -14617,6 +15016,7 @@ class FindManyUserArgsFromE(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive1'
 
 
@@ -14627,6 +15027,7 @@ class FindManyUserArgsFromERecursive1(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive2'
 
 
@@ -14637,6 +15038,7 @@ class FindManyUserArgsFromERecursive2(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     
     
 
@@ -14677,6 +15079,7 @@ class FindManyMArgsFromE(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive1'
 
 
@@ -14687,6 +15090,7 @@ class FindManyMArgsFromERecursive1(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive2'
 
 
@@ -14697,6 +15101,7 @@ class FindManyMArgsFromERecursive2(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     
     
 
@@ -14737,6 +15142,7 @@ class FindManyNArgsFromE(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive1'
 
 
@@ -14747,6 +15153,7 @@ class FindManyNArgsFromERecursive1(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive2'
 
 
@@ -14757,6 +15164,7 @@ class FindManyNArgsFromERecursive2(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     
     
 
@@ -14797,6 +15205,7 @@ class FindManyOneOptionalArgsFromE(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive1'
 
 
@@ -14807,6 +15216,7 @@ class FindManyOneOptionalArgsFromERecursive1(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive2'
 
 
@@ -14817,6 +15227,7 @@ class FindManyOneOptionalArgsFromERecursive2(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     
     
 
@@ -14857,6 +15268,7 @@ class FindManyManyRequiredArgsFromE(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive1'
 
 
@@ -14867,6 +15279,7 @@ class FindManyManyRequiredArgsFromERecursive1(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive2'
 
 
@@ -14877,6 +15290,7 @@ class FindManyManyRequiredArgsFromERecursive2(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     
     
 
@@ -14915,6 +15329,7 @@ class FindManyListsArgsFromE(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive1'
 
 
@@ -14925,6 +15340,7 @@ class FindManyListsArgsFromERecursive1(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive2'
 
 
@@ -14935,6 +15351,7 @@ class FindManyListsArgsFromERecursive2(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     
     
 
@@ -14973,6 +15390,7 @@ class FindManyAArgsFromE(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive1'
 
 
@@ -14983,6 +15401,7 @@ class FindManyAArgsFromERecursive1(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive2'
 
 
@@ -14993,6 +15412,7 @@ class FindManyAArgsFromERecursive2(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     
     
 
@@ -15031,6 +15451,7 @@ class FindManyBArgsFromE(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive1'
 
 
@@ -15041,6 +15462,7 @@ class FindManyBArgsFromERecursive1(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive2'
 
 
@@ -15051,6 +15473,7 @@ class FindManyBArgsFromERecursive2(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     
     
 
@@ -15089,6 +15512,7 @@ class FindManyCArgsFromE(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive1'
 
 
@@ -15099,6 +15523,7 @@ class FindManyCArgsFromERecursive1(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive2'
 
 
@@ -15109,6 +15534,7 @@ class FindManyCArgsFromERecursive2(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     
     
 
@@ -15147,6 +15573,7 @@ class FindManyDArgsFromE(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive1'
 
 
@@ -15157,6 +15584,7 @@ class FindManyDArgsFromERecursive1(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive2'
 
 
@@ -15167,6 +15595,7 @@ class FindManyDArgsFromERecursive2(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     
     
 
@@ -15205,6 +15634,7 @@ class FindManyEArgsFromE(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive1'
 
 
@@ -15215,6 +15645,7 @@ class FindManyEArgsFromERecursive1(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive2'
 
 
@@ -15225,6 +15656,7 @@ class FindManyEArgsFromERecursive2(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     
 
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[actions.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[actions.py].raw
@@ -366,6 +366,7 @@ class PostActions:
         cursor: Optional[types.PostWhereUniqueInput] = None,
         include: Optional[types.PostInclude] = None,
         order: Optional[Union[types.PostOrderByInput, List[types.PostOrderByInput]]] = None,
+        distinct: Optional[List[types.PostScalarFieldKeys]] = None,
     ) -> List['models.Post']:
         """Find multiple Post records.
 
@@ -422,6 +423,7 @@ class PostActions:
                 'order_by': order,
                 'cursor': cursor,
                 'include': include,
+                'distinct': distinct,
             },
         )
         return [self._model.parse_obj(r) for r in resp['data']['result']]
@@ -433,6 +435,7 @@ class PostActions:
         cursor: Optional[types.PostWhereUniqueInput] = None,
         include: Optional[types.PostInclude] = None,
         order: Optional[Union[types.PostOrderByInput, List[types.PostOrderByInput]]] = None,
+        distinct: Optional[List[types.PostScalarFieldKeys]] = None,
     ) -> Optional['models.Post']:
         """Find a single Post record.
 
@@ -482,7 +485,8 @@ class PostActions:
                 'where': where,
                 'order_by': order,
                 'cursor': cursor,
-                'include': include
+                'include': include,
+                'distinct': distinct,
             },
         )
         result = resp['data']['result']
@@ -1297,6 +1301,7 @@ class UserActions:
         cursor: Optional[types.UserWhereUniqueInput] = None,
         include: Optional[types.UserInclude] = None,
         order: Optional[Union[types.UserOrderByInput, List[types.UserOrderByInput]]] = None,
+        distinct: Optional[List[types.UserScalarFieldKeys]] = None,
     ) -> List['models.User']:
         """Find multiple User records.
 
@@ -1353,6 +1358,7 @@ class UserActions:
                 'order_by': order,
                 'cursor': cursor,
                 'include': include,
+                'distinct': distinct,
             },
         )
         return [self._model.parse_obj(r) for r in resp['data']['result']]
@@ -1364,6 +1370,7 @@ class UserActions:
         cursor: Optional[types.UserWhereUniqueInput] = None,
         include: Optional[types.UserInclude] = None,
         order: Optional[Union[types.UserOrderByInput, List[types.UserOrderByInput]]] = None,
+        distinct: Optional[List[types.UserScalarFieldKeys]] = None,
     ) -> Optional['models.User']:
         """Find a single User record.
 
@@ -1413,7 +1420,8 @@ class UserActions:
                 'where': where,
                 'order_by': order,
                 'cursor': cursor,
-                'include': include
+                'include': include,
+                'distinct': distinct,
             },
         )
         result = resp['data']['result']
@@ -2233,6 +2241,7 @@ class MActions:
         cursor: Optional[types.MWhereUniqueInput] = None,
         include: Optional[types.MInclude] = None,
         order: Optional[Union[types.MOrderByInput, List[types.MOrderByInput]]] = None,
+        distinct: Optional[List[types.MScalarFieldKeys]] = None,
     ) -> List['models.M']:
         """Find multiple M records.
 
@@ -2289,6 +2298,7 @@ class MActions:
                 'order_by': order,
                 'cursor': cursor,
                 'include': include,
+                'distinct': distinct,
             },
         )
         return [self._model.parse_obj(r) for r in resp['data']['result']]
@@ -2300,6 +2310,7 @@ class MActions:
         cursor: Optional[types.MWhereUniqueInput] = None,
         include: Optional[types.MInclude] = None,
         order: Optional[Union[types.MOrderByInput, List[types.MOrderByInput]]] = None,
+        distinct: Optional[List[types.MScalarFieldKeys]] = None,
     ) -> Optional['models.M']:
         """Find a single M record.
 
@@ -2349,7 +2360,8 @@ class MActions:
                 'where': where,
                 'order_by': order,
                 'cursor': cursor,
-                'include': include
+                'include': include,
+                'distinct': distinct,
             },
         )
         result = resp['data']['result']
@@ -3170,6 +3182,7 @@ class NActions:
         cursor: Optional[types.NWhereUniqueInput] = None,
         include: Optional[types.NInclude] = None,
         order: Optional[Union[types.NOrderByInput, List[types.NOrderByInput]]] = None,
+        distinct: Optional[List[types.NScalarFieldKeys]] = None,
     ) -> List['models.N']:
         """Find multiple N records.
 
@@ -3226,6 +3239,7 @@ class NActions:
                 'order_by': order,
                 'cursor': cursor,
                 'include': include,
+                'distinct': distinct,
             },
         )
         return [self._model.parse_obj(r) for r in resp['data']['result']]
@@ -3237,6 +3251,7 @@ class NActions:
         cursor: Optional[types.NWhereUniqueInput] = None,
         include: Optional[types.NInclude] = None,
         order: Optional[Union[types.NOrderByInput, List[types.NOrderByInput]]] = None,
+        distinct: Optional[List[types.NScalarFieldKeys]] = None,
     ) -> Optional['models.N']:
         """Find a single N record.
 
@@ -3286,7 +3301,8 @@ class NActions:
                 'where': where,
                 'order_by': order,
                 'cursor': cursor,
-                'include': include
+                'include': include,
+                'distinct': distinct,
             },
         )
         result = resp['data']['result']
@@ -4106,6 +4122,7 @@ class OneOptionalActions:
         cursor: Optional[types.OneOptionalWhereUniqueInput] = None,
         include: Optional[types.OneOptionalInclude] = None,
         order: Optional[Union[types.OneOptionalOrderByInput, List[types.OneOptionalOrderByInput]]] = None,
+        distinct: Optional[List[types.OneOptionalScalarFieldKeys]] = None,
     ) -> List['models.OneOptional']:
         """Find multiple OneOptional records.
 
@@ -4162,6 +4179,7 @@ class OneOptionalActions:
                 'order_by': order,
                 'cursor': cursor,
                 'include': include,
+                'distinct': distinct,
             },
         )
         return [self._model.parse_obj(r) for r in resp['data']['result']]
@@ -4173,6 +4191,7 @@ class OneOptionalActions:
         cursor: Optional[types.OneOptionalWhereUniqueInput] = None,
         include: Optional[types.OneOptionalInclude] = None,
         order: Optional[Union[types.OneOptionalOrderByInput, List[types.OneOptionalOrderByInput]]] = None,
+        distinct: Optional[List[types.OneOptionalScalarFieldKeys]] = None,
     ) -> Optional['models.OneOptional']:
         """Find a single OneOptional record.
 
@@ -4222,7 +4241,8 @@ class OneOptionalActions:
                 'where': where,
                 'order_by': order,
                 'cursor': cursor,
-                'include': include
+                'include': include,
+                'distinct': distinct,
             },
         )
         result = resp['data']['result']
@@ -5040,6 +5060,7 @@ class ManyRequiredActions:
         cursor: Optional[types.ManyRequiredWhereUniqueInput] = None,
         include: Optional[types.ManyRequiredInclude] = None,
         order: Optional[Union[types.ManyRequiredOrderByInput, List[types.ManyRequiredOrderByInput]]] = None,
+        distinct: Optional[List[types.ManyRequiredScalarFieldKeys]] = None,
     ) -> List['models.ManyRequired']:
         """Find multiple ManyRequired records.
 
@@ -5096,6 +5117,7 @@ class ManyRequiredActions:
                 'order_by': order,
                 'cursor': cursor,
                 'include': include,
+                'distinct': distinct,
             },
         )
         return [self._model.parse_obj(r) for r in resp['data']['result']]
@@ -5107,6 +5129,7 @@ class ManyRequiredActions:
         cursor: Optional[types.ManyRequiredWhereUniqueInput] = None,
         include: Optional[types.ManyRequiredInclude] = None,
         order: Optional[Union[types.ManyRequiredOrderByInput, List[types.ManyRequiredOrderByInput]]] = None,
+        distinct: Optional[List[types.ManyRequiredScalarFieldKeys]] = None,
     ) -> Optional['models.ManyRequired']:
         """Find a single ManyRequired record.
 
@@ -5156,7 +5179,8 @@ class ManyRequiredActions:
                 'where': where,
                 'order_by': order,
                 'cursor': cursor,
-                'include': include
+                'include': include,
+                'distinct': distinct,
             },
         )
         result = resp['data']['result']
@@ -5959,6 +5983,7 @@ class ListsActions:
         cursor: Optional[types.ListsWhereUniqueInput] = None,
         include: Optional[types.ListsInclude] = None,
         order: Optional[Union[types.ListsOrderByInput, List[types.ListsOrderByInput]]] = None,
+        distinct: Optional[List[types.ListsScalarFieldKeys]] = None,
     ) -> List['models.Lists']:
         """Find multiple Lists records.
 
@@ -6015,6 +6040,7 @@ class ListsActions:
                 'order_by': order,
                 'cursor': cursor,
                 'include': include,
+                'distinct': distinct,
             },
         )
         return [self._model.parse_obj(r) for r in resp['data']['result']]
@@ -6026,6 +6052,7 @@ class ListsActions:
         cursor: Optional[types.ListsWhereUniqueInput] = None,
         include: Optional[types.ListsInclude] = None,
         order: Optional[Union[types.ListsOrderByInput, List[types.ListsOrderByInput]]] = None,
+        distinct: Optional[List[types.ListsScalarFieldKeys]] = None,
     ) -> Optional['models.Lists']:
         """Find a single Lists record.
 
@@ -6075,7 +6102,8 @@ class ListsActions:
                 'where': where,
                 'order_by': order,
                 'cursor': cursor,
-                'include': include
+                'include': include,
+                'distinct': distinct,
             },
         )
         result = resp['data']['result']
@@ -6880,6 +6908,7 @@ class AActions:
         cursor: Optional[types.AWhereUniqueInput] = None,
         include: Optional[types.AInclude] = None,
         order: Optional[Union[types.AOrderByInput, List[types.AOrderByInput]]] = None,
+        distinct: Optional[List[types.AScalarFieldKeys]] = None,
     ) -> List['models.A']:
         """Find multiple A records.
 
@@ -6936,6 +6965,7 @@ class AActions:
                 'order_by': order,
                 'cursor': cursor,
                 'include': include,
+                'distinct': distinct,
             },
         )
         return [self._model.parse_obj(r) for r in resp['data']['result']]
@@ -6947,6 +6977,7 @@ class AActions:
         cursor: Optional[types.AWhereUniqueInput] = None,
         include: Optional[types.AInclude] = None,
         order: Optional[Union[types.AOrderByInput, List[types.AOrderByInput]]] = None,
+        distinct: Optional[List[types.AScalarFieldKeys]] = None,
     ) -> Optional['models.A']:
         """Find a single A record.
 
@@ -6996,7 +7027,8 @@ class AActions:
                 'where': where,
                 'order_by': order,
                 'cursor': cursor,
-                'include': include
+                'include': include,
+                'distinct': distinct,
             },
         )
         result = resp['data']['result']
@@ -7807,6 +7839,7 @@ class BActions:
         cursor: Optional[types.BWhereUniqueInput] = None,
         include: Optional[types.BInclude] = None,
         order: Optional[Union[types.BOrderByInput, List[types.BOrderByInput]]] = None,
+        distinct: Optional[List[types.BScalarFieldKeys]] = None,
     ) -> List['models.B']:
         """Find multiple B records.
 
@@ -7863,6 +7896,7 @@ class BActions:
                 'order_by': order,
                 'cursor': cursor,
                 'include': include,
+                'distinct': distinct,
             },
         )
         return [self._model.parse_obj(r) for r in resp['data']['result']]
@@ -7874,6 +7908,7 @@ class BActions:
         cursor: Optional[types.BWhereUniqueInput] = None,
         include: Optional[types.BInclude] = None,
         order: Optional[Union[types.BOrderByInput, List[types.BOrderByInput]]] = None,
+        distinct: Optional[List[types.BScalarFieldKeys]] = None,
     ) -> Optional['models.B']:
         """Find a single B record.
 
@@ -7923,7 +7958,8 @@ class BActions:
                 'where': where,
                 'order_by': order,
                 'cursor': cursor,
-                'include': include
+                'include': include,
+                'distinct': distinct,
             },
         )
         result = resp['data']['result']
@@ -8744,6 +8780,7 @@ class CActions:
         cursor: Optional[types.CWhereUniqueInput] = None,
         include: Optional[types.CInclude] = None,
         order: Optional[Union[types.COrderByInput, List[types.COrderByInput]]] = None,
+        distinct: Optional[List[types.CScalarFieldKeys]] = None,
     ) -> List['models.C']:
         """Find multiple C records.
 
@@ -8800,6 +8837,7 @@ class CActions:
                 'order_by': order,
                 'cursor': cursor,
                 'include': include,
+                'distinct': distinct,
             },
         )
         return [self._model.parse_obj(r) for r in resp['data']['result']]
@@ -8811,6 +8849,7 @@ class CActions:
         cursor: Optional[types.CWhereUniqueInput] = None,
         include: Optional[types.CInclude] = None,
         order: Optional[Union[types.COrderByInput, List[types.COrderByInput]]] = None,
+        distinct: Optional[List[types.CScalarFieldKeys]] = None,
     ) -> Optional['models.C']:
         """Find a single C record.
 
@@ -8860,7 +8899,8 @@ class CActions:
                 'where': where,
                 'order_by': order,
                 'cursor': cursor,
-                'include': include
+                'include': include,
+                'distinct': distinct,
             },
         )
         result = resp['data']['result']
@@ -9670,6 +9710,7 @@ class DActions:
         cursor: Optional[types.DWhereUniqueInput] = None,
         include: Optional[types.DInclude] = None,
         order: Optional[Union[types.DOrderByInput, List[types.DOrderByInput]]] = None,
+        distinct: Optional[List[types.DScalarFieldKeys]] = None,
     ) -> List['models.D']:
         """Find multiple D records.
 
@@ -9726,6 +9767,7 @@ class DActions:
                 'order_by': order,
                 'cursor': cursor,
                 'include': include,
+                'distinct': distinct,
             },
         )
         return [self._model.parse_obj(r) for r in resp['data']['result']]
@@ -9737,6 +9779,7 @@ class DActions:
         cursor: Optional[types.DWhereUniqueInput] = None,
         include: Optional[types.DInclude] = None,
         order: Optional[Union[types.DOrderByInput, List[types.DOrderByInput]]] = None,
+        distinct: Optional[List[types.DScalarFieldKeys]] = None,
     ) -> Optional['models.D']:
         """Find a single D record.
 
@@ -9786,7 +9829,8 @@ class DActions:
                 'where': where,
                 'order_by': order,
                 'cursor': cursor,
-                'include': include
+                'include': include,
+                'distinct': distinct,
             },
         )
         result = resp['data']['result']
@@ -10598,6 +10642,7 @@ class EActions:
         cursor: Optional[types.EWhereUniqueInput] = None,
         include: Optional[types.EInclude] = None,
         order: Optional[Union[types.EOrderByInput, List[types.EOrderByInput]]] = None,
+        distinct: Optional[List[types.EScalarFieldKeys]] = None,
     ) -> List['models.E']:
         """Find multiple E records.
 
@@ -10654,6 +10699,7 @@ class EActions:
                 'order_by': order,
                 'cursor': cursor,
                 'include': include,
+                'distinct': distinct,
             },
         )
         return [self._model.parse_obj(r) for r in resp['data']['result']]
@@ -10665,6 +10711,7 @@ class EActions:
         cursor: Optional[types.EWhereUniqueInput] = None,
         include: Optional[types.EInclude] = None,
         order: Optional[Union[types.EOrderByInput, List[types.EOrderByInput]]] = None,
+        distinct: Optional[List[types.EScalarFieldKeys]] = None,
     ) -> Optional['models.E']:
         """Find a single E record.
 
@@ -10714,7 +10761,8 @@ class EActions:
                 'where': where,
                 'order_by': order,
                 'cursor': cursor,
-                'include': include
+                'include': include,
+                'distinct': distinct,
             },
         )
         result = resp['data']['result']

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[actions.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[actions.py].raw
@@ -386,6 +386,8 @@ class PostActions:
             Specifies which relations should be loaded on the returned Post model
         order
             Order the returned Post records by any field
+        distinct
+            Filter Post records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -451,6 +453,8 @@ class PostActions:
             Specifies which relations should be loaded on the returned Post model
         order
             Order the returned Post records by any field
+        distinct
+            Filter Post records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -1321,6 +1325,8 @@ class UserActions:
             Specifies which relations should be loaded on the returned User model
         order
             Order the returned User records by any field
+        distinct
+            Filter User records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -1386,6 +1392,8 @@ class UserActions:
             Specifies which relations should be loaded on the returned User model
         order
             Order the returned User records by any field
+        distinct
+            Filter User records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -2261,6 +2269,8 @@ class MActions:
             Specifies which relations should be loaded on the returned M model
         order
             Order the returned M records by any field
+        distinct
+            Filter M records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -2326,6 +2336,8 @@ class MActions:
             Specifies which relations should be loaded on the returned M model
         order
             Order the returned M records by any field
+        distinct
+            Filter M records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -3202,6 +3214,8 @@ class NActions:
             Specifies which relations should be loaded on the returned N model
         order
             Order the returned N records by any field
+        distinct
+            Filter N records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -3267,6 +3281,8 @@ class NActions:
             Specifies which relations should be loaded on the returned N model
         order
             Order the returned N records by any field
+        distinct
+            Filter N records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -4142,6 +4158,8 @@ class OneOptionalActions:
             Specifies which relations should be loaded on the returned OneOptional model
         order
             Order the returned OneOptional records by any field
+        distinct
+            Filter OneOptional records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -4207,6 +4225,8 @@ class OneOptionalActions:
             Specifies which relations should be loaded on the returned OneOptional model
         order
             Order the returned OneOptional records by any field
+        distinct
+            Filter OneOptional records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -5080,6 +5100,8 @@ class ManyRequiredActions:
             Specifies which relations should be loaded on the returned ManyRequired model
         order
             Order the returned ManyRequired records by any field
+        distinct
+            Filter ManyRequired records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -5145,6 +5167,8 @@ class ManyRequiredActions:
             Specifies which relations should be loaded on the returned ManyRequired model
         order
             Order the returned ManyRequired records by any field
+        distinct
+            Filter ManyRequired records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -6003,6 +6027,8 @@ class ListsActions:
             Specifies which relations should be loaded on the returned Lists model
         order
             Order the returned Lists records by any field
+        distinct
+            Filter Lists records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -6068,6 +6094,8 @@ class ListsActions:
             Specifies which relations should be loaded on the returned Lists model
         order
             Order the returned Lists records by any field
+        distinct
+            Filter Lists records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -6928,6 +6956,8 @@ class AActions:
             Specifies which relations should be loaded on the returned A model
         order
             Order the returned A records by any field
+        distinct
+            Filter A records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -6993,6 +7023,8 @@ class AActions:
             Specifies which relations should be loaded on the returned A model
         order
             Order the returned A records by any field
+        distinct
+            Filter A records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -7859,6 +7891,8 @@ class BActions:
             Specifies which relations should be loaded on the returned B model
         order
             Order the returned B records by any field
+        distinct
+            Filter B records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -7924,6 +7958,8 @@ class BActions:
             Specifies which relations should be loaded on the returned B model
         order
             Order the returned B records by any field
+        distinct
+            Filter B records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -8800,6 +8836,8 @@ class CActions:
             Specifies which relations should be loaded on the returned C model
         order
             Order the returned C records by any field
+        distinct
+            Filter C records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -8865,6 +8903,8 @@ class CActions:
             Specifies which relations should be loaded on the returned C model
         order
             Order the returned C records by any field
+        distinct
+            Filter C records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -9730,6 +9770,8 @@ class DActions:
             Specifies which relations should be loaded on the returned D model
         order
             Order the returned D records by any field
+        distinct
+            Filter D records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -9795,6 +9837,8 @@ class DActions:
             Specifies which relations should be loaded on the returned D model
         order
             Order the returned D records by any field
+        distinct
+            Filter D records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -10662,6 +10706,8 @@ class EActions:
             Specifies which relations should be loaded on the returned E model
         order
             Order the returned E records by any field
+        distinct
+            Filter E records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------
@@ -10727,6 +10773,8 @@ class EActions:
             Specifies which relations should be loaded on the returned E model
         order
             Order the returned E records by any field
+        distinct
+            Filter E records by either a single distinct field or distinct combinations of fields
 
         Returns
         -------

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[types.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[types.py].raw
@@ -1212,6 +1212,7 @@ class FindManyPostArgsFromPost(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive1'
 
 
@@ -1222,6 +1223,7 @@ class FindManyPostArgsFromPostRecursive1(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive2'
 
 
@@ -1232,6 +1234,7 @@ class FindManyPostArgsFromPostRecursive2(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     
     
 
@@ -1272,6 +1275,7 @@ class FindManyUserArgsFromPost(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive1'
 
 
@@ -1282,6 +1286,7 @@ class FindManyUserArgsFromPostRecursive1(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive2'
 
 
@@ -1292,6 +1297,7 @@ class FindManyUserArgsFromPostRecursive2(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     
     
 
@@ -1332,6 +1338,7 @@ class FindManyMArgsFromPost(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive1'
 
 
@@ -1342,6 +1349,7 @@ class FindManyMArgsFromPostRecursive1(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive2'
 
 
@@ -1352,6 +1360,7 @@ class FindManyMArgsFromPostRecursive2(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     
     
 
@@ -1392,6 +1401,7 @@ class FindManyNArgsFromPost(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive1'
 
 
@@ -1402,6 +1412,7 @@ class FindManyNArgsFromPostRecursive1(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive2'
 
 
@@ -1412,6 +1423,7 @@ class FindManyNArgsFromPostRecursive2(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     
     
 
@@ -1452,6 +1464,7 @@ class FindManyOneOptionalArgsFromPost(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive1'
 
 
@@ -1462,6 +1475,7 @@ class FindManyOneOptionalArgsFromPostRecursive1(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive2'
 
 
@@ -1472,6 +1486,7 @@ class FindManyOneOptionalArgsFromPostRecursive2(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     
     
 
@@ -1512,6 +1527,7 @@ class FindManyManyRequiredArgsFromPost(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive1'
 
 
@@ -1522,6 +1538,7 @@ class FindManyManyRequiredArgsFromPostRecursive1(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive2'
 
 
@@ -1532,6 +1549,7 @@ class FindManyManyRequiredArgsFromPostRecursive2(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     
     
 
@@ -1570,6 +1588,7 @@ class FindManyListsArgsFromPost(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive1'
 
 
@@ -1580,6 +1599,7 @@ class FindManyListsArgsFromPostRecursive1(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive2'
 
 
@@ -1590,6 +1610,7 @@ class FindManyListsArgsFromPostRecursive2(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     
     
 
@@ -1628,6 +1649,7 @@ class FindManyAArgsFromPost(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive1'
 
 
@@ -1638,6 +1660,7 @@ class FindManyAArgsFromPostRecursive1(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive2'
 
 
@@ -1648,6 +1671,7 @@ class FindManyAArgsFromPostRecursive2(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     
     
 
@@ -1686,6 +1710,7 @@ class FindManyBArgsFromPost(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive1'
 
 
@@ -1696,6 +1721,7 @@ class FindManyBArgsFromPostRecursive1(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive2'
 
 
@@ -1706,6 +1732,7 @@ class FindManyBArgsFromPostRecursive2(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     
     
 
@@ -1744,6 +1771,7 @@ class FindManyCArgsFromPost(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive1'
 
 
@@ -1754,6 +1782,7 @@ class FindManyCArgsFromPostRecursive1(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive2'
 
 
@@ -1764,6 +1793,7 @@ class FindManyCArgsFromPostRecursive2(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     
     
 
@@ -1802,6 +1832,7 @@ class FindManyDArgsFromPost(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive1'
 
 
@@ -1812,6 +1843,7 @@ class FindManyDArgsFromPostRecursive1(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive2'
 
 
@@ -1822,6 +1854,7 @@ class FindManyDArgsFromPostRecursive2(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     
     
 
@@ -1860,6 +1893,7 @@ class FindManyEArgsFromPost(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive1'
 
 
@@ -1870,6 +1904,7 @@ class FindManyEArgsFromPostRecursive1(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive2'
 
 
@@ -1880,6 +1915,7 @@ class FindManyEArgsFromPostRecursive2(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     
 
 
@@ -2425,6 +2461,7 @@ class FindManyPostArgsFromUser(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive1'
 
 
@@ -2435,6 +2472,7 @@ class FindManyPostArgsFromUserRecursive1(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive2'
 
 
@@ -2445,6 +2483,7 @@ class FindManyPostArgsFromUserRecursive2(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     
     
 
@@ -2485,6 +2524,7 @@ class FindManyUserArgsFromUser(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive1'
 
 
@@ -2495,6 +2535,7 @@ class FindManyUserArgsFromUserRecursive1(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive2'
 
 
@@ -2505,6 +2546,7 @@ class FindManyUserArgsFromUserRecursive2(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     
     
 
@@ -2545,6 +2587,7 @@ class FindManyMArgsFromUser(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive1'
 
 
@@ -2555,6 +2598,7 @@ class FindManyMArgsFromUserRecursive1(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive2'
 
 
@@ -2565,6 +2609,7 @@ class FindManyMArgsFromUserRecursive2(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     
     
 
@@ -2605,6 +2650,7 @@ class FindManyNArgsFromUser(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive1'
 
 
@@ -2615,6 +2661,7 @@ class FindManyNArgsFromUserRecursive1(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive2'
 
 
@@ -2625,6 +2672,7 @@ class FindManyNArgsFromUserRecursive2(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     
     
 
@@ -2665,6 +2713,7 @@ class FindManyOneOptionalArgsFromUser(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive1'
 
 
@@ -2675,6 +2724,7 @@ class FindManyOneOptionalArgsFromUserRecursive1(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive2'
 
 
@@ -2685,6 +2735,7 @@ class FindManyOneOptionalArgsFromUserRecursive2(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     
     
 
@@ -2725,6 +2776,7 @@ class FindManyManyRequiredArgsFromUser(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive1'
 
 
@@ -2735,6 +2787,7 @@ class FindManyManyRequiredArgsFromUserRecursive1(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive2'
 
 
@@ -2745,6 +2798,7 @@ class FindManyManyRequiredArgsFromUserRecursive2(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     
     
 
@@ -2783,6 +2837,7 @@ class FindManyListsArgsFromUser(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive1'
 
 
@@ -2793,6 +2848,7 @@ class FindManyListsArgsFromUserRecursive1(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive2'
 
 
@@ -2803,6 +2859,7 @@ class FindManyListsArgsFromUserRecursive2(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     
     
 
@@ -2841,6 +2898,7 @@ class FindManyAArgsFromUser(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive1'
 
 
@@ -2851,6 +2909,7 @@ class FindManyAArgsFromUserRecursive1(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive2'
 
 
@@ -2861,6 +2920,7 @@ class FindManyAArgsFromUserRecursive2(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     
     
 
@@ -2899,6 +2959,7 @@ class FindManyBArgsFromUser(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive1'
 
 
@@ -2909,6 +2970,7 @@ class FindManyBArgsFromUserRecursive1(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive2'
 
 
@@ -2919,6 +2981,7 @@ class FindManyBArgsFromUserRecursive2(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     
     
 
@@ -2957,6 +3020,7 @@ class FindManyCArgsFromUser(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive1'
 
 
@@ -2967,6 +3031,7 @@ class FindManyCArgsFromUserRecursive1(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive2'
 
 
@@ -2977,6 +3042,7 @@ class FindManyCArgsFromUserRecursive2(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     
     
 
@@ -3015,6 +3081,7 @@ class FindManyDArgsFromUser(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive1'
 
 
@@ -3025,6 +3092,7 @@ class FindManyDArgsFromUserRecursive1(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive2'
 
 
@@ -3035,6 +3103,7 @@ class FindManyDArgsFromUserRecursive2(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     
     
 
@@ -3073,6 +3142,7 @@ class FindManyEArgsFromUser(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive1'
 
 
@@ -3083,6 +3153,7 @@ class FindManyEArgsFromUserRecursive1(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive2'
 
 
@@ -3093,6 +3164,7 @@ class FindManyEArgsFromUserRecursive2(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     
 
 
@@ -3707,6 +3779,7 @@ class FindManyPostArgsFromM(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive1'
 
 
@@ -3717,6 +3790,7 @@ class FindManyPostArgsFromMRecursive1(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive2'
 
 
@@ -3727,6 +3801,7 @@ class FindManyPostArgsFromMRecursive2(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     
     
 
@@ -3767,6 +3842,7 @@ class FindManyUserArgsFromM(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive1'
 
 
@@ -3777,6 +3853,7 @@ class FindManyUserArgsFromMRecursive1(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive2'
 
 
@@ -3787,6 +3864,7 @@ class FindManyUserArgsFromMRecursive2(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     
     
 
@@ -3827,6 +3905,7 @@ class FindManyMArgsFromM(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive1'
 
 
@@ -3837,6 +3916,7 @@ class FindManyMArgsFromMRecursive1(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive2'
 
 
@@ -3847,6 +3927,7 @@ class FindManyMArgsFromMRecursive2(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     
     
 
@@ -3887,6 +3968,7 @@ class FindManyNArgsFromM(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive1'
 
 
@@ -3897,6 +3979,7 @@ class FindManyNArgsFromMRecursive1(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive2'
 
 
@@ -3907,6 +3990,7 @@ class FindManyNArgsFromMRecursive2(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     
     
 
@@ -3947,6 +4031,7 @@ class FindManyOneOptionalArgsFromM(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive1'
 
 
@@ -3957,6 +4042,7 @@ class FindManyOneOptionalArgsFromMRecursive1(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive2'
 
 
@@ -3967,6 +4053,7 @@ class FindManyOneOptionalArgsFromMRecursive2(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     
     
 
@@ -4007,6 +4094,7 @@ class FindManyManyRequiredArgsFromM(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive1'
 
 
@@ -4017,6 +4105,7 @@ class FindManyManyRequiredArgsFromMRecursive1(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive2'
 
 
@@ -4027,6 +4116,7 @@ class FindManyManyRequiredArgsFromMRecursive2(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     
     
 
@@ -4065,6 +4155,7 @@ class FindManyListsArgsFromM(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive1'
 
 
@@ -4075,6 +4166,7 @@ class FindManyListsArgsFromMRecursive1(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive2'
 
 
@@ -4085,6 +4177,7 @@ class FindManyListsArgsFromMRecursive2(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     
     
 
@@ -4123,6 +4216,7 @@ class FindManyAArgsFromM(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive1'
 
 
@@ -4133,6 +4227,7 @@ class FindManyAArgsFromMRecursive1(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive2'
 
 
@@ -4143,6 +4238,7 @@ class FindManyAArgsFromMRecursive2(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     
     
 
@@ -4181,6 +4277,7 @@ class FindManyBArgsFromM(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive1'
 
 
@@ -4191,6 +4288,7 @@ class FindManyBArgsFromMRecursive1(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive2'
 
 
@@ -4201,6 +4299,7 @@ class FindManyBArgsFromMRecursive2(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     
     
 
@@ -4239,6 +4338,7 @@ class FindManyCArgsFromM(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive1'
 
 
@@ -4249,6 +4349,7 @@ class FindManyCArgsFromMRecursive1(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive2'
 
 
@@ -4259,6 +4360,7 @@ class FindManyCArgsFromMRecursive2(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     
     
 
@@ -4297,6 +4399,7 @@ class FindManyDArgsFromM(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive1'
 
 
@@ -4307,6 +4410,7 @@ class FindManyDArgsFromMRecursive1(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive2'
 
 
@@ -4317,6 +4421,7 @@ class FindManyDArgsFromMRecursive2(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     
     
 
@@ -4355,6 +4460,7 @@ class FindManyEArgsFromM(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive1'
 
 
@@ -4365,6 +4471,7 @@ class FindManyEArgsFromMRecursive1(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive2'
 
 
@@ -4375,6 +4482,7 @@ class FindManyEArgsFromMRecursive2(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     
 
 
@@ -5001,6 +5109,7 @@ class FindManyPostArgsFromN(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive1'
 
 
@@ -5011,6 +5120,7 @@ class FindManyPostArgsFromNRecursive1(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive2'
 
 
@@ -5021,6 +5131,7 @@ class FindManyPostArgsFromNRecursive2(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     
     
 
@@ -5061,6 +5172,7 @@ class FindManyUserArgsFromN(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive1'
 
 
@@ -5071,6 +5183,7 @@ class FindManyUserArgsFromNRecursive1(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive2'
 
 
@@ -5081,6 +5194,7 @@ class FindManyUserArgsFromNRecursive2(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     
     
 
@@ -5121,6 +5235,7 @@ class FindManyMArgsFromN(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive1'
 
 
@@ -5131,6 +5246,7 @@ class FindManyMArgsFromNRecursive1(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive2'
 
 
@@ -5141,6 +5257,7 @@ class FindManyMArgsFromNRecursive2(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     
     
 
@@ -5181,6 +5298,7 @@ class FindManyNArgsFromN(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive1'
 
 
@@ -5191,6 +5309,7 @@ class FindManyNArgsFromNRecursive1(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive2'
 
 
@@ -5201,6 +5320,7 @@ class FindManyNArgsFromNRecursive2(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     
     
 
@@ -5241,6 +5361,7 @@ class FindManyOneOptionalArgsFromN(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive1'
 
 
@@ -5251,6 +5372,7 @@ class FindManyOneOptionalArgsFromNRecursive1(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive2'
 
 
@@ -5261,6 +5383,7 @@ class FindManyOneOptionalArgsFromNRecursive2(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     
     
 
@@ -5301,6 +5424,7 @@ class FindManyManyRequiredArgsFromN(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive1'
 
 
@@ -5311,6 +5435,7 @@ class FindManyManyRequiredArgsFromNRecursive1(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive2'
 
 
@@ -5321,6 +5446,7 @@ class FindManyManyRequiredArgsFromNRecursive2(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     
     
 
@@ -5359,6 +5485,7 @@ class FindManyListsArgsFromN(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive1'
 
 
@@ -5369,6 +5496,7 @@ class FindManyListsArgsFromNRecursive1(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive2'
 
 
@@ -5379,6 +5507,7 @@ class FindManyListsArgsFromNRecursive2(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     
     
 
@@ -5417,6 +5546,7 @@ class FindManyAArgsFromN(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive1'
 
 
@@ -5427,6 +5557,7 @@ class FindManyAArgsFromNRecursive1(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive2'
 
 
@@ -5437,6 +5568,7 @@ class FindManyAArgsFromNRecursive2(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     
     
 
@@ -5475,6 +5607,7 @@ class FindManyBArgsFromN(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive1'
 
 
@@ -5485,6 +5618,7 @@ class FindManyBArgsFromNRecursive1(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive2'
 
 
@@ -5495,6 +5629,7 @@ class FindManyBArgsFromNRecursive2(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     
     
 
@@ -5533,6 +5668,7 @@ class FindManyCArgsFromN(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive1'
 
 
@@ -5543,6 +5679,7 @@ class FindManyCArgsFromNRecursive1(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive2'
 
 
@@ -5553,6 +5690,7 @@ class FindManyCArgsFromNRecursive2(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     
     
 
@@ -5591,6 +5729,7 @@ class FindManyDArgsFromN(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive1'
 
 
@@ -5601,6 +5740,7 @@ class FindManyDArgsFromNRecursive1(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive2'
 
 
@@ -5611,6 +5751,7 @@ class FindManyDArgsFromNRecursive2(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     
     
 
@@ -5649,6 +5790,7 @@ class FindManyEArgsFromN(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive1'
 
 
@@ -5659,6 +5801,7 @@ class FindManyEArgsFromNRecursive1(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive2'
 
 
@@ -5669,6 +5812,7 @@ class FindManyEArgsFromNRecursive2(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     
 
 
@@ -6297,6 +6441,7 @@ class FindManyPostArgsFromOneOptional(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive1'
 
 
@@ -6307,6 +6452,7 @@ class FindManyPostArgsFromOneOptionalRecursive1(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive2'
 
 
@@ -6317,6 +6463,7 @@ class FindManyPostArgsFromOneOptionalRecursive2(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     
     
 
@@ -6357,6 +6504,7 @@ class FindManyUserArgsFromOneOptional(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive1'
 
 
@@ -6367,6 +6515,7 @@ class FindManyUserArgsFromOneOptionalRecursive1(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive2'
 
 
@@ -6377,6 +6526,7 @@ class FindManyUserArgsFromOneOptionalRecursive2(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     
     
 
@@ -6417,6 +6567,7 @@ class FindManyMArgsFromOneOptional(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive1'
 
 
@@ -6427,6 +6578,7 @@ class FindManyMArgsFromOneOptionalRecursive1(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive2'
 
 
@@ -6437,6 +6589,7 @@ class FindManyMArgsFromOneOptionalRecursive2(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     
     
 
@@ -6477,6 +6630,7 @@ class FindManyNArgsFromOneOptional(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive1'
 
 
@@ -6487,6 +6641,7 @@ class FindManyNArgsFromOneOptionalRecursive1(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive2'
 
 
@@ -6497,6 +6652,7 @@ class FindManyNArgsFromOneOptionalRecursive2(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     
     
 
@@ -6537,6 +6693,7 @@ class FindManyOneOptionalArgsFromOneOptional(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive1'
 
 
@@ -6547,6 +6704,7 @@ class FindManyOneOptionalArgsFromOneOptionalRecursive1(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive2'
 
 
@@ -6557,6 +6715,7 @@ class FindManyOneOptionalArgsFromOneOptionalRecursive2(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     
     
 
@@ -6597,6 +6756,7 @@ class FindManyManyRequiredArgsFromOneOptional(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive1'
 
 
@@ -6607,6 +6767,7 @@ class FindManyManyRequiredArgsFromOneOptionalRecursive1(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive2'
 
 
@@ -6617,6 +6778,7 @@ class FindManyManyRequiredArgsFromOneOptionalRecursive2(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     
     
 
@@ -6655,6 +6817,7 @@ class FindManyListsArgsFromOneOptional(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive1'
 
 
@@ -6665,6 +6828,7 @@ class FindManyListsArgsFromOneOptionalRecursive1(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive2'
 
 
@@ -6675,6 +6839,7 @@ class FindManyListsArgsFromOneOptionalRecursive2(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     
     
 
@@ -6713,6 +6878,7 @@ class FindManyAArgsFromOneOptional(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive1'
 
 
@@ -6723,6 +6889,7 @@ class FindManyAArgsFromOneOptionalRecursive1(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive2'
 
 
@@ -6733,6 +6900,7 @@ class FindManyAArgsFromOneOptionalRecursive2(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     
     
 
@@ -6771,6 +6939,7 @@ class FindManyBArgsFromOneOptional(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive1'
 
 
@@ -6781,6 +6950,7 @@ class FindManyBArgsFromOneOptionalRecursive1(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive2'
 
 
@@ -6791,6 +6961,7 @@ class FindManyBArgsFromOneOptionalRecursive2(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     
     
 
@@ -6829,6 +7000,7 @@ class FindManyCArgsFromOneOptional(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive1'
 
 
@@ -6839,6 +7011,7 @@ class FindManyCArgsFromOneOptionalRecursive1(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive2'
 
 
@@ -6849,6 +7022,7 @@ class FindManyCArgsFromOneOptionalRecursive2(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     
     
 
@@ -6887,6 +7061,7 @@ class FindManyDArgsFromOneOptional(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive1'
 
 
@@ -6897,6 +7072,7 @@ class FindManyDArgsFromOneOptionalRecursive1(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive2'
 
 
@@ -6907,6 +7083,7 @@ class FindManyDArgsFromOneOptionalRecursive2(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     
     
 
@@ -6945,6 +7122,7 @@ class FindManyEArgsFromOneOptional(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive1'
 
 
@@ -6955,6 +7133,7 @@ class FindManyEArgsFromOneOptionalRecursive1(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive2'
 
 
@@ -6965,6 +7144,7 @@ class FindManyEArgsFromOneOptionalRecursive2(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     
 
 
@@ -7576,6 +7756,7 @@ class FindManyPostArgsFromManyRequired(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive1'
 
 
@@ -7586,6 +7767,7 @@ class FindManyPostArgsFromManyRequiredRecursive1(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive2'
 
 
@@ -7596,6 +7778,7 @@ class FindManyPostArgsFromManyRequiredRecursive2(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     
     
 
@@ -7636,6 +7819,7 @@ class FindManyUserArgsFromManyRequired(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive1'
 
 
@@ -7646,6 +7830,7 @@ class FindManyUserArgsFromManyRequiredRecursive1(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive2'
 
 
@@ -7656,6 +7841,7 @@ class FindManyUserArgsFromManyRequiredRecursive2(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     
     
 
@@ -7696,6 +7882,7 @@ class FindManyMArgsFromManyRequired(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive1'
 
 
@@ -7706,6 +7893,7 @@ class FindManyMArgsFromManyRequiredRecursive1(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive2'
 
 
@@ -7716,6 +7904,7 @@ class FindManyMArgsFromManyRequiredRecursive2(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     
     
 
@@ -7756,6 +7945,7 @@ class FindManyNArgsFromManyRequired(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive1'
 
 
@@ -7766,6 +7956,7 @@ class FindManyNArgsFromManyRequiredRecursive1(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive2'
 
 
@@ -7776,6 +7967,7 @@ class FindManyNArgsFromManyRequiredRecursive2(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     
     
 
@@ -7816,6 +8008,7 @@ class FindManyOneOptionalArgsFromManyRequired(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive1'
 
 
@@ -7826,6 +8019,7 @@ class FindManyOneOptionalArgsFromManyRequiredRecursive1(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive2'
 
 
@@ -7836,6 +8030,7 @@ class FindManyOneOptionalArgsFromManyRequiredRecursive2(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     
     
 
@@ -7876,6 +8071,7 @@ class FindManyManyRequiredArgsFromManyRequired(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive1'
 
 
@@ -7886,6 +8082,7 @@ class FindManyManyRequiredArgsFromManyRequiredRecursive1(TypedDict, total=False)
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive2'
 
 
@@ -7896,6 +8093,7 @@ class FindManyManyRequiredArgsFromManyRequiredRecursive2(TypedDict, total=False)
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     
     
 
@@ -7934,6 +8132,7 @@ class FindManyListsArgsFromManyRequired(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive1'
 
 
@@ -7944,6 +8143,7 @@ class FindManyListsArgsFromManyRequiredRecursive1(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive2'
 
 
@@ -7954,6 +8154,7 @@ class FindManyListsArgsFromManyRequiredRecursive2(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     
     
 
@@ -7992,6 +8193,7 @@ class FindManyAArgsFromManyRequired(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive1'
 
 
@@ -8002,6 +8204,7 @@ class FindManyAArgsFromManyRequiredRecursive1(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive2'
 
 
@@ -8012,6 +8215,7 @@ class FindManyAArgsFromManyRequiredRecursive2(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     
     
 
@@ -8050,6 +8254,7 @@ class FindManyBArgsFromManyRequired(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive1'
 
 
@@ -8060,6 +8265,7 @@ class FindManyBArgsFromManyRequiredRecursive1(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive2'
 
 
@@ -8070,6 +8276,7 @@ class FindManyBArgsFromManyRequiredRecursive2(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     
     
 
@@ -8108,6 +8315,7 @@ class FindManyCArgsFromManyRequired(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive1'
 
 
@@ -8118,6 +8326,7 @@ class FindManyCArgsFromManyRequiredRecursive1(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive2'
 
 
@@ -8128,6 +8337,7 @@ class FindManyCArgsFromManyRequiredRecursive2(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     
     
 
@@ -8166,6 +8376,7 @@ class FindManyDArgsFromManyRequired(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive1'
 
 
@@ -8176,6 +8387,7 @@ class FindManyDArgsFromManyRequiredRecursive1(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive2'
 
 
@@ -8186,6 +8398,7 @@ class FindManyDArgsFromManyRequiredRecursive2(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     
     
 
@@ -8224,6 +8437,7 @@ class FindManyEArgsFromManyRequired(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive1'
 
 
@@ -8234,6 +8448,7 @@ class FindManyEArgsFromManyRequiredRecursive1(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive2'
 
 
@@ -8244,6 +8459,7 @@ class FindManyEArgsFromManyRequiredRecursive2(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     
 
 
@@ -8845,6 +9061,7 @@ class FindManyPostArgsFromLists(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive1'
 
 
@@ -8855,6 +9072,7 @@ class FindManyPostArgsFromListsRecursive1(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive2'
 
 
@@ -8865,6 +9083,7 @@ class FindManyPostArgsFromListsRecursive2(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     
     
 
@@ -8905,6 +9124,7 @@ class FindManyUserArgsFromLists(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive1'
 
 
@@ -8915,6 +9135,7 @@ class FindManyUserArgsFromListsRecursive1(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive2'
 
 
@@ -8925,6 +9146,7 @@ class FindManyUserArgsFromListsRecursive2(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     
     
 
@@ -8965,6 +9187,7 @@ class FindManyMArgsFromLists(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive1'
 
 
@@ -8975,6 +9198,7 @@ class FindManyMArgsFromListsRecursive1(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive2'
 
 
@@ -8985,6 +9209,7 @@ class FindManyMArgsFromListsRecursive2(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     
     
 
@@ -9025,6 +9250,7 @@ class FindManyNArgsFromLists(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive1'
 
 
@@ -9035,6 +9261,7 @@ class FindManyNArgsFromListsRecursive1(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive2'
 
 
@@ -9045,6 +9272,7 @@ class FindManyNArgsFromListsRecursive2(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     
     
 
@@ -9085,6 +9313,7 @@ class FindManyOneOptionalArgsFromLists(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive1'
 
 
@@ -9095,6 +9324,7 @@ class FindManyOneOptionalArgsFromListsRecursive1(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive2'
 
 
@@ -9105,6 +9335,7 @@ class FindManyOneOptionalArgsFromListsRecursive2(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     
     
 
@@ -9145,6 +9376,7 @@ class FindManyManyRequiredArgsFromLists(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive1'
 
 
@@ -9155,6 +9387,7 @@ class FindManyManyRequiredArgsFromListsRecursive1(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive2'
 
 
@@ -9165,6 +9398,7 @@ class FindManyManyRequiredArgsFromListsRecursive2(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     
     
 
@@ -9203,6 +9437,7 @@ class FindManyListsArgsFromLists(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive1'
 
 
@@ -9213,6 +9448,7 @@ class FindManyListsArgsFromListsRecursive1(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive2'
 
 
@@ -9223,6 +9459,7 @@ class FindManyListsArgsFromListsRecursive2(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     
     
 
@@ -9261,6 +9498,7 @@ class FindManyAArgsFromLists(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive1'
 
 
@@ -9271,6 +9509,7 @@ class FindManyAArgsFromListsRecursive1(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive2'
 
 
@@ -9281,6 +9520,7 @@ class FindManyAArgsFromListsRecursive2(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     
     
 
@@ -9319,6 +9559,7 @@ class FindManyBArgsFromLists(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive1'
 
 
@@ -9329,6 +9570,7 @@ class FindManyBArgsFromListsRecursive1(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive2'
 
 
@@ -9339,6 +9581,7 @@ class FindManyBArgsFromListsRecursive2(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     
     
 
@@ -9377,6 +9620,7 @@ class FindManyCArgsFromLists(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive1'
 
 
@@ -9387,6 +9631,7 @@ class FindManyCArgsFromListsRecursive1(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive2'
 
 
@@ -9397,6 +9642,7 @@ class FindManyCArgsFromListsRecursive2(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     
     
 
@@ -9435,6 +9681,7 @@ class FindManyDArgsFromLists(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive1'
 
 
@@ -9445,6 +9692,7 @@ class FindManyDArgsFromListsRecursive1(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive2'
 
 
@@ -9455,6 +9703,7 @@ class FindManyDArgsFromListsRecursive2(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     
     
 
@@ -9493,6 +9742,7 @@ class FindManyEArgsFromLists(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive1'
 
 
@@ -9503,6 +9753,7 @@ class FindManyEArgsFromListsRecursive1(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive2'
 
 
@@ -9513,6 +9764,7 @@ class FindManyEArgsFromListsRecursive2(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     
 
 
@@ -10079,6 +10331,7 @@ class FindManyPostArgsFromA(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive1'
 
 
@@ -10089,6 +10342,7 @@ class FindManyPostArgsFromARecursive1(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive2'
 
 
@@ -10099,6 +10353,7 @@ class FindManyPostArgsFromARecursive2(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     
     
 
@@ -10139,6 +10394,7 @@ class FindManyUserArgsFromA(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive1'
 
 
@@ -10149,6 +10405,7 @@ class FindManyUserArgsFromARecursive1(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive2'
 
 
@@ -10159,6 +10416,7 @@ class FindManyUserArgsFromARecursive2(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     
     
 
@@ -10199,6 +10457,7 @@ class FindManyMArgsFromA(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive1'
 
 
@@ -10209,6 +10468,7 @@ class FindManyMArgsFromARecursive1(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive2'
 
 
@@ -10219,6 +10479,7 @@ class FindManyMArgsFromARecursive2(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     
     
 
@@ -10259,6 +10520,7 @@ class FindManyNArgsFromA(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive1'
 
 
@@ -10269,6 +10531,7 @@ class FindManyNArgsFromARecursive1(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive2'
 
 
@@ -10279,6 +10542,7 @@ class FindManyNArgsFromARecursive2(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     
     
 
@@ -10319,6 +10583,7 @@ class FindManyOneOptionalArgsFromA(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive1'
 
 
@@ -10329,6 +10594,7 @@ class FindManyOneOptionalArgsFromARecursive1(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive2'
 
 
@@ -10339,6 +10605,7 @@ class FindManyOneOptionalArgsFromARecursive2(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     
     
 
@@ -10379,6 +10646,7 @@ class FindManyManyRequiredArgsFromA(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive1'
 
 
@@ -10389,6 +10657,7 @@ class FindManyManyRequiredArgsFromARecursive1(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive2'
 
 
@@ -10399,6 +10668,7 @@ class FindManyManyRequiredArgsFromARecursive2(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     
     
 
@@ -10437,6 +10707,7 @@ class FindManyListsArgsFromA(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive1'
 
 
@@ -10447,6 +10718,7 @@ class FindManyListsArgsFromARecursive1(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive2'
 
 
@@ -10457,6 +10729,7 @@ class FindManyListsArgsFromARecursive2(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     
     
 
@@ -10495,6 +10768,7 @@ class FindManyAArgsFromA(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive1'
 
 
@@ -10505,6 +10779,7 @@ class FindManyAArgsFromARecursive1(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive2'
 
 
@@ -10515,6 +10790,7 @@ class FindManyAArgsFromARecursive2(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     
     
 
@@ -10553,6 +10829,7 @@ class FindManyBArgsFromA(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive1'
 
 
@@ -10563,6 +10840,7 @@ class FindManyBArgsFromARecursive1(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive2'
 
 
@@ -10573,6 +10851,7 @@ class FindManyBArgsFromARecursive2(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     
     
 
@@ -10611,6 +10890,7 @@ class FindManyCArgsFromA(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive1'
 
 
@@ -10621,6 +10901,7 @@ class FindManyCArgsFromARecursive1(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive2'
 
 
@@ -10631,6 +10912,7 @@ class FindManyCArgsFromARecursive2(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     
     
 
@@ -10669,6 +10951,7 @@ class FindManyDArgsFromA(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive1'
 
 
@@ -10679,6 +10962,7 @@ class FindManyDArgsFromARecursive1(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive2'
 
 
@@ -10689,6 +10973,7 @@ class FindManyDArgsFromARecursive2(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     
     
 
@@ -10727,6 +11012,7 @@ class FindManyEArgsFromA(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive1'
 
 
@@ -10737,6 +11023,7 @@ class FindManyEArgsFromARecursive1(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive2'
 
 
@@ -10747,6 +11034,7 @@ class FindManyEArgsFromARecursive2(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     
 
 
@@ -11255,6 +11543,7 @@ class FindManyPostArgsFromB(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive1'
 
 
@@ -11265,6 +11554,7 @@ class FindManyPostArgsFromBRecursive1(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive2'
 
 
@@ -11275,6 +11565,7 @@ class FindManyPostArgsFromBRecursive2(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     
     
 
@@ -11315,6 +11606,7 @@ class FindManyUserArgsFromB(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive1'
 
 
@@ -11325,6 +11617,7 @@ class FindManyUserArgsFromBRecursive1(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive2'
 
 
@@ -11335,6 +11628,7 @@ class FindManyUserArgsFromBRecursive2(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     
     
 
@@ -11375,6 +11669,7 @@ class FindManyMArgsFromB(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive1'
 
 
@@ -11385,6 +11680,7 @@ class FindManyMArgsFromBRecursive1(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive2'
 
 
@@ -11395,6 +11691,7 @@ class FindManyMArgsFromBRecursive2(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     
     
 
@@ -11435,6 +11732,7 @@ class FindManyNArgsFromB(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive1'
 
 
@@ -11445,6 +11743,7 @@ class FindManyNArgsFromBRecursive1(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive2'
 
 
@@ -11455,6 +11754,7 @@ class FindManyNArgsFromBRecursive2(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     
     
 
@@ -11495,6 +11795,7 @@ class FindManyOneOptionalArgsFromB(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive1'
 
 
@@ -11505,6 +11806,7 @@ class FindManyOneOptionalArgsFromBRecursive1(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive2'
 
 
@@ -11515,6 +11817,7 @@ class FindManyOneOptionalArgsFromBRecursive2(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     
     
 
@@ -11555,6 +11858,7 @@ class FindManyManyRequiredArgsFromB(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive1'
 
 
@@ -11565,6 +11869,7 @@ class FindManyManyRequiredArgsFromBRecursive1(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive2'
 
 
@@ -11575,6 +11880,7 @@ class FindManyManyRequiredArgsFromBRecursive2(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     
     
 
@@ -11613,6 +11919,7 @@ class FindManyListsArgsFromB(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive1'
 
 
@@ -11623,6 +11930,7 @@ class FindManyListsArgsFromBRecursive1(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive2'
 
 
@@ -11633,6 +11941,7 @@ class FindManyListsArgsFromBRecursive2(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     
     
 
@@ -11671,6 +11980,7 @@ class FindManyAArgsFromB(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive1'
 
 
@@ -11681,6 +11991,7 @@ class FindManyAArgsFromBRecursive1(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive2'
 
 
@@ -11691,6 +12002,7 @@ class FindManyAArgsFromBRecursive2(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     
     
 
@@ -11729,6 +12041,7 @@ class FindManyBArgsFromB(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive1'
 
 
@@ -11739,6 +12052,7 @@ class FindManyBArgsFromBRecursive1(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive2'
 
 
@@ -11749,6 +12063,7 @@ class FindManyBArgsFromBRecursive2(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     
     
 
@@ -11787,6 +12102,7 @@ class FindManyCArgsFromB(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive1'
 
 
@@ -11797,6 +12113,7 @@ class FindManyCArgsFromBRecursive1(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive2'
 
 
@@ -11807,6 +12124,7 @@ class FindManyCArgsFromBRecursive2(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     
     
 
@@ -11845,6 +12163,7 @@ class FindManyDArgsFromB(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive1'
 
 
@@ -11855,6 +12174,7 @@ class FindManyDArgsFromBRecursive1(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive2'
 
 
@@ -11865,6 +12185,7 @@ class FindManyDArgsFromBRecursive2(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     
     
 
@@ -11903,6 +12224,7 @@ class FindManyEArgsFromB(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive1'
 
 
@@ -11913,6 +12235,7 @@ class FindManyEArgsFromBRecursive1(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive2'
 
 
@@ -11923,6 +12246,7 @@ class FindManyEArgsFromBRecursive2(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     
 
 
@@ -12365,6 +12689,7 @@ class FindManyPostArgsFromC(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive1'
 
 
@@ -12375,6 +12700,7 @@ class FindManyPostArgsFromCRecursive1(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive2'
 
 
@@ -12385,6 +12711,7 @@ class FindManyPostArgsFromCRecursive2(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     
     
 
@@ -12425,6 +12752,7 @@ class FindManyUserArgsFromC(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive1'
 
 
@@ -12435,6 +12763,7 @@ class FindManyUserArgsFromCRecursive1(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive2'
 
 
@@ -12445,6 +12774,7 @@ class FindManyUserArgsFromCRecursive2(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     
     
 
@@ -12485,6 +12815,7 @@ class FindManyMArgsFromC(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive1'
 
 
@@ -12495,6 +12826,7 @@ class FindManyMArgsFromCRecursive1(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive2'
 
 
@@ -12505,6 +12837,7 @@ class FindManyMArgsFromCRecursive2(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     
     
 
@@ -12545,6 +12878,7 @@ class FindManyNArgsFromC(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive1'
 
 
@@ -12555,6 +12889,7 @@ class FindManyNArgsFromCRecursive1(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive2'
 
 
@@ -12565,6 +12900,7 @@ class FindManyNArgsFromCRecursive2(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     
     
 
@@ -12605,6 +12941,7 @@ class FindManyOneOptionalArgsFromC(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive1'
 
 
@@ -12615,6 +12952,7 @@ class FindManyOneOptionalArgsFromCRecursive1(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive2'
 
 
@@ -12625,6 +12963,7 @@ class FindManyOneOptionalArgsFromCRecursive2(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     
     
 
@@ -12665,6 +13004,7 @@ class FindManyManyRequiredArgsFromC(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive1'
 
 
@@ -12675,6 +13015,7 @@ class FindManyManyRequiredArgsFromCRecursive1(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive2'
 
 
@@ -12685,6 +13026,7 @@ class FindManyManyRequiredArgsFromCRecursive2(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     
     
 
@@ -12723,6 +13065,7 @@ class FindManyListsArgsFromC(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive1'
 
 
@@ -12733,6 +13076,7 @@ class FindManyListsArgsFromCRecursive1(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive2'
 
 
@@ -12743,6 +13087,7 @@ class FindManyListsArgsFromCRecursive2(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     
     
 
@@ -12781,6 +13126,7 @@ class FindManyAArgsFromC(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive1'
 
 
@@ -12791,6 +13137,7 @@ class FindManyAArgsFromCRecursive1(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive2'
 
 
@@ -12801,6 +13148,7 @@ class FindManyAArgsFromCRecursive2(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     
     
 
@@ -12839,6 +13187,7 @@ class FindManyBArgsFromC(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive1'
 
 
@@ -12849,6 +13198,7 @@ class FindManyBArgsFromCRecursive1(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive2'
 
 
@@ -12859,6 +13209,7 @@ class FindManyBArgsFromCRecursive2(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     
     
 
@@ -12897,6 +13248,7 @@ class FindManyCArgsFromC(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive1'
 
 
@@ -12907,6 +13259,7 @@ class FindManyCArgsFromCRecursive1(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive2'
 
 
@@ -12917,6 +13270,7 @@ class FindManyCArgsFromCRecursive2(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     
     
 
@@ -12955,6 +13309,7 @@ class FindManyDArgsFromC(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive1'
 
 
@@ -12965,6 +13320,7 @@ class FindManyDArgsFromCRecursive1(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive2'
 
 
@@ -12975,6 +13331,7 @@ class FindManyDArgsFromCRecursive2(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     
     
 
@@ -13013,6 +13370,7 @@ class FindManyEArgsFromC(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive1'
 
 
@@ -13023,6 +13381,7 @@ class FindManyEArgsFromCRecursive1(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive2'
 
 
@@ -13033,6 +13392,7 @@ class FindManyEArgsFromCRecursive2(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     
 
 
@@ -13474,6 +13834,7 @@ class FindManyPostArgsFromD(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive1'
 
 
@@ -13484,6 +13845,7 @@ class FindManyPostArgsFromDRecursive1(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive2'
 
 
@@ -13494,6 +13856,7 @@ class FindManyPostArgsFromDRecursive2(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     
     
 
@@ -13534,6 +13897,7 @@ class FindManyUserArgsFromD(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive1'
 
 
@@ -13544,6 +13908,7 @@ class FindManyUserArgsFromDRecursive1(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive2'
 
 
@@ -13554,6 +13919,7 @@ class FindManyUserArgsFromDRecursive2(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     
     
 
@@ -13594,6 +13960,7 @@ class FindManyMArgsFromD(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive1'
 
 
@@ -13604,6 +13971,7 @@ class FindManyMArgsFromDRecursive1(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive2'
 
 
@@ -13614,6 +13982,7 @@ class FindManyMArgsFromDRecursive2(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     
     
 
@@ -13654,6 +14023,7 @@ class FindManyNArgsFromD(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive1'
 
 
@@ -13664,6 +14034,7 @@ class FindManyNArgsFromDRecursive1(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive2'
 
 
@@ -13674,6 +14045,7 @@ class FindManyNArgsFromDRecursive2(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     
     
 
@@ -13714,6 +14086,7 @@ class FindManyOneOptionalArgsFromD(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive1'
 
 
@@ -13724,6 +14097,7 @@ class FindManyOneOptionalArgsFromDRecursive1(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive2'
 
 
@@ -13734,6 +14108,7 @@ class FindManyOneOptionalArgsFromDRecursive2(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     
     
 
@@ -13774,6 +14149,7 @@ class FindManyManyRequiredArgsFromD(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive1'
 
 
@@ -13784,6 +14160,7 @@ class FindManyManyRequiredArgsFromDRecursive1(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive2'
 
 
@@ -13794,6 +14171,7 @@ class FindManyManyRequiredArgsFromDRecursive2(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     
     
 
@@ -13832,6 +14210,7 @@ class FindManyListsArgsFromD(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive1'
 
 
@@ -13842,6 +14221,7 @@ class FindManyListsArgsFromDRecursive1(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive2'
 
 
@@ -13852,6 +14232,7 @@ class FindManyListsArgsFromDRecursive2(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     
     
 
@@ -13890,6 +14271,7 @@ class FindManyAArgsFromD(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive1'
 
 
@@ -13900,6 +14282,7 @@ class FindManyAArgsFromDRecursive1(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive2'
 
 
@@ -13910,6 +14293,7 @@ class FindManyAArgsFromDRecursive2(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     
     
 
@@ -13948,6 +14332,7 @@ class FindManyBArgsFromD(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive1'
 
 
@@ -13958,6 +14343,7 @@ class FindManyBArgsFromDRecursive1(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive2'
 
 
@@ -13968,6 +14354,7 @@ class FindManyBArgsFromDRecursive2(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     
     
 
@@ -14006,6 +14393,7 @@ class FindManyCArgsFromD(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive1'
 
 
@@ -14016,6 +14404,7 @@ class FindManyCArgsFromDRecursive1(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive2'
 
 
@@ -14026,6 +14415,7 @@ class FindManyCArgsFromDRecursive2(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     
     
 
@@ -14064,6 +14454,7 @@ class FindManyDArgsFromD(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive1'
 
 
@@ -14074,6 +14465,7 @@ class FindManyDArgsFromDRecursive1(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive2'
 
 
@@ -14084,6 +14476,7 @@ class FindManyDArgsFromDRecursive2(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     
     
 
@@ -14122,6 +14515,7 @@ class FindManyEArgsFromD(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive1'
 
 
@@ -14132,6 +14526,7 @@ class FindManyEArgsFromDRecursive1(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive2'
 
 
@@ -14142,6 +14537,7 @@ class FindManyEArgsFromDRecursive2(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     
 
 
@@ -14557,6 +14953,7 @@ class FindManyPostArgsFromE(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive1'
 
 
@@ -14567,6 +14964,7 @@ class FindManyPostArgsFromERecursive1(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     include: 'PostIncludeFromPostRecursive2'
 
 
@@ -14577,6 +14975,7 @@ class FindManyPostArgsFromERecursive2(TypedDict, total=False):
     order_by: Union['PostOrderByInput', List['PostOrderByInput']]
     where: 'PostWhereInput'
     cursor: 'PostWhereUniqueInput'
+    distinct: List['PostScalarFieldKeys']
     
     
 
@@ -14617,6 +15016,7 @@ class FindManyUserArgsFromE(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive1'
 
 
@@ -14627,6 +15027,7 @@ class FindManyUserArgsFromERecursive1(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     include: 'UserIncludeFromUserRecursive2'
 
 
@@ -14637,6 +15038,7 @@ class FindManyUserArgsFromERecursive2(TypedDict, total=False):
     order_by: Union['UserOrderByInput', List['UserOrderByInput']]
     where: 'UserWhereInput'
     cursor: 'UserWhereUniqueInput'
+    distinct: List['UserScalarFieldKeys']
     
     
 
@@ -14677,6 +15079,7 @@ class FindManyMArgsFromE(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive1'
 
 
@@ -14687,6 +15090,7 @@ class FindManyMArgsFromERecursive1(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     include: 'MIncludeFromMRecursive2'
 
 
@@ -14697,6 +15101,7 @@ class FindManyMArgsFromERecursive2(TypedDict, total=False):
     order_by: Union['MOrderByInput', List['MOrderByInput']]
     where: 'MWhereInput'
     cursor: 'MWhereUniqueInput'
+    distinct: List['MScalarFieldKeys']
     
     
 
@@ -14737,6 +15142,7 @@ class FindManyNArgsFromE(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive1'
 
 
@@ -14747,6 +15153,7 @@ class FindManyNArgsFromERecursive1(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     include: 'NIncludeFromNRecursive2'
 
 
@@ -14757,6 +15164,7 @@ class FindManyNArgsFromERecursive2(TypedDict, total=False):
     order_by: Union['NOrderByInput', List['NOrderByInput']]
     where: 'NWhereInput'
     cursor: 'NWhereUniqueInput'
+    distinct: List['NScalarFieldKeys']
     
     
 
@@ -14797,6 +15205,7 @@ class FindManyOneOptionalArgsFromE(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive1'
 
 
@@ -14807,6 +15216,7 @@ class FindManyOneOptionalArgsFromERecursive1(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     include: 'OneOptionalIncludeFromOneOptionalRecursive2'
 
 
@@ -14817,6 +15227,7 @@ class FindManyOneOptionalArgsFromERecursive2(TypedDict, total=False):
     order_by: Union['OneOptionalOrderByInput', List['OneOptionalOrderByInput']]
     where: 'OneOptionalWhereInput'
     cursor: 'OneOptionalWhereUniqueInput'
+    distinct: List['OneOptionalScalarFieldKeys']
     
     
 
@@ -14857,6 +15268,7 @@ class FindManyManyRequiredArgsFromE(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive1'
 
 
@@ -14867,6 +15279,7 @@ class FindManyManyRequiredArgsFromERecursive1(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     include: 'ManyRequiredIncludeFromManyRequiredRecursive2'
 
 
@@ -14877,6 +15290,7 @@ class FindManyManyRequiredArgsFromERecursive2(TypedDict, total=False):
     order_by: Union['ManyRequiredOrderByInput', List['ManyRequiredOrderByInput']]
     where: 'ManyRequiredWhereInput'
     cursor: 'ManyRequiredWhereUniqueInput'
+    distinct: List['ManyRequiredScalarFieldKeys']
     
     
 
@@ -14915,6 +15329,7 @@ class FindManyListsArgsFromE(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive1'
 
 
@@ -14925,6 +15340,7 @@ class FindManyListsArgsFromERecursive1(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     include: 'ListsIncludeFromListsRecursive2'
 
 
@@ -14935,6 +15351,7 @@ class FindManyListsArgsFromERecursive2(TypedDict, total=False):
     order_by: Union['ListsOrderByInput', List['ListsOrderByInput']]
     where: 'ListsWhereInput'
     cursor: 'ListsWhereUniqueInput'
+    distinct: List['ListsScalarFieldKeys']
     
     
 
@@ -14973,6 +15390,7 @@ class FindManyAArgsFromE(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive1'
 
 
@@ -14983,6 +15401,7 @@ class FindManyAArgsFromERecursive1(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     include: 'AIncludeFromARecursive2'
 
 
@@ -14993,6 +15412,7 @@ class FindManyAArgsFromERecursive2(TypedDict, total=False):
     order_by: Union['AOrderByInput', List['AOrderByInput']]
     where: 'AWhereInput'
     cursor: 'AWhereUniqueInput'
+    distinct: List['AScalarFieldKeys']
     
     
 
@@ -15031,6 +15451,7 @@ class FindManyBArgsFromE(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive1'
 
 
@@ -15041,6 +15462,7 @@ class FindManyBArgsFromERecursive1(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     include: 'BIncludeFromBRecursive2'
 
 
@@ -15051,6 +15473,7 @@ class FindManyBArgsFromERecursive2(TypedDict, total=False):
     order_by: Union['BOrderByInput', List['BOrderByInput']]
     where: 'BWhereInput'
     cursor: 'BWhereUniqueInput'
+    distinct: List['BScalarFieldKeys']
     
     
 
@@ -15089,6 +15512,7 @@ class FindManyCArgsFromE(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive1'
 
 
@@ -15099,6 +15523,7 @@ class FindManyCArgsFromERecursive1(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     include: 'CIncludeFromCRecursive2'
 
 
@@ -15109,6 +15534,7 @@ class FindManyCArgsFromERecursive2(TypedDict, total=False):
     order_by: Union['COrderByInput', List['COrderByInput']]
     where: 'CWhereInput'
     cursor: 'CWhereUniqueInput'
+    distinct: List['CScalarFieldKeys']
     
     
 
@@ -15147,6 +15573,7 @@ class FindManyDArgsFromE(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive1'
 
 
@@ -15157,6 +15584,7 @@ class FindManyDArgsFromERecursive1(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     include: 'DIncludeFromDRecursive2'
 
 
@@ -15167,6 +15595,7 @@ class FindManyDArgsFromERecursive2(TypedDict, total=False):
     order_by: Union['DOrderByInput', List['DOrderByInput']]
     where: 'DWhereInput'
     cursor: 'DWhereUniqueInput'
+    distinct: List['DScalarFieldKeys']
     
     
 
@@ -15205,6 +15634,7 @@ class FindManyEArgsFromE(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive1'
 
 
@@ -15215,6 +15645,7 @@ class FindManyEArgsFromERecursive1(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     include: 'EIncludeFromERecursive2'
 
 
@@ -15225,6 +15656,7 @@ class FindManyEArgsFromERecursive2(TypedDict, total=False):
     order_by: Union['EOrderByInput', List['EOrderByInput']]
     where: 'EWhereInput'
     cursor: 'EWhereUniqueInput'
+    distinct: List['EScalarFieldKeys']
     
 
 


### PR DESCRIPTION
## Change Summary

This PR adds support for the `distinct` filter to `find_many()` and `find_first()` queries.

closes #654

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
