### PR TITLE
feat(ci): test mypy typesafety

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,10 +104,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
-      - name: Run tests
-        # TODO: run mypy too
+      - name: Run Pyright tests
         run: |
           nox -s typesafety-pyright
+
+      - name: Run mypy tests
+        run: |
+          nox -s typesafety-mypy
+
 
   lint:
     name: lint

--- a/typesafety/mypy/test_mypy.yml
+++ b/typesafety/mypy/test_mypy.yml
@@ -125,8 +125,8 @@
       reveal_type(user.profile)  # N: Revealed type is "Union[prisma.models.Profile, None]"
 
       if user.posts is not None:
-        reveal_type(user.posts)  # N: Revealed type is "builtins.list[prisma.models.Post, prisma.models.Post]"
-        reveal_type(user.posts[0].categories)  # N: Revealed type is "builtins.list[prisma.models.Category]"
+        reveal_type(user.posts)  # N: Revealed type is "builtins.list[prisma.models.Post]"
+        reveal_type(user.posts[0].categories)  # N: Revealed type is "Union[builtins.list[prisma.models.Category], None]"
 
     async def test_explicit_include_type(client: Prisma) -> None:
       user = await client.user.find_unique(
@@ -134,9 +134,7 @@
         include=UserInclude(posts=True)
       )
       assert user is not None
-
-      # TODO: why is the type duplicated?
-      reveal_type(user.posts)  # N: Revealed type is "Union[builtins.list[prisma.models.Post, prisma.models.Post], None]"
+      reveal_type(user.posts)  # N: Revealed type is "Union[builtins.list[prisma.models.Post], None]"
 
     async def test_correct_return_model_type(client: Prisma) -> None:
       query = '''
@@ -165,7 +163,7 @@
         WHERE title = "hi"
       '''
       posts = await client.query_raw(query)
-      reveal_type(posts)  # N: Revealed type is "Any"
+      reveal_type(posts)  # N: Revealed type is "builtins.list[builtins.dict[builtins.str, Any]]"
 
     async def test_bad_model_argument(client: Prisma) -> None:
       query = '''
@@ -212,7 +210,8 @@
       )
 
     def test_validator() -> None:
-      reveal_type(validate(PostCreateInput, {}))  # N: Revealed type is "prisma.types.PostCreateInput"
+      validated = validate(PostCreateInput, {})
+      reveal_type(validated.get('id'))  # N: Revealed type is "Union[builtins.str, None]"
 
     async def test_count_select(client: Prisma) -> None:
       count = await client.post.count()

--- a/typesafety/mypy/test_mypy.yml
+++ b/typesafety/mypy/test_mypy.yml
@@ -71,10 +71,10 @@
         reveal_type(post.title.lower())  # N: Revealed type is "builtins.str"
         oops = post.oops  # E: "Post" has no attribute "oops"  [attr-defined]
 
-    async def test_include_removes_optional(client: Prisma) -> None:
+    async def test_include(client: Prisma) -> None:
       user = await client.user.find_unique({'id': '1'}, include={'posts': True})
       if user is not None:
-        reveal_type(user.posts)  # N: Revealed type is "builtins.list[prisma.models.Post]"
+        reveal_type(user.posts)  # N: Revealed type is "Union[builtins.list[prisma.models.Post], None]"
         if len(user.posts) == 0:
           print('user does not have any posts!')
         else:
@@ -84,21 +84,19 @@
 
       user = await client.user.find_unique(include={'posts': True}, where={'id': '1'})
       if user is not None:
-        reveal_type(user.posts)  # N: Revealed type is "builtins.list[prisma.models.Post]"
+        reveal_type(user.posts)  # N: Revealed type is "Union[None, builtins.list[prisma.models.Post]]"
 
       user = await client.user.find_unique({'id': '1'}, {'posts': True})
       if user is not None:
-        reveal_type(user.posts)  # N: Revealed type is "builtins.list[prisma.models.Post]"
+        reveal_type(user.posts)  # N: Revealed type is "Union[None, builtins.list[prisma.models.Post]]"
 
       user = await client.user.find_unique({'id': '1'}, dict(posts=True))
       if user is not None:
-        reveal_type(user.posts)  # N: Revealed type is "builtins.list[prisma.models.Post]"
+        reveal_type(user.posts)  # N: Revealed type is "Union[None, builtins.list[prisma.models.Post]]"
 
       user = await client.user.find_unique({'id': '1'}, include={'posts': True, 'profile': True})
       if user is not None:
-        reveal_type(user.posts)  # N: Revealed type is "builtins.list[prisma.models.Post]"
-
-        # profile is still optional as it is optional on a database level
+        reveal_type(user.posts)  # N: Revealed type is "Union[None, builtins.list[prisma.models.Post]]"
         reveal_type(user.profile)  # N: Revealed type is "Union[prisma.models.Profile, None]"
 
       user = await client.user.find_unique({'id': '1'}, include={'posts': False})
@@ -126,9 +124,9 @@
       assert user is not None
       reveal_type(user.profile)  # N: Revealed type is "Union[prisma.models.Profile, None]"
 
-      # TODO: models.Post shouldn't be duplicated
-      reveal_type(user.posts)  # N: Revealed type is "builtins.list[prisma.models.Post, prisma.models.Post]"
-      reveal_type(user.posts[0].categories)  # N: Revealed type is "builtins.list[prisma.models.Category]"
+      if user.posts is not None:
+        reveal_type(user.posts)  # N: Revealed type is "builtins.list[prisma.models.Post, prisma.models.Post]"
+        reveal_type(user.posts[0].categories)  # N: Revealed type is "builtins.list[prisma.models.Category]"
 
     async def test_explicit_include_type(client: Prisma) -> None:
       user = await client.user.find_unique(
@@ -138,7 +136,7 @@
       assert user is not None
 
       # TODO: why is the type duplicated?
-      reveal_type(user.posts)  # N: Revealed type is "builtins.list[prisma.models.Post, prisma.models.Post]"
+      reveal_type(user.posts)  # N: Revealed type is "Union[builtins.list[prisma.models.Post, prisma.models.Post], None]"
 
     async def test_correct_return_model_type(client: Prisma) -> None:
       query = '''

--- a/typesafety/mypy/test_mypy.yml
+++ b/typesafety/mypy/test_mypy.yml
@@ -84,19 +84,19 @@
 
       user = await client.user.find_unique(include={'posts': True}, where={'id': '1'})
       if user is not None:
-        reveal_type(user.posts)  # N: Revealed type is "Union[None, builtins.list[prisma.models.Post]]"
+        reveal_type(user.posts)  # N: Revealed type is "Union[builtins.list[prisma.models.Post], None]"
 
       user = await client.user.find_unique({'id': '1'}, {'posts': True})
       if user is not None:
-        reveal_type(user.posts)  # N: Revealed type is "Union[None, builtins.list[prisma.models.Post]]"
+        reveal_type(user.posts)  # N: Revealed type is "Union[builtins.list[prisma.models.Post], None]"
 
       user = await client.user.find_unique({'id': '1'}, dict(posts=True))
       if user is not None:
-        reveal_type(user.posts)  # N: Revealed type is "Union[None, builtins.list[prisma.models.Post]]"
+        reveal_type(user.posts)  # N: Revealed type is "Union[builtins.list[prisma.models.Post], None]"
 
       user = await client.user.find_unique({'id': '1'}, include={'posts': True, 'profile': True})
       if user is not None:
-        reveal_type(user.posts)  # N: Revealed type is "Union[None, builtins.list[prisma.models.Post]]"
+        reveal_type(user.posts)  # N: Revealed type is "Union[builtins.list[prisma.models.Post], None]"
         reveal_type(user.profile)  # N: Revealed type is "Union[prisma.models.Profile, None]"
 
       user = await client.user.find_unique({'id': '1'}, include={'posts': False})

--- a/typesafety/mypy/test_mypy.yml
+++ b/typesafety/mypy/test_mypy.yml
@@ -75,7 +75,7 @@
       user = await client.user.find_unique({'id': '1'}, include={'posts': True})
       if user is not None:
         reveal_type(user.posts)  # N: Revealed type is "Union[builtins.list[prisma.models.Post], None]"
-        if len(user.posts) == 0:
+        if user.posts is not None and len(user.posts) == 0:
           print('user does not have any posts!')
         else:
           print('user has at least one post')


### PR DESCRIPTION
## Change Summary

Re-enable the Mypy typesafety tests in CI.

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
