### PR TITLE
feat(models): remove non-recursive types subclass restriction

### DIFF
--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -18,47 +18,6 @@ to use recursive types.
 You can catch all errors while type checking by using [pyright](https://github.com/microsoft/pyright)
 and [configuring](config.md#recursive) prisma to use recursive types.
 
-### Querying Using Model-based Access
-
-Prisma Client Python supports querying directly from model classes, however, internally typing this feature to support subclassing with generics causes mypy to be *incredibly* slow, it takes upwards of 35 minutes to type check the Prisma Client Python codebase on CI and upwards of 2 hours locally.
-
-This kind of performance is not acceptable and as such, this typing has been disabled by default (switching to use recursive types will re-enable subclassing).
-
-The downside of this is that static type checkers will not correctly recognise subclassed actions, for example:
-
-```py
-from prisma.models import User
-
-class MyUser(User):
-    pass
-
-# static type checkers will think that `user` is an instance of `User`
-# when it is actually an instance of `MyUser` at runtime
-user = MyUser.prisma().create(
-    data={
-        'name': 'Robert',
-    },
-)
-```
-
-To combat this surprising behaviour, subclassing a prisma model will raise a warning at runtime.
-
-```py
-from prisma.models import User
-
-class MyUser(User):  # warning: UnsupportedSubclassWarning
-    pass
-```
-
-Warnings are raised using Pythons standard library [warnings](https://docs.python.org/3/library/warnings.html) module and can be disabled using [filters](https://docs.python.org/3/library/warnings.html#temporarily-suppressing-warnings) or by passing `warn_subclass=False` in the class definition, for example:
-
-```py
-from prisma.models import User
-
-class MyUser(User, warn_subclass=False):
-    pass
-```
-
 ### Filtering by Relational Fields
 
 Prisma supports searching for records based off of relational record values.

--- a/src/prisma/errors.py
+++ b/src/prisma/errors.py
@@ -150,5 +150,6 @@ class PrismaWarning(Warning):
     pass
 
 
+# Note: this is currently unused but not worth removing
 class UnsupportedSubclassWarning(PrismaWarning):
     pass

--- a/src/prisma/generator/templates/actions.py.jinja
+++ b/src/prisma/generator/templates/actions.py.jinja
@@ -36,13 +36,8 @@ if TYPE_CHECKING:
 {% set RawModelType = "prisma.models.%s" % model.name %}
 {% set include_doc = 'Specifies which relations should be loaded on the returned %s model' % model.name %}
 
-{% if recursive_types %}
 {% set ModelType = 'BaseModelT' %}
 class {{ model.name }}Actions(Generic[BaseModelT]):
-{% else %}
-{% set ModelType = "'models.%s'" % model.name %}
-class {{ model.name }}Actions:
-{% endif %}
     __slots__ = (
         '_client',
         '_model',

--- a/src/prisma/generator/templates/client.py.jinja
+++ b/src/prisma/generator/templates/client.py.jinja
@@ -114,11 +114,7 @@ def get_client() -> 'Prisma':
 
 class Prisma:
     {% for model in dmmf.datamodel.models %}
-    {% if recursive_types %}
     {{ model.name.lower() }}: 'actions.{{ model.name }}Actions[models.{{ model.name }}]'
-    {% else %}
-    {{ model.name.lower() }}: 'actions.{{ model.name }}Actions'
-    {% endif %}
     {% endfor %}
 
     __slots__ = (
@@ -144,11 +140,7 @@ class Prisma:
         http: Optional[HttpConfig] = None,
     ) -> None:
         {% for model in dmmf.datamodel.models %}
-        {% if recursive_types %}
         self.{{ model.name.lower() }} = actions.{{ model.name }}Actions[models.{{ model.name }}](self, models.{{ model.name }})
-        {% else %}
-        self.{{ model.name.lower() }} = actions.{{ model.name }}Actions(self, models.{{ model.name }})
-        {% endif %}
         {% endfor %}
         self.__engine: Optional[AbstractEngine] = None
         self._active_provider = '{{ active_provider }}'

--- a/src/prisma/generator/templates/models.py.jinja
+++ b/src/prisma/generator/templates/models.py.jinja
@@ -27,43 +27,6 @@ class Config(BaseConfig):
 log: logging.Logger = logging.getLogger(__name__)
 _created_partial_types: Set[str] = set()
 
-{% if not recursive_types %}
-# packages that implicitly subclass models
-# this should not raise any warnings as users
-# of these packages cannot do anything about it
-_implicit_subclass_packages: Set[str] = {
-    'fastapi',
-}
-
-
-def _maybe_warn_subclassing(new_model: str, base_model: str, *, stacklevel: int = 3) -> None:
-    # at least 3 frames are guaranteed to exist if we are being called from __init_subclass__
-    # stack: 1 = __init_subclass__, 2 = abc, 3 = <caller>
-    try:
-        frame = inspect.stack()[stacklevel]
-        module = inspect.getmodule(frame[0])
-        if module is not None:
-            name, *_ = module.__name__.split('.')
-            if name in _implicit_subclass_packages:
-                return
-    except Exception as exc:
-        # disabling subclass warnings depending on the caller module is not a mission critical
-        # feature, users can disable these warnings themselves
-        # https://github.com/RobertCraigie/prisma-client-py/issues/278#issuecomment-1031421561
-        log.debug('Ignoring exception encountered during stack inspection check: %s', str(exc))
-
-    message = (
-        'Subclassing models while using pseudo-recursive types may cause unexpected '
-        'errors when static type checking;\n'
-        'You can disable this warning by generating fully recursive types: \n'
-        'https://prisma-client-py.readthedocs.io/en/stable/reference/config/#recursive\n'
-        'or if that is not possible you can pass warn_subclass=False e.g.\n'
-        f'  class {new_model}(prisma.models.{base_model}, warn_subclass=False):'
-    )
-    warnings.warn(message, errors.UnsupportedSubclassWarning, stacklevel=4)
-{% endif %}
-
-
 {% for model in dmmf.datamodel.models %}
 class {{ model.name }}(BaseModel):
     {% if model.documentation is none %}
@@ -87,29 +50,27 @@ class {{ model.name }}(BaseModel):
 
     Config = Config
 
-    {% if recursive_types %}
     @classmethod
     def prisma(cls: Type[BaseModelT]) -> 'actions.{{ model.name }}Actions[BaseModelT]':
         from .client import get_client
 
         return actions.{{ model.name }}Actions[BaseModelT](get_client(), cls)
-    {% else %}
-    @classmethod
-    def prisma(cls) -> 'actions.{{ model.name }}Actions':
-        from .client import get_client
 
-        return actions.{{ model.name }}Actions(get_client(), cls)
-
+    {% if not recursive_types %}
     # take *args and **kwargs so that other metaclasses can define arguments
     def __init_subclass__(
         cls,
         *args: Any,
-        warn_subclass: bool = True,
+        warn_subclass: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         super().__init_subclass__()
-        if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, '{{ model.name }}', stacklevel=3)
+        if warn_subclass is not None:
+            warnings.warn(
+                'The `warn_subclass` argument is deprecated as it is no longer necessary and will be removed in the next release',
+                DeprecationWarning,
+                stacklevel=3,
+            )
     {% endif %}
 
     {% if model.required_array_fields|list|length > 0 %}

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[actions.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[actions.py].raw
@@ -47,13 +47,13 @@ if TYPE_CHECKING:
     from .client import Client
 
 
-class PostActions:
+class PostActions(Generic[BaseModelT]):
     __slots__ = (
         '_client',
         '_model',
     )
 
-    def __init__(self, client: 'Client', model: Type['models.Post']) -> None:
+    def __init__(self, client: 'Client', model: Type[BaseModelT]) -> None:
         self._client = client
         self._model = model
 
@@ -61,7 +61,7 @@ class PostActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> List['models.Post']:
+    ) -> List[BaseModelT]:
         """Execute a raw SQL query
 
         Parameters
@@ -99,7 +99,7 @@ class PostActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> Optional['models.Post']:
+    ) -> Optional[BaseModelT]:
         """Execute a raw SQL query, returning the first result
 
         Parameters
@@ -139,7 +139,7 @@ class PostActions:
         self,
         data: types.PostCreateInput,
         include: Optional[types.PostInclude] = None
-    ) -> 'models.Post':
+    ) -> BaseModelT:
         """Create a new Post record.
 
         Parameters
@@ -257,7 +257,7 @@ class PostActions:
         self,
         where: types.PostWhereUniqueInput,
         include: Optional[types.PostInclude] = None
-    ) -> Optional['models.Post']:
+    ) -> Optional[BaseModelT]:
         """Delete a single Post record.
 
         Parameters
@@ -310,7 +310,7 @@ class PostActions:
         self,
         where: types.PostWhereUniqueInput,
         include: Optional[types.PostInclude] = None
-    ) -> Optional['models.Post']:
+    ) -> Optional[BaseModelT]:
         """Find a unique Post record.
 
         Parameters
@@ -367,7 +367,7 @@ class PostActions:
         include: Optional[types.PostInclude] = None,
         order: Optional[Union[types.PostOrderByInput, List[types.PostOrderByInput]]] = None,
         distinct: Optional[List[types.PostScalarFieldKeys]] = None,
-    ) -> List['models.Post']:
+    ) -> List[BaseModelT]:
         """Find multiple Post records.
 
         An empty list is returned if no records could be found.
@@ -438,7 +438,7 @@ class PostActions:
         include: Optional[types.PostInclude] = None,
         order: Optional[Union[types.PostOrderByInput, List[types.PostOrderByInput]]] = None,
         distinct: Optional[List[types.PostScalarFieldKeys]] = None,
-    ) -> Optional['models.Post']:
+    ) -> Optional[BaseModelT]:
         """Find a single Post record.
 
         Parameters
@@ -503,7 +503,7 @@ class PostActions:
         data: types.PostUpdateInput,
         where: types.PostWhereUniqueInput,
         include: Optional[types.PostInclude] = None
-    ) -> Optional['models.Post']:
+    ) -> Optional[BaseModelT]:
         """Update a single Post record.
 
         Parameters
@@ -561,7 +561,7 @@ class PostActions:
         where: types.PostWhereUniqueInput,
         data: types.PostUpsertInput,
         include: Optional[types.PostInclude] = None,
-    ) -> 'models.Post':
+    ) -> BaseModelT:
         """Updates an existing record or create a new one
 
         Parameters
@@ -974,13 +974,13 @@ class PostActions:
         return resp['data']['result']  # type: ignore[no-any-return]
 
 
-class UserActions:
+class UserActions(Generic[BaseModelT]):
     __slots__ = (
         '_client',
         '_model',
     )
 
-    def __init__(self, client: 'Client', model: Type['models.User']) -> None:
+    def __init__(self, client: 'Client', model: Type[BaseModelT]) -> None:
         self._client = client
         self._model = model
 
@@ -988,7 +988,7 @@ class UserActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> List['models.User']:
+    ) -> List[BaseModelT]:
         """Execute a raw SQL query
 
         Parameters
@@ -1026,7 +1026,7 @@ class UserActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> Optional['models.User']:
+    ) -> Optional[BaseModelT]:
         """Execute a raw SQL query, returning the first result
 
         Parameters
@@ -1066,7 +1066,7 @@ class UserActions:
         self,
         data: types.UserCreateInput,
         include: Optional[types.UserInclude] = None
-    ) -> 'models.User':
+    ) -> BaseModelT:
         """Create a new User record.
 
         Parameters
@@ -1196,7 +1196,7 @@ class UserActions:
         self,
         where: types.UserWhereUniqueInput,
         include: Optional[types.UserInclude] = None
-    ) -> Optional['models.User']:
+    ) -> Optional[BaseModelT]:
         """Delete a single User record.
 
         Parameters
@@ -1249,7 +1249,7 @@ class UserActions:
         self,
         where: types.UserWhereUniqueInput,
         include: Optional[types.UserInclude] = None
-    ) -> Optional['models.User']:
+    ) -> Optional[BaseModelT]:
         """Find a unique User record.
 
         Parameters
@@ -1306,7 +1306,7 @@ class UserActions:
         include: Optional[types.UserInclude] = None,
         order: Optional[Union[types.UserOrderByInput, List[types.UserOrderByInput]]] = None,
         distinct: Optional[List[types.UserScalarFieldKeys]] = None,
-    ) -> List['models.User']:
+    ) -> List[BaseModelT]:
         """Find multiple User records.
 
         An empty list is returned if no records could be found.
@@ -1377,7 +1377,7 @@ class UserActions:
         include: Optional[types.UserInclude] = None,
         order: Optional[Union[types.UserOrderByInput, List[types.UserOrderByInput]]] = None,
         distinct: Optional[List[types.UserScalarFieldKeys]] = None,
-    ) -> Optional['models.User']:
+    ) -> Optional[BaseModelT]:
         """Find a single User record.
 
         Parameters
@@ -1442,7 +1442,7 @@ class UserActions:
         data: types.UserUpdateInput,
         where: types.UserWhereUniqueInput,
         include: Optional[types.UserInclude] = None
-    ) -> Optional['models.User']:
+    ) -> Optional[BaseModelT]:
         """Update a single User record.
 
         Parameters
@@ -1500,7 +1500,7 @@ class UserActions:
         where: types.UserWhereUniqueInput,
         data: types.UserUpsertInput,
         include: Optional[types.UserInclude] = None,
-    ) -> 'models.User':
+    ) -> BaseModelT:
         """Updates an existing record or create a new one
 
         Parameters
@@ -1921,13 +1921,13 @@ class UserActions:
         return resp['data']['result']  # type: ignore[no-any-return]
 
 
-class MActions:
+class MActions(Generic[BaseModelT]):
     __slots__ = (
         '_client',
         '_model',
     )
 
-    def __init__(self, client: 'Client', model: Type['models.M']) -> None:
+    def __init__(self, client: 'Client', model: Type[BaseModelT]) -> None:
         self._client = client
         self._model = model
 
@@ -1935,7 +1935,7 @@ class MActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> List['models.M']:
+    ) -> List[BaseModelT]:
         """Execute a raw SQL query
 
         Parameters
@@ -1973,7 +1973,7 @@ class MActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> Optional['models.M']:
+    ) -> Optional[BaseModelT]:
         """Execute a raw SQL query, returning the first result
 
         Parameters
@@ -2013,7 +2013,7 @@ class MActions:
         self,
         data: types.MCreateInput,
         include: Optional[types.MInclude] = None
-    ) -> 'models.M':
+    ) -> BaseModelT:
         """Create a new M record.
 
         Parameters
@@ -2140,7 +2140,7 @@ class MActions:
         self,
         where: types.MWhereUniqueInput,
         include: Optional[types.MInclude] = None
-    ) -> Optional['models.M']:
+    ) -> Optional[BaseModelT]:
         """Delete a single M record.
 
         Parameters
@@ -2193,7 +2193,7 @@ class MActions:
         self,
         where: types.MWhereUniqueInput,
         include: Optional[types.MInclude] = None
-    ) -> Optional['models.M']:
+    ) -> Optional[BaseModelT]:
         """Find a unique M record.
 
         Parameters
@@ -2250,7 +2250,7 @@ class MActions:
         include: Optional[types.MInclude] = None,
         order: Optional[Union[types.MOrderByInput, List[types.MOrderByInput]]] = None,
         distinct: Optional[List[types.MScalarFieldKeys]] = None,
-    ) -> List['models.M']:
+    ) -> List[BaseModelT]:
         """Find multiple M records.
 
         An empty list is returned if no records could be found.
@@ -2321,7 +2321,7 @@ class MActions:
         include: Optional[types.MInclude] = None,
         order: Optional[Union[types.MOrderByInput, List[types.MOrderByInput]]] = None,
         distinct: Optional[List[types.MScalarFieldKeys]] = None,
-    ) -> Optional['models.M']:
+    ) -> Optional[BaseModelT]:
         """Find a single M record.
 
         Parameters
@@ -2386,7 +2386,7 @@ class MActions:
         data: types.MUpdateInput,
         where: types.MWhereUniqueInput,
         include: Optional[types.MInclude] = None
-    ) -> Optional['models.M']:
+    ) -> Optional[BaseModelT]:
         """Update a single M record.
 
         Parameters
@@ -2444,7 +2444,7 @@ class MActions:
         where: types.MWhereUniqueInput,
         data: types.MUpsertInput,
         include: Optional[types.MInclude] = None,
-    ) -> 'models.M':
+    ) -> BaseModelT:
         """Updates an existing record or create a new one
 
         Parameters
@@ -2863,13 +2863,13 @@ class MActions:
         return resp['data']['result']  # type: ignore[no-any-return]
 
 
-class NActions:
+class NActions(Generic[BaseModelT]):
     __slots__ = (
         '_client',
         '_model',
     )
 
-    def __init__(self, client: 'Client', model: Type['models.N']) -> None:
+    def __init__(self, client: 'Client', model: Type[BaseModelT]) -> None:
         self._client = client
         self._model = model
 
@@ -2877,7 +2877,7 @@ class NActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> List['models.N']:
+    ) -> List[BaseModelT]:
         """Execute a raw SQL query
 
         Parameters
@@ -2915,7 +2915,7 @@ class NActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> Optional['models.N']:
+    ) -> Optional[BaseModelT]:
         """Execute a raw SQL query, returning the first result
 
         Parameters
@@ -2955,7 +2955,7 @@ class NActions:
         self,
         data: types.NCreateInput,
         include: Optional[types.NInclude] = None
-    ) -> 'models.N':
+    ) -> BaseModelT:
         """Create a new N record.
 
         Parameters
@@ -3085,7 +3085,7 @@ class NActions:
         self,
         where: types.NWhereUniqueInput,
         include: Optional[types.NInclude] = None
-    ) -> Optional['models.N']:
+    ) -> Optional[BaseModelT]:
         """Delete a single N record.
 
         Parameters
@@ -3138,7 +3138,7 @@ class NActions:
         self,
         where: types.NWhereUniqueInput,
         include: Optional[types.NInclude] = None
-    ) -> Optional['models.N']:
+    ) -> Optional[BaseModelT]:
         """Find a unique N record.
 
         Parameters
@@ -3195,7 +3195,7 @@ class NActions:
         include: Optional[types.NInclude] = None,
         order: Optional[Union[types.NOrderByInput, List[types.NOrderByInput]]] = None,
         distinct: Optional[List[types.NScalarFieldKeys]] = None,
-    ) -> List['models.N']:
+    ) -> List[BaseModelT]:
         """Find multiple N records.
 
         An empty list is returned if no records could be found.
@@ -3266,7 +3266,7 @@ class NActions:
         include: Optional[types.NInclude] = None,
         order: Optional[Union[types.NOrderByInput, List[types.NOrderByInput]]] = None,
         distinct: Optional[List[types.NScalarFieldKeys]] = None,
-    ) -> Optional['models.N']:
+    ) -> Optional[BaseModelT]:
         """Find a single N record.
 
         Parameters
@@ -3331,7 +3331,7 @@ class NActions:
         data: types.NUpdateInput,
         where: types.NWhereUniqueInput,
         include: Optional[types.NInclude] = None
-    ) -> Optional['models.N']:
+    ) -> Optional[BaseModelT]:
         """Update a single N record.
 
         Parameters
@@ -3389,7 +3389,7 @@ class NActions:
         where: types.NWhereUniqueInput,
         data: types.NUpsertInput,
         include: Optional[types.NInclude] = None,
-    ) -> 'models.N':
+    ) -> BaseModelT:
         """Updates an existing record or create a new one
 
         Parameters
@@ -3810,13 +3810,13 @@ class NActions:
         return resp['data']['result']  # type: ignore[no-any-return]
 
 
-class OneOptionalActions:
+class OneOptionalActions(Generic[BaseModelT]):
     __slots__ = (
         '_client',
         '_model',
     )
 
-    def __init__(self, client: 'Client', model: Type['models.OneOptional']) -> None:
+    def __init__(self, client: 'Client', model: Type[BaseModelT]) -> None:
         self._client = client
         self._model = model
 
@@ -3824,7 +3824,7 @@ class OneOptionalActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> List['models.OneOptional']:
+    ) -> List[BaseModelT]:
         """Execute a raw SQL query
 
         Parameters
@@ -3862,7 +3862,7 @@ class OneOptionalActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> Optional['models.OneOptional']:
+    ) -> Optional[BaseModelT]:
         """Execute a raw SQL query, returning the first result
 
         Parameters
@@ -3902,7 +3902,7 @@ class OneOptionalActions:
         self,
         data: types.OneOptionalCreateInput,
         include: Optional[types.OneOptionalInclude] = None
-    ) -> 'models.OneOptional':
+    ) -> BaseModelT:
         """Create a new OneOptional record.
 
         Parameters
@@ -4029,7 +4029,7 @@ class OneOptionalActions:
         self,
         where: types.OneOptionalWhereUniqueInput,
         include: Optional[types.OneOptionalInclude] = None
-    ) -> Optional['models.OneOptional']:
+    ) -> Optional[BaseModelT]:
         """Delete a single OneOptional record.
 
         Parameters
@@ -4082,7 +4082,7 @@ class OneOptionalActions:
         self,
         where: types.OneOptionalWhereUniqueInput,
         include: Optional[types.OneOptionalInclude] = None
-    ) -> Optional['models.OneOptional']:
+    ) -> Optional[BaseModelT]:
         """Find a unique OneOptional record.
 
         Parameters
@@ -4139,7 +4139,7 @@ class OneOptionalActions:
         include: Optional[types.OneOptionalInclude] = None,
         order: Optional[Union[types.OneOptionalOrderByInput, List[types.OneOptionalOrderByInput]]] = None,
         distinct: Optional[List[types.OneOptionalScalarFieldKeys]] = None,
-    ) -> List['models.OneOptional']:
+    ) -> List[BaseModelT]:
         """Find multiple OneOptional records.
 
         An empty list is returned if no records could be found.
@@ -4210,7 +4210,7 @@ class OneOptionalActions:
         include: Optional[types.OneOptionalInclude] = None,
         order: Optional[Union[types.OneOptionalOrderByInput, List[types.OneOptionalOrderByInput]]] = None,
         distinct: Optional[List[types.OneOptionalScalarFieldKeys]] = None,
-    ) -> Optional['models.OneOptional']:
+    ) -> Optional[BaseModelT]:
         """Find a single OneOptional record.
 
         Parameters
@@ -4275,7 +4275,7 @@ class OneOptionalActions:
         data: types.OneOptionalUpdateInput,
         where: types.OneOptionalWhereUniqueInput,
         include: Optional[types.OneOptionalInclude] = None
-    ) -> Optional['models.OneOptional']:
+    ) -> Optional[BaseModelT]:
         """Update a single OneOptional record.
 
         Parameters
@@ -4333,7 +4333,7 @@ class OneOptionalActions:
         where: types.OneOptionalWhereUniqueInput,
         data: types.OneOptionalUpsertInput,
         include: Optional[types.OneOptionalInclude] = None,
-    ) -> 'models.OneOptional':
+    ) -> BaseModelT:
         """Updates an existing record or create a new one
 
         Parameters
@@ -4752,13 +4752,13 @@ class OneOptionalActions:
         return resp['data']['result']  # type: ignore[no-any-return]
 
 
-class ManyRequiredActions:
+class ManyRequiredActions(Generic[BaseModelT]):
     __slots__ = (
         '_client',
         '_model',
     )
 
-    def __init__(self, client: 'Client', model: Type['models.ManyRequired']) -> None:
+    def __init__(self, client: 'Client', model: Type[BaseModelT]) -> None:
         self._client = client
         self._model = model
 
@@ -4766,7 +4766,7 @@ class ManyRequiredActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> List['models.ManyRequired']:
+    ) -> List[BaseModelT]:
         """Execute a raw SQL query
 
         Parameters
@@ -4804,7 +4804,7 @@ class ManyRequiredActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> Optional['models.ManyRequired']:
+    ) -> Optional[BaseModelT]:
         """Execute a raw SQL query, returning the first result
 
         Parameters
@@ -4844,7 +4844,7 @@ class ManyRequiredActions:
         self,
         data: types.ManyRequiredCreateInput,
         include: Optional[types.ManyRequiredInclude] = None
-    ) -> 'models.ManyRequired':
+    ) -> BaseModelT:
         """Create a new ManyRequired record.
 
         Parameters
@@ -4971,7 +4971,7 @@ class ManyRequiredActions:
         self,
         where: types.ManyRequiredWhereUniqueInput,
         include: Optional[types.ManyRequiredInclude] = None
-    ) -> Optional['models.ManyRequired']:
+    ) -> Optional[BaseModelT]:
         """Delete a single ManyRequired record.
 
         Parameters
@@ -5024,7 +5024,7 @@ class ManyRequiredActions:
         self,
         where: types.ManyRequiredWhereUniqueInput,
         include: Optional[types.ManyRequiredInclude] = None
-    ) -> Optional['models.ManyRequired']:
+    ) -> Optional[BaseModelT]:
         """Find a unique ManyRequired record.
 
         Parameters
@@ -5081,7 +5081,7 @@ class ManyRequiredActions:
         include: Optional[types.ManyRequiredInclude] = None,
         order: Optional[Union[types.ManyRequiredOrderByInput, List[types.ManyRequiredOrderByInput]]] = None,
         distinct: Optional[List[types.ManyRequiredScalarFieldKeys]] = None,
-    ) -> List['models.ManyRequired']:
+    ) -> List[BaseModelT]:
         """Find multiple ManyRequired records.
 
         An empty list is returned if no records could be found.
@@ -5152,7 +5152,7 @@ class ManyRequiredActions:
         include: Optional[types.ManyRequiredInclude] = None,
         order: Optional[Union[types.ManyRequiredOrderByInput, List[types.ManyRequiredOrderByInput]]] = None,
         distinct: Optional[List[types.ManyRequiredScalarFieldKeys]] = None,
-    ) -> Optional['models.ManyRequired']:
+    ) -> Optional[BaseModelT]:
         """Find a single ManyRequired record.
 
         Parameters
@@ -5217,7 +5217,7 @@ class ManyRequiredActions:
         data: types.ManyRequiredUpdateInput,
         where: types.ManyRequiredWhereUniqueInput,
         include: Optional[types.ManyRequiredInclude] = None
-    ) -> Optional['models.ManyRequired']:
+    ) -> Optional[BaseModelT]:
         """Update a single ManyRequired record.
 
         Parameters
@@ -5275,7 +5275,7 @@ class ManyRequiredActions:
         where: types.ManyRequiredWhereUniqueInput,
         data: types.ManyRequiredUpsertInput,
         include: Optional[types.ManyRequiredInclude] = None,
-    ) -> 'models.ManyRequired':
+    ) -> BaseModelT:
         """Updates an existing record or create a new one
 
         Parameters
@@ -5694,13 +5694,13 @@ class ManyRequiredActions:
         return resp['data']['result']  # type: ignore[no-any-return]
 
 
-class ListsActions:
+class ListsActions(Generic[BaseModelT]):
     __slots__ = (
         '_client',
         '_model',
     )
 
-    def __init__(self, client: 'Client', model: Type['models.Lists']) -> None:
+    def __init__(self, client: 'Client', model: Type[BaseModelT]) -> None:
         self._client = client
         self._model = model
 
@@ -5708,7 +5708,7 @@ class ListsActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> List['models.Lists']:
+    ) -> List[BaseModelT]:
         """Execute a raw SQL query
 
         Parameters
@@ -5746,7 +5746,7 @@ class ListsActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> Optional['models.Lists']:
+    ) -> Optional[BaseModelT]:
         """Execute a raw SQL query, returning the first result
 
         Parameters
@@ -5786,7 +5786,7 @@ class ListsActions:
         self,
         data: types.ListsCreateInput,
         include: Optional[types.ListsInclude] = None
-    ) -> 'models.Lists':
+    ) -> BaseModelT:
         """Create a new Lists record.
 
         Parameters
@@ -5898,7 +5898,7 @@ class ListsActions:
         self,
         where: types.ListsWhereUniqueInput,
         include: Optional[types.ListsInclude] = None
-    ) -> Optional['models.Lists']:
+    ) -> Optional[BaseModelT]:
         """Delete a single Lists record.
 
         Parameters
@@ -5951,7 +5951,7 @@ class ListsActions:
         self,
         where: types.ListsWhereUniqueInput,
         include: Optional[types.ListsInclude] = None
-    ) -> Optional['models.Lists']:
+    ) -> Optional[BaseModelT]:
         """Find a unique Lists record.
 
         Parameters
@@ -6008,7 +6008,7 @@ class ListsActions:
         include: Optional[types.ListsInclude] = None,
         order: Optional[Union[types.ListsOrderByInput, List[types.ListsOrderByInput]]] = None,
         distinct: Optional[List[types.ListsScalarFieldKeys]] = None,
-    ) -> List['models.Lists']:
+    ) -> List[BaseModelT]:
         """Find multiple Lists records.
 
         An empty list is returned if no records could be found.
@@ -6079,7 +6079,7 @@ class ListsActions:
         include: Optional[types.ListsInclude] = None,
         order: Optional[Union[types.ListsOrderByInput, List[types.ListsOrderByInput]]] = None,
         distinct: Optional[List[types.ListsScalarFieldKeys]] = None,
-    ) -> Optional['models.Lists']:
+    ) -> Optional[BaseModelT]:
         """Find a single Lists record.
 
         Parameters
@@ -6144,7 +6144,7 @@ class ListsActions:
         data: types.ListsUpdateInput,
         where: types.ListsWhereUniqueInput,
         include: Optional[types.ListsInclude] = None
-    ) -> Optional['models.Lists']:
+    ) -> Optional[BaseModelT]:
         """Update a single Lists record.
 
         Parameters
@@ -6202,7 +6202,7 @@ class ListsActions:
         where: types.ListsWhereUniqueInput,
         data: types.ListsUpsertInput,
         include: Optional[types.ListsInclude] = None,
-    ) -> 'models.Lists':
+    ) -> BaseModelT:
         """Updates an existing record or create a new one
 
         Parameters
@@ -6611,13 +6611,13 @@ class ListsActions:
         return resp['data']['result']  # type: ignore[no-any-return]
 
 
-class AActions:
+class AActions(Generic[BaseModelT]):
     __slots__ = (
         '_client',
         '_model',
     )
 
-    def __init__(self, client: 'Client', model: Type['models.A']) -> None:
+    def __init__(self, client: 'Client', model: Type[BaseModelT]) -> None:
         self._client = client
         self._model = model
 
@@ -6625,7 +6625,7 @@ class AActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> List['models.A']:
+    ) -> List[BaseModelT]:
         """Execute a raw SQL query
 
         Parameters
@@ -6663,7 +6663,7 @@ class AActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> Optional['models.A']:
+    ) -> Optional[BaseModelT]:
         """Execute a raw SQL query, returning the first result
 
         Parameters
@@ -6703,7 +6703,7 @@ class AActions:
         self,
         data: types.ACreateInput,
         include: Optional[types.AInclude] = None
-    ) -> 'models.A':
+    ) -> BaseModelT:
         """Create a new A record.
 
         Parameters
@@ -6827,7 +6827,7 @@ class AActions:
         self,
         where: types.AWhereUniqueInput,
         include: Optional[types.AInclude] = None
-    ) -> Optional['models.A']:
+    ) -> Optional[BaseModelT]:
         """Delete a single A record.
 
         Parameters
@@ -6880,7 +6880,7 @@ class AActions:
         self,
         where: types.AWhereUniqueInput,
         include: Optional[types.AInclude] = None
-    ) -> Optional['models.A']:
+    ) -> Optional[BaseModelT]:
         """Find a unique A record.
 
         Parameters
@@ -6937,7 +6937,7 @@ class AActions:
         include: Optional[types.AInclude] = None,
         order: Optional[Union[types.AOrderByInput, List[types.AOrderByInput]]] = None,
         distinct: Optional[List[types.AScalarFieldKeys]] = None,
-    ) -> List['models.A']:
+    ) -> List[BaseModelT]:
         """Find multiple A records.
 
         An empty list is returned if no records could be found.
@@ -7008,7 +7008,7 @@ class AActions:
         include: Optional[types.AInclude] = None,
         order: Optional[Union[types.AOrderByInput, List[types.AOrderByInput]]] = None,
         distinct: Optional[List[types.AScalarFieldKeys]] = None,
-    ) -> Optional['models.A']:
+    ) -> Optional[BaseModelT]:
         """Find a single A record.
 
         Parameters
@@ -7073,7 +7073,7 @@ class AActions:
         data: types.AUpdateInput,
         where: types.AWhereUniqueInput,
         include: Optional[types.AInclude] = None
-    ) -> Optional['models.A']:
+    ) -> Optional[BaseModelT]:
         """Update a single A record.
 
         Parameters
@@ -7131,7 +7131,7 @@ class AActions:
         where: types.AWhereUniqueInput,
         data: types.AUpsertInput,
         include: Optional[types.AInclude] = None,
-    ) -> 'models.A':
+    ) -> BaseModelT:
         """Updates an existing record or create a new one
 
         Parameters
@@ -7546,13 +7546,13 @@ class AActions:
         return resp['data']['result']  # type: ignore[no-any-return]
 
 
-class BActions:
+class BActions(Generic[BaseModelT]):
     __slots__ = (
         '_client',
         '_model',
     )
 
-    def __init__(self, client: 'Client', model: Type['models.B']) -> None:
+    def __init__(self, client: 'Client', model: Type[BaseModelT]) -> None:
         self._client = client
         self._model = model
 
@@ -7560,7 +7560,7 @@ class BActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> List['models.B']:
+    ) -> List[BaseModelT]:
         """Execute a raw SQL query
 
         Parameters
@@ -7598,7 +7598,7 @@ class BActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> Optional['models.B']:
+    ) -> Optional[BaseModelT]:
         """Execute a raw SQL query, returning the first result
 
         Parameters
@@ -7638,7 +7638,7 @@ class BActions:
         self,
         data: types.BCreateInput,
         include: Optional[types.BInclude] = None
-    ) -> 'models.B':
+    ) -> BaseModelT:
         """Create a new B record.
 
         Parameters
@@ -7762,7 +7762,7 @@ class BActions:
         self,
         where: types.BWhereUniqueInput,
         include: Optional[types.BInclude] = None
-    ) -> Optional['models.B']:
+    ) -> Optional[BaseModelT]:
         """Delete a single B record.
 
         Parameters
@@ -7815,7 +7815,7 @@ class BActions:
         self,
         where: types.BWhereUniqueInput,
         include: Optional[types.BInclude] = None
-    ) -> Optional['models.B']:
+    ) -> Optional[BaseModelT]:
         """Find a unique B record.
 
         Parameters
@@ -7872,7 +7872,7 @@ class BActions:
         include: Optional[types.BInclude] = None,
         order: Optional[Union[types.BOrderByInput, List[types.BOrderByInput]]] = None,
         distinct: Optional[List[types.BScalarFieldKeys]] = None,
-    ) -> List['models.B']:
+    ) -> List[BaseModelT]:
         """Find multiple B records.
 
         An empty list is returned if no records could be found.
@@ -7943,7 +7943,7 @@ class BActions:
         include: Optional[types.BInclude] = None,
         order: Optional[Union[types.BOrderByInput, List[types.BOrderByInput]]] = None,
         distinct: Optional[List[types.BScalarFieldKeys]] = None,
-    ) -> Optional['models.B']:
+    ) -> Optional[BaseModelT]:
         """Find a single B record.
 
         Parameters
@@ -8008,7 +8008,7 @@ class BActions:
         data: types.BUpdateInput,
         where: types.BWhereUniqueInput,
         include: Optional[types.BInclude] = None
-    ) -> Optional['models.B']:
+    ) -> Optional[BaseModelT]:
         """Update a single B record.
 
         Parameters
@@ -8066,7 +8066,7 @@ class BActions:
         where: types.BWhereUniqueInput,
         data: types.BUpsertInput,
         include: Optional[types.BInclude] = None,
-    ) -> 'models.B':
+    ) -> BaseModelT:
         """Updates an existing record or create a new one
 
         Parameters
@@ -8483,13 +8483,13 @@ class BActions:
         return resp['data']['result']  # type: ignore[no-any-return]
 
 
-class CActions:
+class CActions(Generic[BaseModelT]):
     __slots__ = (
         '_client',
         '_model',
     )
 
-    def __init__(self, client: 'Client', model: Type['models.C']) -> None:
+    def __init__(self, client: 'Client', model: Type[BaseModelT]) -> None:
         self._client = client
         self._model = model
 
@@ -8497,7 +8497,7 @@ class CActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> List['models.C']:
+    ) -> List[BaseModelT]:
         """Execute a raw SQL query
 
         Parameters
@@ -8535,7 +8535,7 @@ class CActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> Optional['models.C']:
+    ) -> Optional[BaseModelT]:
         """Execute a raw SQL query, returning the first result
 
         Parameters
@@ -8575,7 +8575,7 @@ class CActions:
         self,
         data: types.CCreateInput,
         include: Optional[types.CInclude] = None
-    ) -> 'models.C':
+    ) -> BaseModelT:
         """Create a new C record.
 
         Parameters
@@ -8705,7 +8705,7 @@ class CActions:
         self,
         where: types.CWhereUniqueInput,
         include: Optional[types.CInclude] = None
-    ) -> Optional['models.C']:
+    ) -> Optional[BaseModelT]:
         """Delete a single C record.
 
         Parameters
@@ -8759,7 +8759,7 @@ class CActions:
         self,
         where: types.CWhereUniqueInput,
         include: Optional[types.CInclude] = None
-    ) -> Optional['models.C']:
+    ) -> Optional[BaseModelT]:
         """Find a unique C record.
 
         Parameters
@@ -8817,7 +8817,7 @@ class CActions:
         include: Optional[types.CInclude] = None,
         order: Optional[Union[types.COrderByInput, List[types.COrderByInput]]] = None,
         distinct: Optional[List[types.CScalarFieldKeys]] = None,
-    ) -> List['models.C']:
+    ) -> List[BaseModelT]:
         """Find multiple C records.
 
         An empty list is returned if no records could be found.
@@ -8888,7 +8888,7 @@ class CActions:
         include: Optional[types.CInclude] = None,
         order: Optional[Union[types.COrderByInput, List[types.COrderByInput]]] = None,
         distinct: Optional[List[types.CScalarFieldKeys]] = None,
-    ) -> Optional['models.C']:
+    ) -> Optional[BaseModelT]:
         """Find a single C record.
 
         Parameters
@@ -8953,7 +8953,7 @@ class CActions:
         data: types.CUpdateInput,
         where: types.CWhereUniqueInput,
         include: Optional[types.CInclude] = None
-    ) -> Optional['models.C']:
+    ) -> Optional[BaseModelT]:
         """Update a single C record.
 
         Parameters
@@ -9012,7 +9012,7 @@ class CActions:
         where: types.CWhereUniqueInput,
         data: types.CUpsertInput,
         include: Optional[types.CInclude] = None,
-    ) -> 'models.C':
+    ) -> BaseModelT:
         """Updates an existing record or create a new one
 
         Parameters
@@ -9422,13 +9422,13 @@ class CActions:
         return resp['data']['result']  # type: ignore[no-any-return]
 
 
-class DActions:
+class DActions(Generic[BaseModelT]):
     __slots__ = (
         '_client',
         '_model',
     )
 
-    def __init__(self, client: 'Client', model: Type['models.D']) -> None:
+    def __init__(self, client: 'Client', model: Type[BaseModelT]) -> None:
         self._client = client
         self._model = model
 
@@ -9436,7 +9436,7 @@ class DActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> List['models.D']:
+    ) -> List[BaseModelT]:
         """Execute a raw SQL query
 
         Parameters
@@ -9474,7 +9474,7 @@ class DActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> Optional['models.D']:
+    ) -> Optional[BaseModelT]:
         """Execute a raw SQL query, returning the first result
 
         Parameters
@@ -9514,7 +9514,7 @@ class DActions:
         self,
         data: types.DCreateInput,
         include: Optional[types.DInclude] = None
-    ) -> 'models.D':
+    ) -> BaseModelT:
         """Create a new D record.
 
         Parameters
@@ -9641,7 +9641,7 @@ class DActions:
         self,
         where: types.DWhereUniqueInput,
         include: Optional[types.DInclude] = None
-    ) -> Optional['models.D']:
+    ) -> Optional[BaseModelT]:
         """Delete a single D record.
 
         Parameters
@@ -9694,7 +9694,7 @@ class DActions:
         self,
         where: types.DWhereUniqueInput,
         include: Optional[types.DInclude] = None
-    ) -> Optional['models.D']:
+    ) -> Optional[BaseModelT]:
         """Find a unique D record.
 
         Parameters
@@ -9751,7 +9751,7 @@ class DActions:
         include: Optional[types.DInclude] = None,
         order: Optional[Union[types.DOrderByInput, List[types.DOrderByInput]]] = None,
         distinct: Optional[List[types.DScalarFieldKeys]] = None,
-    ) -> List['models.D']:
+    ) -> List[BaseModelT]:
         """Find multiple D records.
 
         An empty list is returned if no records could be found.
@@ -9822,7 +9822,7 @@ class DActions:
         include: Optional[types.DInclude] = None,
         order: Optional[Union[types.DOrderByInput, List[types.DOrderByInput]]] = None,
         distinct: Optional[List[types.DScalarFieldKeys]] = None,
-    ) -> Optional['models.D']:
+    ) -> Optional[BaseModelT]:
         """Find a single D record.
 
         Parameters
@@ -9887,7 +9887,7 @@ class DActions:
         data: types.DUpdateInput,
         where: types.DWhereUniqueInput,
         include: Optional[types.DInclude] = None
-    ) -> Optional['models.D']:
+    ) -> Optional[BaseModelT]:
         """Update a single D record.
 
         Parameters
@@ -9945,7 +9945,7 @@ class DActions:
         where: types.DWhereUniqueInput,
         data: types.DUpsertInput,
         include: Optional[types.DInclude] = None,
-    ) -> 'models.D':
+    ) -> BaseModelT:
         """Updates an existing record or create a new one
 
         Parameters
@@ -10364,13 +10364,13 @@ class DActions:
         return resp['data']['result']  # type: ignore[no-any-return]
 
 
-class EActions:
+class EActions(Generic[BaseModelT]):
     __slots__ = (
         '_client',
         '_model',
     )
 
-    def __init__(self, client: 'Client', model: Type['models.E']) -> None:
+    def __init__(self, client: 'Client', model: Type[BaseModelT]) -> None:
         self._client = client
         self._model = model
 
@@ -10378,7 +10378,7 @@ class EActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> List['models.E']:
+    ) -> List[BaseModelT]:
         """Execute a raw SQL query
 
         Parameters
@@ -10416,7 +10416,7 @@ class EActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> Optional['models.E']:
+    ) -> Optional[BaseModelT]:
         """Execute a raw SQL query, returning the first result
 
         Parameters
@@ -10456,7 +10456,7 @@ class EActions:
         self,
         data: types.ECreateInput,
         include: Optional[types.EInclude] = None
-    ) -> 'models.E':
+    ) -> BaseModelT:
         """Create a new E record.
 
         Parameters
@@ -10577,7 +10577,7 @@ class EActions:
         self,
         where: types.EWhereUniqueInput,
         include: Optional[types.EInclude] = None
-    ) -> Optional['models.E']:
+    ) -> Optional[BaseModelT]:
         """Delete a single E record.
 
         Parameters
@@ -10630,7 +10630,7 @@ class EActions:
         self,
         where: types.EWhereUniqueInput,
         include: Optional[types.EInclude] = None
-    ) -> Optional['models.E']:
+    ) -> Optional[BaseModelT]:
         """Find a unique E record.
 
         Parameters
@@ -10687,7 +10687,7 @@ class EActions:
         include: Optional[types.EInclude] = None,
         order: Optional[Union[types.EOrderByInput, List[types.EOrderByInput]]] = None,
         distinct: Optional[List[types.EScalarFieldKeys]] = None,
-    ) -> List['models.E']:
+    ) -> List[BaseModelT]:
         """Find multiple E records.
 
         An empty list is returned if no records could be found.
@@ -10758,7 +10758,7 @@ class EActions:
         include: Optional[types.EInclude] = None,
         order: Optional[Union[types.EOrderByInput, List[types.EOrderByInput]]] = None,
         distinct: Optional[List[types.EScalarFieldKeys]] = None,
-    ) -> Optional['models.E']:
+    ) -> Optional[BaseModelT]:
         """Find a single E record.
 
         Parameters
@@ -10823,7 +10823,7 @@ class EActions:
         data: types.EUpdateInput,
         where: types.EWhereUniqueInput,
         include: Optional[types.EInclude] = None
-    ) -> Optional['models.E']:
+    ) -> Optional[BaseModelT]:
         """Update a single E record.
 
         Parameters
@@ -10881,7 +10881,7 @@ class EActions:
         where: types.EWhereUniqueInput,
         data: types.EUpsertInput,
         include: Optional[types.EInclude] = None,
-    ) -> 'models.E':
+    ) -> BaseModelT:
         """Updates an existing record or create a new one
 
         Parameters

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
@@ -148,18 +148,18 @@ def get_client() -> 'Prisma':
 
 
 class Prisma:
-    post: 'actions.PostActions'
-    user: 'actions.UserActions'
-    m: 'actions.MActions'
-    n: 'actions.NActions'
-    oneoptional: 'actions.OneOptionalActions'
-    manyrequired: 'actions.ManyRequiredActions'
-    lists: 'actions.ListsActions'
-    a: 'actions.AActions'
-    b: 'actions.BActions'
-    c: 'actions.CActions'
-    d: 'actions.DActions'
-    e: 'actions.EActions'
+    post: 'actions.PostActions[models.Post]'
+    user: 'actions.UserActions[models.User]'
+    m: 'actions.MActions[models.M]'
+    n: 'actions.NActions[models.N]'
+    oneoptional: 'actions.OneOptionalActions[models.OneOptional]'
+    manyrequired: 'actions.ManyRequiredActions[models.ManyRequired]'
+    lists: 'actions.ListsActions[models.Lists]'
+    a: 'actions.AActions[models.A]'
+    b: 'actions.BActions[models.B]'
+    c: 'actions.CActions[models.C]'
+    d: 'actions.DActions[models.D]'
+    e: 'actions.EActions[models.E]'
 
     __slots__ = (
         'post',
@@ -192,18 +192,18 @@ class Prisma:
         connect_timeout: int = 10,
         http: Optional[HttpConfig] = None,
     ) -> None:
-        self.post = actions.PostActions(self, models.Post)
-        self.user = actions.UserActions(self, models.User)
-        self.m = actions.MActions(self, models.M)
-        self.n = actions.NActions(self, models.N)
-        self.oneoptional = actions.OneOptionalActions(self, models.OneOptional)
-        self.manyrequired = actions.ManyRequiredActions(self, models.ManyRequired)
-        self.lists = actions.ListsActions(self, models.Lists)
-        self.a = actions.AActions(self, models.A)
-        self.b = actions.BActions(self, models.B)
-        self.c = actions.CActions(self, models.C)
-        self.d = actions.DActions(self, models.D)
-        self.e = actions.EActions(self, models.E)
+        self.post = actions.PostActions[models.Post](self, models.Post)
+        self.user = actions.UserActions[models.User](self, models.User)
+        self.m = actions.MActions[models.M](self, models.M)
+        self.n = actions.NActions[models.N](self, models.N)
+        self.oneoptional = actions.OneOptionalActions[models.OneOptional](self, models.OneOptional)
+        self.manyrequired = actions.ManyRequiredActions[models.ManyRequired](self, models.ManyRequired)
+        self.lists = actions.ListsActions[models.Lists](self, models.Lists)
+        self.a = actions.AActions[models.A](self, models.A)
+        self.b = actions.BActions[models.B](self, models.B)
+        self.c = actions.CActions[models.C](self, models.C)
+        self.d = actions.DActions[models.D](self, models.D)
+        self.e = actions.EActions[models.E](self, models.E)
         self.__engine: Optional[AbstractEngine] = None
         self._active_provider = 'postgresql'
         self._log_queries = log_queries

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[models.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[models.py].raw
@@ -62,41 +62,6 @@ class Config(BaseConfig):
 log: logging.Logger = logging.getLogger(__name__)
 _created_partial_types: Set[str] = set()
 
-# packages that implicitly subclass models
-# this should not raise any warnings as users
-# of these packages cannot do anything about it
-_implicit_subclass_packages: Set[str] = {
-    'fastapi',
-}
-
-
-def _maybe_warn_subclassing(new_model: str, base_model: str, *, stacklevel: int = 3) -> None:
-    # at least 3 frames are guaranteed to exist if we are being called from __init_subclass__
-    # stack: 1 = __init_subclass__, 2 = abc, 3 = <caller>
-    try:
-        frame = inspect.stack()[stacklevel]
-        module = inspect.getmodule(frame[0])
-        if module is not None:
-            name, *_ = module.__name__.split('.')
-            if name in _implicit_subclass_packages:
-                return
-    except Exception as exc:
-        # disabling subclass warnings depending on the caller module is not a mission critical
-        # feature, users can disable these warnings themselves
-        # https://github.com/RobertCraigie/prisma-client-py/issues/278#issuecomment-1031421561
-        log.debug('Ignoring exception encountered during stack inspection check: %s', str(exc))
-
-    message = (
-        'Subclassing models while using pseudo-recursive types may cause unexpected '
-        'errors when static type checking;\n'
-        'You can disable this warning by generating fully recursive types: \n'
-        'https://prisma-client-py.readthedocs.io/en/stable/reference/config/#recursive\n'
-        'or if that is not possible you can pass warn_subclass=False e.g.\n'
-        f'  class {new_model}(prisma.models.{base_model}, warn_subclass=False):'
-    )
-    warnings.warn(message, errors.UnsupportedSubclassWarning, stacklevel=4)
-
-
 class Post(BaseModel):
     """Post model documentation
     """
@@ -119,21 +84,25 @@ class Post(BaseModel):
     Config = Config
 
     @classmethod
-    def prisma(cls) -> 'actions.PostActions':
+    def prisma(cls: Type[BaseModelT]) -> 'actions.PostActions[BaseModelT]':
         from .client import get_client
 
-        return actions.PostActions(get_client(), cls)
+        return actions.PostActions[BaseModelT](get_client(), cls)
 
     # take *args and **kwargs so that other metaclasses can define arguments
     def __init_subclass__(
         cls,
         *args: Any,
-        warn_subclass: bool = True,
+        warn_subclass: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         super().__init_subclass__()
-        if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'Post', stacklevel=3)
+        if warn_subclass is not None:
+            warnings.warn(
+                'The `warn_subclass` argument is deprecated as it is no longer necessary and will be removed in the next release',
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
 
     @staticmethod
@@ -264,21 +233,25 @@ class User(BaseModel):
     Config = Config
 
     @classmethod
-    def prisma(cls) -> 'actions.UserActions':
+    def prisma(cls: Type[BaseModelT]) -> 'actions.UserActions[BaseModelT]':
         from .client import get_client
 
-        return actions.UserActions(get_client(), cls)
+        return actions.UserActions[BaseModelT](get_client(), cls)
 
     # take *args and **kwargs so that other metaclasses can define arguments
     def __init_subclass__(
         cls,
         *args: Any,
-        warn_subclass: bool = True,
+        warn_subclass: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         super().__init_subclass__()
-        if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'User', stacklevel=3)
+        if warn_subclass is not None:
+            warnings.warn(
+                'The `warn_subclass` argument is deprecated as it is no longer necessary and will be removed in the next release',
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
 
     @staticmethod
@@ -405,21 +378,25 @@ class M(BaseModel):
     Config = Config
 
     @classmethod
-    def prisma(cls) -> 'actions.MActions':
+    def prisma(cls: Type[BaseModelT]) -> 'actions.MActions[BaseModelT]':
         from .client import get_client
 
-        return actions.MActions(get_client(), cls)
+        return actions.MActions[BaseModelT](get_client(), cls)
 
     # take *args and **kwargs so that other metaclasses can define arguments
     def __init_subclass__(
         cls,
         *args: Any,
-        warn_subclass: bool = True,
+        warn_subclass: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         super().__init_subclass__()
-        if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'M', stacklevel=3)
+        if warn_subclass is not None:
+            warnings.warn(
+                'The `warn_subclass` argument is deprecated as it is no longer necessary and will be removed in the next release',
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
 
     @staticmethod
@@ -548,21 +525,25 @@ class N(BaseModel):
     Config = Config
 
     @classmethod
-    def prisma(cls) -> 'actions.NActions':
+    def prisma(cls: Type[BaseModelT]) -> 'actions.NActions[BaseModelT]':
         from .client import get_client
 
-        return actions.NActions(get_client(), cls)
+        return actions.NActions[BaseModelT](get_client(), cls)
 
     # take *args and **kwargs so that other metaclasses can define arguments
     def __init_subclass__(
         cls,
         *args: Any,
-        warn_subclass: bool = True,
+        warn_subclass: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         super().__init_subclass__()
-        if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'N', stacklevel=3)
+        if warn_subclass is not None:
+            warnings.warn(
+                'The `warn_subclass` argument is deprecated as it is no longer necessary and will be removed in the next release',
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
 
     @staticmethod
@@ -689,21 +670,25 @@ class OneOptional(BaseModel):
     Config = Config
 
     @classmethod
-    def prisma(cls) -> 'actions.OneOptionalActions':
+    def prisma(cls: Type[BaseModelT]) -> 'actions.OneOptionalActions[BaseModelT]':
         from .client import get_client
 
-        return actions.OneOptionalActions(get_client(), cls)
+        return actions.OneOptionalActions[BaseModelT](get_client(), cls)
 
     # take *args and **kwargs so that other metaclasses can define arguments
     def __init_subclass__(
         cls,
         *args: Any,
-        warn_subclass: bool = True,
+        warn_subclass: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         super().__init_subclass__()
-        if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'OneOptional', stacklevel=3)
+        if warn_subclass is not None:
+            warnings.warn(
+                'The `warn_subclass` argument is deprecated as it is no longer necessary and will be removed in the next release',
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
 
     @staticmethod
@@ -831,21 +816,25 @@ class ManyRequired(BaseModel):
     Config = Config
 
     @classmethod
-    def prisma(cls) -> 'actions.ManyRequiredActions':
+    def prisma(cls: Type[BaseModelT]) -> 'actions.ManyRequiredActions[BaseModelT]':
         from .client import get_client
 
-        return actions.ManyRequiredActions(get_client(), cls)
+        return actions.ManyRequiredActions[BaseModelT](get_client(), cls)
 
     # take *args and **kwargs so that other metaclasses can define arguments
     def __init_subclass__(
         cls,
         *args: Any,
-        warn_subclass: bool = True,
+        warn_subclass: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         super().__init_subclass__()
-        if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'ManyRequired', stacklevel=3)
+        if warn_subclass is not None:
+            warnings.warn(
+                'The `warn_subclass` argument is deprecated as it is no longer necessary and will be removed in the next release',
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
 
     @staticmethod
@@ -970,21 +959,25 @@ class Lists(BaseModel):
     Config = Config
 
     @classmethod
-    def prisma(cls) -> 'actions.ListsActions':
+    def prisma(cls: Type[BaseModelT]) -> 'actions.ListsActions[BaseModelT]':
         from .client import get_client
 
-        return actions.ListsActions(get_client(), cls)
+        return actions.ListsActions[BaseModelT](get_client(), cls)
 
     # take *args and **kwargs so that other metaclasses can define arguments
     def __init_subclass__(
         cls,
         *args: Any,
-        warn_subclass: bool = True,
+        warn_subclass: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         super().__init_subclass__()
-        if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'Lists', stacklevel=3)
+        if warn_subclass is not None:
+            warnings.warn(
+                'The `warn_subclass` argument is deprecated as it is no longer necessary and will be removed in the next release',
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
     @validator('strings', 'bytes', 'dates', 'bools', 'ints', 'floats', 'bigints', 'json_objects', 'decimals', pre=True, allow_reuse=True)
     @classmethod
@@ -1097,21 +1090,25 @@ class A(BaseModel):
     Config = Config
 
     @classmethod
-    def prisma(cls) -> 'actions.AActions':
+    def prisma(cls: Type[BaseModelT]) -> 'actions.AActions[BaseModelT]':
         from .client import get_client
 
-        return actions.AActions(get_client(), cls)
+        return actions.AActions[BaseModelT](get_client(), cls)
 
     # take *args and **kwargs so that other metaclasses can define arguments
     def __init_subclass__(
         cls,
         *args: Any,
-        warn_subclass: bool = True,
+        warn_subclass: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         super().__init_subclass__()
-        if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'A', stacklevel=3)
+        if warn_subclass is not None:
+            warnings.warn(
+                'The `warn_subclass` argument is deprecated as it is no longer necessary and will be removed in the next release',
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
 
     @staticmethod
@@ -1207,21 +1204,25 @@ class B(BaseModel):
     Config = Config
 
     @classmethod
-    def prisma(cls) -> 'actions.BActions':
+    def prisma(cls: Type[BaseModelT]) -> 'actions.BActions[BaseModelT]':
         from .client import get_client
 
-        return actions.BActions(get_client(), cls)
+        return actions.BActions[BaseModelT](get_client(), cls)
 
     # take *args and **kwargs so that other metaclasses can define arguments
     def __init_subclass__(
         cls,
         *args: Any,
-        warn_subclass: bool = True,
+        warn_subclass: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         super().__init_subclass__()
-        if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'B', stacklevel=3)
+        if warn_subclass is not None:
+            warnings.warn(
+                'The `warn_subclass` argument is deprecated as it is no longer necessary and will be removed in the next release',
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
 
     @staticmethod
@@ -1318,21 +1319,25 @@ class C(BaseModel):
     Config = Config
 
     @classmethod
-    def prisma(cls) -> 'actions.CActions':
+    def prisma(cls: Type[BaseModelT]) -> 'actions.CActions[BaseModelT]':
         from .client import get_client
 
-        return actions.CActions(get_client(), cls)
+        return actions.CActions[BaseModelT](get_client(), cls)
 
     # take *args and **kwargs so that other metaclasses can define arguments
     def __init_subclass__(
         cls,
         *args: Any,
-        warn_subclass: bool = True,
+        warn_subclass: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         super().__init_subclass__()
-        if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'C', stacklevel=3)
+        if warn_subclass is not None:
+            warnings.warn(
+                'The `warn_subclass` argument is deprecated as it is no longer necessary and will be removed in the next release',
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
 
     @staticmethod
@@ -1429,21 +1434,25 @@ class D(BaseModel):
     Config = Config
 
     @classmethod
-    def prisma(cls) -> 'actions.DActions':
+    def prisma(cls: Type[BaseModelT]) -> 'actions.DActions[BaseModelT]':
         from .client import get_client
 
-        return actions.DActions(get_client(), cls)
+        return actions.DActions[BaseModelT](get_client(), cls)
 
     # take *args and **kwargs so that other metaclasses can define arguments
     def __init_subclass__(
         cls,
         *args: Any,
-        warn_subclass: bool = True,
+        warn_subclass: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         super().__init_subclass__()
-        if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'D', stacklevel=3)
+        if warn_subclass is not None:
+            warnings.warn(
+                'The `warn_subclass` argument is deprecated as it is no longer necessary and will be removed in the next release',
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
 
     @staticmethod
@@ -1538,21 +1547,25 @@ class E(BaseModel):
     Config = Config
 
     @classmethod
-    def prisma(cls) -> 'actions.EActions':
+    def prisma(cls: Type[BaseModelT]) -> 'actions.EActions[BaseModelT]':
         from .client import get_client
 
-        return actions.EActions(get_client(), cls)
+        return actions.EActions[BaseModelT](get_client(), cls)
 
     # take *args and **kwargs so that other metaclasses can define arguments
     def __init_subclass__(
         cls,
         *args: Any,
-        warn_subclass: bool = True,
+        warn_subclass: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         super().__init_subclass__()
-        if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'E', stacklevel=3)
+        if warn_subclass is not None:
+            warnings.warn(
+                'The `warn_subclass` argument is deprecated as it is no longer necessary and will be removed in the next release',
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
 
     @staticmethod

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[actions.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[actions.py].raw
@@ -47,13 +47,13 @@ if TYPE_CHECKING:
     from .client import Client
 
 
-class PostActions:
+class PostActions(Generic[BaseModelT]):
     __slots__ = (
         '_client',
         '_model',
     )
 
-    def __init__(self, client: 'Client', model: Type['models.Post']) -> None:
+    def __init__(self, client: 'Client', model: Type[BaseModelT]) -> None:
         self._client = client
         self._model = model
 
@@ -61,7 +61,7 @@ class PostActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> List['models.Post']:
+    ) -> List[BaseModelT]:
         """Execute a raw SQL query
 
         Parameters
@@ -99,7 +99,7 @@ class PostActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> Optional['models.Post']:
+    ) -> Optional[BaseModelT]:
         """Execute a raw SQL query, returning the first result
 
         Parameters
@@ -139,7 +139,7 @@ class PostActions:
         self,
         data: types.PostCreateInput,
         include: Optional[types.PostInclude] = None
-    ) -> 'models.Post':
+    ) -> BaseModelT:
         """Create a new Post record.
 
         Parameters
@@ -257,7 +257,7 @@ class PostActions:
         self,
         where: types.PostWhereUniqueInput,
         include: Optional[types.PostInclude] = None
-    ) -> Optional['models.Post']:
+    ) -> Optional[BaseModelT]:
         """Delete a single Post record.
 
         Parameters
@@ -310,7 +310,7 @@ class PostActions:
         self,
         where: types.PostWhereUniqueInput,
         include: Optional[types.PostInclude] = None
-    ) -> Optional['models.Post']:
+    ) -> Optional[BaseModelT]:
         """Find a unique Post record.
 
         Parameters
@@ -367,7 +367,7 @@ class PostActions:
         include: Optional[types.PostInclude] = None,
         order: Optional[Union[types.PostOrderByInput, List[types.PostOrderByInput]]] = None,
         distinct: Optional[List[types.PostScalarFieldKeys]] = None,
-    ) -> List['models.Post']:
+    ) -> List[BaseModelT]:
         """Find multiple Post records.
 
         An empty list is returned if no records could be found.
@@ -438,7 +438,7 @@ class PostActions:
         include: Optional[types.PostInclude] = None,
         order: Optional[Union[types.PostOrderByInput, List[types.PostOrderByInput]]] = None,
         distinct: Optional[List[types.PostScalarFieldKeys]] = None,
-    ) -> Optional['models.Post']:
+    ) -> Optional[BaseModelT]:
         """Find a single Post record.
 
         Parameters
@@ -503,7 +503,7 @@ class PostActions:
         data: types.PostUpdateInput,
         where: types.PostWhereUniqueInput,
         include: Optional[types.PostInclude] = None
-    ) -> Optional['models.Post']:
+    ) -> Optional[BaseModelT]:
         """Update a single Post record.
 
         Parameters
@@ -561,7 +561,7 @@ class PostActions:
         where: types.PostWhereUniqueInput,
         data: types.PostUpsertInput,
         include: Optional[types.PostInclude] = None,
-    ) -> 'models.Post':
+    ) -> BaseModelT:
         """Updates an existing record or create a new one
 
         Parameters
@@ -974,13 +974,13 @@ class PostActions:
         return resp['data']['result']  # type: ignore[no-any-return]
 
 
-class UserActions:
+class UserActions(Generic[BaseModelT]):
     __slots__ = (
         '_client',
         '_model',
     )
 
-    def __init__(self, client: 'Client', model: Type['models.User']) -> None:
+    def __init__(self, client: 'Client', model: Type[BaseModelT]) -> None:
         self._client = client
         self._model = model
 
@@ -988,7 +988,7 @@ class UserActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> List['models.User']:
+    ) -> List[BaseModelT]:
         """Execute a raw SQL query
 
         Parameters
@@ -1026,7 +1026,7 @@ class UserActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> Optional['models.User']:
+    ) -> Optional[BaseModelT]:
         """Execute a raw SQL query, returning the first result
 
         Parameters
@@ -1066,7 +1066,7 @@ class UserActions:
         self,
         data: types.UserCreateInput,
         include: Optional[types.UserInclude] = None
-    ) -> 'models.User':
+    ) -> BaseModelT:
         """Create a new User record.
 
         Parameters
@@ -1196,7 +1196,7 @@ class UserActions:
         self,
         where: types.UserWhereUniqueInput,
         include: Optional[types.UserInclude] = None
-    ) -> Optional['models.User']:
+    ) -> Optional[BaseModelT]:
         """Delete a single User record.
 
         Parameters
@@ -1249,7 +1249,7 @@ class UserActions:
         self,
         where: types.UserWhereUniqueInput,
         include: Optional[types.UserInclude] = None
-    ) -> Optional['models.User']:
+    ) -> Optional[BaseModelT]:
         """Find a unique User record.
 
         Parameters
@@ -1306,7 +1306,7 @@ class UserActions:
         include: Optional[types.UserInclude] = None,
         order: Optional[Union[types.UserOrderByInput, List[types.UserOrderByInput]]] = None,
         distinct: Optional[List[types.UserScalarFieldKeys]] = None,
-    ) -> List['models.User']:
+    ) -> List[BaseModelT]:
         """Find multiple User records.
 
         An empty list is returned if no records could be found.
@@ -1377,7 +1377,7 @@ class UserActions:
         include: Optional[types.UserInclude] = None,
         order: Optional[Union[types.UserOrderByInput, List[types.UserOrderByInput]]] = None,
         distinct: Optional[List[types.UserScalarFieldKeys]] = None,
-    ) -> Optional['models.User']:
+    ) -> Optional[BaseModelT]:
         """Find a single User record.
 
         Parameters
@@ -1442,7 +1442,7 @@ class UserActions:
         data: types.UserUpdateInput,
         where: types.UserWhereUniqueInput,
         include: Optional[types.UserInclude] = None
-    ) -> Optional['models.User']:
+    ) -> Optional[BaseModelT]:
         """Update a single User record.
 
         Parameters
@@ -1500,7 +1500,7 @@ class UserActions:
         where: types.UserWhereUniqueInput,
         data: types.UserUpsertInput,
         include: Optional[types.UserInclude] = None,
-    ) -> 'models.User':
+    ) -> BaseModelT:
         """Updates an existing record or create a new one
 
         Parameters
@@ -1921,13 +1921,13 @@ class UserActions:
         return resp['data']['result']  # type: ignore[no-any-return]
 
 
-class MActions:
+class MActions(Generic[BaseModelT]):
     __slots__ = (
         '_client',
         '_model',
     )
 
-    def __init__(self, client: 'Client', model: Type['models.M']) -> None:
+    def __init__(self, client: 'Client', model: Type[BaseModelT]) -> None:
         self._client = client
         self._model = model
 
@@ -1935,7 +1935,7 @@ class MActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> List['models.M']:
+    ) -> List[BaseModelT]:
         """Execute a raw SQL query
 
         Parameters
@@ -1973,7 +1973,7 @@ class MActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> Optional['models.M']:
+    ) -> Optional[BaseModelT]:
         """Execute a raw SQL query, returning the first result
 
         Parameters
@@ -2013,7 +2013,7 @@ class MActions:
         self,
         data: types.MCreateInput,
         include: Optional[types.MInclude] = None
-    ) -> 'models.M':
+    ) -> BaseModelT:
         """Create a new M record.
 
         Parameters
@@ -2140,7 +2140,7 @@ class MActions:
         self,
         where: types.MWhereUniqueInput,
         include: Optional[types.MInclude] = None
-    ) -> Optional['models.M']:
+    ) -> Optional[BaseModelT]:
         """Delete a single M record.
 
         Parameters
@@ -2193,7 +2193,7 @@ class MActions:
         self,
         where: types.MWhereUniqueInput,
         include: Optional[types.MInclude] = None
-    ) -> Optional['models.M']:
+    ) -> Optional[BaseModelT]:
         """Find a unique M record.
 
         Parameters
@@ -2250,7 +2250,7 @@ class MActions:
         include: Optional[types.MInclude] = None,
         order: Optional[Union[types.MOrderByInput, List[types.MOrderByInput]]] = None,
         distinct: Optional[List[types.MScalarFieldKeys]] = None,
-    ) -> List['models.M']:
+    ) -> List[BaseModelT]:
         """Find multiple M records.
 
         An empty list is returned if no records could be found.
@@ -2321,7 +2321,7 @@ class MActions:
         include: Optional[types.MInclude] = None,
         order: Optional[Union[types.MOrderByInput, List[types.MOrderByInput]]] = None,
         distinct: Optional[List[types.MScalarFieldKeys]] = None,
-    ) -> Optional['models.M']:
+    ) -> Optional[BaseModelT]:
         """Find a single M record.
 
         Parameters
@@ -2386,7 +2386,7 @@ class MActions:
         data: types.MUpdateInput,
         where: types.MWhereUniqueInput,
         include: Optional[types.MInclude] = None
-    ) -> Optional['models.M']:
+    ) -> Optional[BaseModelT]:
         """Update a single M record.
 
         Parameters
@@ -2444,7 +2444,7 @@ class MActions:
         where: types.MWhereUniqueInput,
         data: types.MUpsertInput,
         include: Optional[types.MInclude] = None,
-    ) -> 'models.M':
+    ) -> BaseModelT:
         """Updates an existing record or create a new one
 
         Parameters
@@ -2863,13 +2863,13 @@ class MActions:
         return resp['data']['result']  # type: ignore[no-any-return]
 
 
-class NActions:
+class NActions(Generic[BaseModelT]):
     __slots__ = (
         '_client',
         '_model',
     )
 
-    def __init__(self, client: 'Client', model: Type['models.N']) -> None:
+    def __init__(self, client: 'Client', model: Type[BaseModelT]) -> None:
         self._client = client
         self._model = model
 
@@ -2877,7 +2877,7 @@ class NActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> List['models.N']:
+    ) -> List[BaseModelT]:
         """Execute a raw SQL query
 
         Parameters
@@ -2915,7 +2915,7 @@ class NActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> Optional['models.N']:
+    ) -> Optional[BaseModelT]:
         """Execute a raw SQL query, returning the first result
 
         Parameters
@@ -2955,7 +2955,7 @@ class NActions:
         self,
         data: types.NCreateInput,
         include: Optional[types.NInclude] = None
-    ) -> 'models.N':
+    ) -> BaseModelT:
         """Create a new N record.
 
         Parameters
@@ -3085,7 +3085,7 @@ class NActions:
         self,
         where: types.NWhereUniqueInput,
         include: Optional[types.NInclude] = None
-    ) -> Optional['models.N']:
+    ) -> Optional[BaseModelT]:
         """Delete a single N record.
 
         Parameters
@@ -3138,7 +3138,7 @@ class NActions:
         self,
         where: types.NWhereUniqueInput,
         include: Optional[types.NInclude] = None
-    ) -> Optional['models.N']:
+    ) -> Optional[BaseModelT]:
         """Find a unique N record.
 
         Parameters
@@ -3195,7 +3195,7 @@ class NActions:
         include: Optional[types.NInclude] = None,
         order: Optional[Union[types.NOrderByInput, List[types.NOrderByInput]]] = None,
         distinct: Optional[List[types.NScalarFieldKeys]] = None,
-    ) -> List['models.N']:
+    ) -> List[BaseModelT]:
         """Find multiple N records.
 
         An empty list is returned if no records could be found.
@@ -3266,7 +3266,7 @@ class NActions:
         include: Optional[types.NInclude] = None,
         order: Optional[Union[types.NOrderByInput, List[types.NOrderByInput]]] = None,
         distinct: Optional[List[types.NScalarFieldKeys]] = None,
-    ) -> Optional['models.N']:
+    ) -> Optional[BaseModelT]:
         """Find a single N record.
 
         Parameters
@@ -3331,7 +3331,7 @@ class NActions:
         data: types.NUpdateInput,
         where: types.NWhereUniqueInput,
         include: Optional[types.NInclude] = None
-    ) -> Optional['models.N']:
+    ) -> Optional[BaseModelT]:
         """Update a single N record.
 
         Parameters
@@ -3389,7 +3389,7 @@ class NActions:
         where: types.NWhereUniqueInput,
         data: types.NUpsertInput,
         include: Optional[types.NInclude] = None,
-    ) -> 'models.N':
+    ) -> BaseModelT:
         """Updates an existing record or create a new one
 
         Parameters
@@ -3810,13 +3810,13 @@ class NActions:
         return resp['data']['result']  # type: ignore[no-any-return]
 
 
-class OneOptionalActions:
+class OneOptionalActions(Generic[BaseModelT]):
     __slots__ = (
         '_client',
         '_model',
     )
 
-    def __init__(self, client: 'Client', model: Type['models.OneOptional']) -> None:
+    def __init__(self, client: 'Client', model: Type[BaseModelT]) -> None:
         self._client = client
         self._model = model
 
@@ -3824,7 +3824,7 @@ class OneOptionalActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> List['models.OneOptional']:
+    ) -> List[BaseModelT]:
         """Execute a raw SQL query
 
         Parameters
@@ -3862,7 +3862,7 @@ class OneOptionalActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> Optional['models.OneOptional']:
+    ) -> Optional[BaseModelT]:
         """Execute a raw SQL query, returning the first result
 
         Parameters
@@ -3902,7 +3902,7 @@ class OneOptionalActions:
         self,
         data: types.OneOptionalCreateInput,
         include: Optional[types.OneOptionalInclude] = None
-    ) -> 'models.OneOptional':
+    ) -> BaseModelT:
         """Create a new OneOptional record.
 
         Parameters
@@ -4029,7 +4029,7 @@ class OneOptionalActions:
         self,
         where: types.OneOptionalWhereUniqueInput,
         include: Optional[types.OneOptionalInclude] = None
-    ) -> Optional['models.OneOptional']:
+    ) -> Optional[BaseModelT]:
         """Delete a single OneOptional record.
 
         Parameters
@@ -4082,7 +4082,7 @@ class OneOptionalActions:
         self,
         where: types.OneOptionalWhereUniqueInput,
         include: Optional[types.OneOptionalInclude] = None
-    ) -> Optional['models.OneOptional']:
+    ) -> Optional[BaseModelT]:
         """Find a unique OneOptional record.
 
         Parameters
@@ -4139,7 +4139,7 @@ class OneOptionalActions:
         include: Optional[types.OneOptionalInclude] = None,
         order: Optional[Union[types.OneOptionalOrderByInput, List[types.OneOptionalOrderByInput]]] = None,
         distinct: Optional[List[types.OneOptionalScalarFieldKeys]] = None,
-    ) -> List['models.OneOptional']:
+    ) -> List[BaseModelT]:
         """Find multiple OneOptional records.
 
         An empty list is returned if no records could be found.
@@ -4210,7 +4210,7 @@ class OneOptionalActions:
         include: Optional[types.OneOptionalInclude] = None,
         order: Optional[Union[types.OneOptionalOrderByInput, List[types.OneOptionalOrderByInput]]] = None,
         distinct: Optional[List[types.OneOptionalScalarFieldKeys]] = None,
-    ) -> Optional['models.OneOptional']:
+    ) -> Optional[BaseModelT]:
         """Find a single OneOptional record.
 
         Parameters
@@ -4275,7 +4275,7 @@ class OneOptionalActions:
         data: types.OneOptionalUpdateInput,
         where: types.OneOptionalWhereUniqueInput,
         include: Optional[types.OneOptionalInclude] = None
-    ) -> Optional['models.OneOptional']:
+    ) -> Optional[BaseModelT]:
         """Update a single OneOptional record.
 
         Parameters
@@ -4333,7 +4333,7 @@ class OneOptionalActions:
         where: types.OneOptionalWhereUniqueInput,
         data: types.OneOptionalUpsertInput,
         include: Optional[types.OneOptionalInclude] = None,
-    ) -> 'models.OneOptional':
+    ) -> BaseModelT:
         """Updates an existing record or create a new one
 
         Parameters
@@ -4752,13 +4752,13 @@ class OneOptionalActions:
         return resp['data']['result']  # type: ignore[no-any-return]
 
 
-class ManyRequiredActions:
+class ManyRequiredActions(Generic[BaseModelT]):
     __slots__ = (
         '_client',
         '_model',
     )
 
-    def __init__(self, client: 'Client', model: Type['models.ManyRequired']) -> None:
+    def __init__(self, client: 'Client', model: Type[BaseModelT]) -> None:
         self._client = client
         self._model = model
 
@@ -4766,7 +4766,7 @@ class ManyRequiredActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> List['models.ManyRequired']:
+    ) -> List[BaseModelT]:
         """Execute a raw SQL query
 
         Parameters
@@ -4804,7 +4804,7 @@ class ManyRequiredActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> Optional['models.ManyRequired']:
+    ) -> Optional[BaseModelT]:
         """Execute a raw SQL query, returning the first result
 
         Parameters
@@ -4844,7 +4844,7 @@ class ManyRequiredActions:
         self,
         data: types.ManyRequiredCreateInput,
         include: Optional[types.ManyRequiredInclude] = None
-    ) -> 'models.ManyRequired':
+    ) -> BaseModelT:
         """Create a new ManyRequired record.
 
         Parameters
@@ -4971,7 +4971,7 @@ class ManyRequiredActions:
         self,
         where: types.ManyRequiredWhereUniqueInput,
         include: Optional[types.ManyRequiredInclude] = None
-    ) -> Optional['models.ManyRequired']:
+    ) -> Optional[BaseModelT]:
         """Delete a single ManyRequired record.
 
         Parameters
@@ -5024,7 +5024,7 @@ class ManyRequiredActions:
         self,
         where: types.ManyRequiredWhereUniqueInput,
         include: Optional[types.ManyRequiredInclude] = None
-    ) -> Optional['models.ManyRequired']:
+    ) -> Optional[BaseModelT]:
         """Find a unique ManyRequired record.
 
         Parameters
@@ -5081,7 +5081,7 @@ class ManyRequiredActions:
         include: Optional[types.ManyRequiredInclude] = None,
         order: Optional[Union[types.ManyRequiredOrderByInput, List[types.ManyRequiredOrderByInput]]] = None,
         distinct: Optional[List[types.ManyRequiredScalarFieldKeys]] = None,
-    ) -> List['models.ManyRequired']:
+    ) -> List[BaseModelT]:
         """Find multiple ManyRequired records.
 
         An empty list is returned if no records could be found.
@@ -5152,7 +5152,7 @@ class ManyRequiredActions:
         include: Optional[types.ManyRequiredInclude] = None,
         order: Optional[Union[types.ManyRequiredOrderByInput, List[types.ManyRequiredOrderByInput]]] = None,
         distinct: Optional[List[types.ManyRequiredScalarFieldKeys]] = None,
-    ) -> Optional['models.ManyRequired']:
+    ) -> Optional[BaseModelT]:
         """Find a single ManyRequired record.
 
         Parameters
@@ -5217,7 +5217,7 @@ class ManyRequiredActions:
         data: types.ManyRequiredUpdateInput,
         where: types.ManyRequiredWhereUniqueInput,
         include: Optional[types.ManyRequiredInclude] = None
-    ) -> Optional['models.ManyRequired']:
+    ) -> Optional[BaseModelT]:
         """Update a single ManyRequired record.
 
         Parameters
@@ -5275,7 +5275,7 @@ class ManyRequiredActions:
         where: types.ManyRequiredWhereUniqueInput,
         data: types.ManyRequiredUpsertInput,
         include: Optional[types.ManyRequiredInclude] = None,
-    ) -> 'models.ManyRequired':
+    ) -> BaseModelT:
         """Updates an existing record or create a new one
 
         Parameters
@@ -5694,13 +5694,13 @@ class ManyRequiredActions:
         return resp['data']['result']  # type: ignore[no-any-return]
 
 
-class ListsActions:
+class ListsActions(Generic[BaseModelT]):
     __slots__ = (
         '_client',
         '_model',
     )
 
-    def __init__(self, client: 'Client', model: Type['models.Lists']) -> None:
+    def __init__(self, client: 'Client', model: Type[BaseModelT]) -> None:
         self._client = client
         self._model = model
 
@@ -5708,7 +5708,7 @@ class ListsActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> List['models.Lists']:
+    ) -> List[BaseModelT]:
         """Execute a raw SQL query
 
         Parameters
@@ -5746,7 +5746,7 @@ class ListsActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> Optional['models.Lists']:
+    ) -> Optional[BaseModelT]:
         """Execute a raw SQL query, returning the first result
 
         Parameters
@@ -5786,7 +5786,7 @@ class ListsActions:
         self,
         data: types.ListsCreateInput,
         include: Optional[types.ListsInclude] = None
-    ) -> 'models.Lists':
+    ) -> BaseModelT:
         """Create a new Lists record.
 
         Parameters
@@ -5898,7 +5898,7 @@ class ListsActions:
         self,
         where: types.ListsWhereUniqueInput,
         include: Optional[types.ListsInclude] = None
-    ) -> Optional['models.Lists']:
+    ) -> Optional[BaseModelT]:
         """Delete a single Lists record.
 
         Parameters
@@ -5951,7 +5951,7 @@ class ListsActions:
         self,
         where: types.ListsWhereUniqueInput,
         include: Optional[types.ListsInclude] = None
-    ) -> Optional['models.Lists']:
+    ) -> Optional[BaseModelT]:
         """Find a unique Lists record.
 
         Parameters
@@ -6008,7 +6008,7 @@ class ListsActions:
         include: Optional[types.ListsInclude] = None,
         order: Optional[Union[types.ListsOrderByInput, List[types.ListsOrderByInput]]] = None,
         distinct: Optional[List[types.ListsScalarFieldKeys]] = None,
-    ) -> List['models.Lists']:
+    ) -> List[BaseModelT]:
         """Find multiple Lists records.
 
         An empty list is returned if no records could be found.
@@ -6079,7 +6079,7 @@ class ListsActions:
         include: Optional[types.ListsInclude] = None,
         order: Optional[Union[types.ListsOrderByInput, List[types.ListsOrderByInput]]] = None,
         distinct: Optional[List[types.ListsScalarFieldKeys]] = None,
-    ) -> Optional['models.Lists']:
+    ) -> Optional[BaseModelT]:
         """Find a single Lists record.
 
         Parameters
@@ -6144,7 +6144,7 @@ class ListsActions:
         data: types.ListsUpdateInput,
         where: types.ListsWhereUniqueInput,
         include: Optional[types.ListsInclude] = None
-    ) -> Optional['models.Lists']:
+    ) -> Optional[BaseModelT]:
         """Update a single Lists record.
 
         Parameters
@@ -6202,7 +6202,7 @@ class ListsActions:
         where: types.ListsWhereUniqueInput,
         data: types.ListsUpsertInput,
         include: Optional[types.ListsInclude] = None,
-    ) -> 'models.Lists':
+    ) -> BaseModelT:
         """Updates an existing record or create a new one
 
         Parameters
@@ -6611,13 +6611,13 @@ class ListsActions:
         return resp['data']['result']  # type: ignore[no-any-return]
 
 
-class AActions:
+class AActions(Generic[BaseModelT]):
     __slots__ = (
         '_client',
         '_model',
     )
 
-    def __init__(self, client: 'Client', model: Type['models.A']) -> None:
+    def __init__(self, client: 'Client', model: Type[BaseModelT]) -> None:
         self._client = client
         self._model = model
 
@@ -6625,7 +6625,7 @@ class AActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> List['models.A']:
+    ) -> List[BaseModelT]:
         """Execute a raw SQL query
 
         Parameters
@@ -6663,7 +6663,7 @@ class AActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> Optional['models.A']:
+    ) -> Optional[BaseModelT]:
         """Execute a raw SQL query, returning the first result
 
         Parameters
@@ -6703,7 +6703,7 @@ class AActions:
         self,
         data: types.ACreateInput,
         include: Optional[types.AInclude] = None
-    ) -> 'models.A':
+    ) -> BaseModelT:
         """Create a new A record.
 
         Parameters
@@ -6827,7 +6827,7 @@ class AActions:
         self,
         where: types.AWhereUniqueInput,
         include: Optional[types.AInclude] = None
-    ) -> Optional['models.A']:
+    ) -> Optional[BaseModelT]:
         """Delete a single A record.
 
         Parameters
@@ -6880,7 +6880,7 @@ class AActions:
         self,
         where: types.AWhereUniqueInput,
         include: Optional[types.AInclude] = None
-    ) -> Optional['models.A']:
+    ) -> Optional[BaseModelT]:
         """Find a unique A record.
 
         Parameters
@@ -6937,7 +6937,7 @@ class AActions:
         include: Optional[types.AInclude] = None,
         order: Optional[Union[types.AOrderByInput, List[types.AOrderByInput]]] = None,
         distinct: Optional[List[types.AScalarFieldKeys]] = None,
-    ) -> List['models.A']:
+    ) -> List[BaseModelT]:
         """Find multiple A records.
 
         An empty list is returned if no records could be found.
@@ -7008,7 +7008,7 @@ class AActions:
         include: Optional[types.AInclude] = None,
         order: Optional[Union[types.AOrderByInput, List[types.AOrderByInput]]] = None,
         distinct: Optional[List[types.AScalarFieldKeys]] = None,
-    ) -> Optional['models.A']:
+    ) -> Optional[BaseModelT]:
         """Find a single A record.
 
         Parameters
@@ -7073,7 +7073,7 @@ class AActions:
         data: types.AUpdateInput,
         where: types.AWhereUniqueInput,
         include: Optional[types.AInclude] = None
-    ) -> Optional['models.A']:
+    ) -> Optional[BaseModelT]:
         """Update a single A record.
 
         Parameters
@@ -7131,7 +7131,7 @@ class AActions:
         where: types.AWhereUniqueInput,
         data: types.AUpsertInput,
         include: Optional[types.AInclude] = None,
-    ) -> 'models.A':
+    ) -> BaseModelT:
         """Updates an existing record or create a new one
 
         Parameters
@@ -7546,13 +7546,13 @@ class AActions:
         return resp['data']['result']  # type: ignore[no-any-return]
 
 
-class BActions:
+class BActions(Generic[BaseModelT]):
     __slots__ = (
         '_client',
         '_model',
     )
 
-    def __init__(self, client: 'Client', model: Type['models.B']) -> None:
+    def __init__(self, client: 'Client', model: Type[BaseModelT]) -> None:
         self._client = client
         self._model = model
 
@@ -7560,7 +7560,7 @@ class BActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> List['models.B']:
+    ) -> List[BaseModelT]:
         """Execute a raw SQL query
 
         Parameters
@@ -7598,7 +7598,7 @@ class BActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> Optional['models.B']:
+    ) -> Optional[BaseModelT]:
         """Execute a raw SQL query, returning the first result
 
         Parameters
@@ -7638,7 +7638,7 @@ class BActions:
         self,
         data: types.BCreateInput,
         include: Optional[types.BInclude] = None
-    ) -> 'models.B':
+    ) -> BaseModelT:
         """Create a new B record.
 
         Parameters
@@ -7762,7 +7762,7 @@ class BActions:
         self,
         where: types.BWhereUniqueInput,
         include: Optional[types.BInclude] = None
-    ) -> Optional['models.B']:
+    ) -> Optional[BaseModelT]:
         """Delete a single B record.
 
         Parameters
@@ -7815,7 +7815,7 @@ class BActions:
         self,
         where: types.BWhereUniqueInput,
         include: Optional[types.BInclude] = None
-    ) -> Optional['models.B']:
+    ) -> Optional[BaseModelT]:
         """Find a unique B record.
 
         Parameters
@@ -7872,7 +7872,7 @@ class BActions:
         include: Optional[types.BInclude] = None,
         order: Optional[Union[types.BOrderByInput, List[types.BOrderByInput]]] = None,
         distinct: Optional[List[types.BScalarFieldKeys]] = None,
-    ) -> List['models.B']:
+    ) -> List[BaseModelT]:
         """Find multiple B records.
 
         An empty list is returned if no records could be found.
@@ -7943,7 +7943,7 @@ class BActions:
         include: Optional[types.BInclude] = None,
         order: Optional[Union[types.BOrderByInput, List[types.BOrderByInput]]] = None,
         distinct: Optional[List[types.BScalarFieldKeys]] = None,
-    ) -> Optional['models.B']:
+    ) -> Optional[BaseModelT]:
         """Find a single B record.
 
         Parameters
@@ -8008,7 +8008,7 @@ class BActions:
         data: types.BUpdateInput,
         where: types.BWhereUniqueInput,
         include: Optional[types.BInclude] = None
-    ) -> Optional['models.B']:
+    ) -> Optional[BaseModelT]:
         """Update a single B record.
 
         Parameters
@@ -8066,7 +8066,7 @@ class BActions:
         where: types.BWhereUniqueInput,
         data: types.BUpsertInput,
         include: Optional[types.BInclude] = None,
-    ) -> 'models.B':
+    ) -> BaseModelT:
         """Updates an existing record or create a new one
 
         Parameters
@@ -8483,13 +8483,13 @@ class BActions:
         return resp['data']['result']  # type: ignore[no-any-return]
 
 
-class CActions:
+class CActions(Generic[BaseModelT]):
     __slots__ = (
         '_client',
         '_model',
     )
 
-    def __init__(self, client: 'Client', model: Type['models.C']) -> None:
+    def __init__(self, client: 'Client', model: Type[BaseModelT]) -> None:
         self._client = client
         self._model = model
 
@@ -8497,7 +8497,7 @@ class CActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> List['models.C']:
+    ) -> List[BaseModelT]:
         """Execute a raw SQL query
 
         Parameters
@@ -8535,7 +8535,7 @@ class CActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> Optional['models.C']:
+    ) -> Optional[BaseModelT]:
         """Execute a raw SQL query, returning the first result
 
         Parameters
@@ -8575,7 +8575,7 @@ class CActions:
         self,
         data: types.CCreateInput,
         include: Optional[types.CInclude] = None
-    ) -> 'models.C':
+    ) -> BaseModelT:
         """Create a new C record.
 
         Parameters
@@ -8705,7 +8705,7 @@ class CActions:
         self,
         where: types.CWhereUniqueInput,
         include: Optional[types.CInclude] = None
-    ) -> Optional['models.C']:
+    ) -> Optional[BaseModelT]:
         """Delete a single C record.
 
         Parameters
@@ -8759,7 +8759,7 @@ class CActions:
         self,
         where: types.CWhereUniqueInput,
         include: Optional[types.CInclude] = None
-    ) -> Optional['models.C']:
+    ) -> Optional[BaseModelT]:
         """Find a unique C record.
 
         Parameters
@@ -8817,7 +8817,7 @@ class CActions:
         include: Optional[types.CInclude] = None,
         order: Optional[Union[types.COrderByInput, List[types.COrderByInput]]] = None,
         distinct: Optional[List[types.CScalarFieldKeys]] = None,
-    ) -> List['models.C']:
+    ) -> List[BaseModelT]:
         """Find multiple C records.
 
         An empty list is returned if no records could be found.
@@ -8888,7 +8888,7 @@ class CActions:
         include: Optional[types.CInclude] = None,
         order: Optional[Union[types.COrderByInput, List[types.COrderByInput]]] = None,
         distinct: Optional[List[types.CScalarFieldKeys]] = None,
-    ) -> Optional['models.C']:
+    ) -> Optional[BaseModelT]:
         """Find a single C record.
 
         Parameters
@@ -8953,7 +8953,7 @@ class CActions:
         data: types.CUpdateInput,
         where: types.CWhereUniqueInput,
         include: Optional[types.CInclude] = None
-    ) -> Optional['models.C']:
+    ) -> Optional[BaseModelT]:
         """Update a single C record.
 
         Parameters
@@ -9012,7 +9012,7 @@ class CActions:
         where: types.CWhereUniqueInput,
         data: types.CUpsertInput,
         include: Optional[types.CInclude] = None,
-    ) -> 'models.C':
+    ) -> BaseModelT:
         """Updates an existing record or create a new one
 
         Parameters
@@ -9422,13 +9422,13 @@ class CActions:
         return resp['data']['result']  # type: ignore[no-any-return]
 
 
-class DActions:
+class DActions(Generic[BaseModelT]):
     __slots__ = (
         '_client',
         '_model',
     )
 
-    def __init__(self, client: 'Client', model: Type['models.D']) -> None:
+    def __init__(self, client: 'Client', model: Type[BaseModelT]) -> None:
         self._client = client
         self._model = model
 
@@ -9436,7 +9436,7 @@ class DActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> List['models.D']:
+    ) -> List[BaseModelT]:
         """Execute a raw SQL query
 
         Parameters
@@ -9474,7 +9474,7 @@ class DActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> Optional['models.D']:
+    ) -> Optional[BaseModelT]:
         """Execute a raw SQL query, returning the first result
 
         Parameters
@@ -9514,7 +9514,7 @@ class DActions:
         self,
         data: types.DCreateInput,
         include: Optional[types.DInclude] = None
-    ) -> 'models.D':
+    ) -> BaseModelT:
         """Create a new D record.
 
         Parameters
@@ -9641,7 +9641,7 @@ class DActions:
         self,
         where: types.DWhereUniqueInput,
         include: Optional[types.DInclude] = None
-    ) -> Optional['models.D']:
+    ) -> Optional[BaseModelT]:
         """Delete a single D record.
 
         Parameters
@@ -9694,7 +9694,7 @@ class DActions:
         self,
         where: types.DWhereUniqueInput,
         include: Optional[types.DInclude] = None
-    ) -> Optional['models.D']:
+    ) -> Optional[BaseModelT]:
         """Find a unique D record.
 
         Parameters
@@ -9751,7 +9751,7 @@ class DActions:
         include: Optional[types.DInclude] = None,
         order: Optional[Union[types.DOrderByInput, List[types.DOrderByInput]]] = None,
         distinct: Optional[List[types.DScalarFieldKeys]] = None,
-    ) -> List['models.D']:
+    ) -> List[BaseModelT]:
         """Find multiple D records.
 
         An empty list is returned if no records could be found.
@@ -9822,7 +9822,7 @@ class DActions:
         include: Optional[types.DInclude] = None,
         order: Optional[Union[types.DOrderByInput, List[types.DOrderByInput]]] = None,
         distinct: Optional[List[types.DScalarFieldKeys]] = None,
-    ) -> Optional['models.D']:
+    ) -> Optional[BaseModelT]:
         """Find a single D record.
 
         Parameters
@@ -9887,7 +9887,7 @@ class DActions:
         data: types.DUpdateInput,
         where: types.DWhereUniqueInput,
         include: Optional[types.DInclude] = None
-    ) -> Optional['models.D']:
+    ) -> Optional[BaseModelT]:
         """Update a single D record.
 
         Parameters
@@ -9945,7 +9945,7 @@ class DActions:
         where: types.DWhereUniqueInput,
         data: types.DUpsertInput,
         include: Optional[types.DInclude] = None,
-    ) -> 'models.D':
+    ) -> BaseModelT:
         """Updates an existing record or create a new one
 
         Parameters
@@ -10364,13 +10364,13 @@ class DActions:
         return resp['data']['result']  # type: ignore[no-any-return]
 
 
-class EActions:
+class EActions(Generic[BaseModelT]):
     __slots__ = (
         '_client',
         '_model',
     )
 
-    def __init__(self, client: 'Client', model: Type['models.E']) -> None:
+    def __init__(self, client: 'Client', model: Type[BaseModelT]) -> None:
         self._client = client
         self._model = model
 
@@ -10378,7 +10378,7 @@ class EActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> List['models.E']:
+    ) -> List[BaseModelT]:
         """Execute a raw SQL query
 
         Parameters
@@ -10416,7 +10416,7 @@ class EActions:
         self,
         query: LiteralString,
         *args: Any,
-    ) -> Optional['models.E']:
+    ) -> Optional[BaseModelT]:
         """Execute a raw SQL query, returning the first result
 
         Parameters
@@ -10456,7 +10456,7 @@ class EActions:
         self,
         data: types.ECreateInput,
         include: Optional[types.EInclude] = None
-    ) -> 'models.E':
+    ) -> BaseModelT:
         """Create a new E record.
 
         Parameters
@@ -10577,7 +10577,7 @@ class EActions:
         self,
         where: types.EWhereUniqueInput,
         include: Optional[types.EInclude] = None
-    ) -> Optional['models.E']:
+    ) -> Optional[BaseModelT]:
         """Delete a single E record.
 
         Parameters
@@ -10630,7 +10630,7 @@ class EActions:
         self,
         where: types.EWhereUniqueInput,
         include: Optional[types.EInclude] = None
-    ) -> Optional['models.E']:
+    ) -> Optional[BaseModelT]:
         """Find a unique E record.
 
         Parameters
@@ -10687,7 +10687,7 @@ class EActions:
         include: Optional[types.EInclude] = None,
         order: Optional[Union[types.EOrderByInput, List[types.EOrderByInput]]] = None,
         distinct: Optional[List[types.EScalarFieldKeys]] = None,
-    ) -> List['models.E']:
+    ) -> List[BaseModelT]:
         """Find multiple E records.
 
         An empty list is returned if no records could be found.
@@ -10758,7 +10758,7 @@ class EActions:
         include: Optional[types.EInclude] = None,
         order: Optional[Union[types.EOrderByInput, List[types.EOrderByInput]]] = None,
         distinct: Optional[List[types.EScalarFieldKeys]] = None,
-    ) -> Optional['models.E']:
+    ) -> Optional[BaseModelT]:
         """Find a single E record.
 
         Parameters
@@ -10823,7 +10823,7 @@ class EActions:
         data: types.EUpdateInput,
         where: types.EWhereUniqueInput,
         include: Optional[types.EInclude] = None
-    ) -> Optional['models.E']:
+    ) -> Optional[BaseModelT]:
         """Update a single E record.
 
         Parameters
@@ -10881,7 +10881,7 @@ class EActions:
         where: types.EWhereUniqueInput,
         data: types.EUpsertInput,
         include: Optional[types.EInclude] = None,
-    ) -> 'models.E':
+    ) -> BaseModelT:
         """Updates an existing record or create a new one
 
         Parameters

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
@@ -148,18 +148,18 @@ def get_client() -> 'Prisma':
 
 
 class Prisma:
-    post: 'actions.PostActions'
-    user: 'actions.UserActions'
-    m: 'actions.MActions'
-    n: 'actions.NActions'
-    oneoptional: 'actions.OneOptionalActions'
-    manyrequired: 'actions.ManyRequiredActions'
-    lists: 'actions.ListsActions'
-    a: 'actions.AActions'
-    b: 'actions.BActions'
-    c: 'actions.CActions'
-    d: 'actions.DActions'
-    e: 'actions.EActions'
+    post: 'actions.PostActions[models.Post]'
+    user: 'actions.UserActions[models.User]'
+    m: 'actions.MActions[models.M]'
+    n: 'actions.NActions[models.N]'
+    oneoptional: 'actions.OneOptionalActions[models.OneOptional]'
+    manyrequired: 'actions.ManyRequiredActions[models.ManyRequired]'
+    lists: 'actions.ListsActions[models.Lists]'
+    a: 'actions.AActions[models.A]'
+    b: 'actions.BActions[models.B]'
+    c: 'actions.CActions[models.C]'
+    d: 'actions.DActions[models.D]'
+    e: 'actions.EActions[models.E]'
 
     __slots__ = (
         'post',
@@ -192,18 +192,18 @@ class Prisma:
         connect_timeout: int = 10,
         http: Optional[HttpConfig] = None,
     ) -> None:
-        self.post = actions.PostActions(self, models.Post)
-        self.user = actions.UserActions(self, models.User)
-        self.m = actions.MActions(self, models.M)
-        self.n = actions.NActions(self, models.N)
-        self.oneoptional = actions.OneOptionalActions(self, models.OneOptional)
-        self.manyrequired = actions.ManyRequiredActions(self, models.ManyRequired)
-        self.lists = actions.ListsActions(self, models.Lists)
-        self.a = actions.AActions(self, models.A)
-        self.b = actions.BActions(self, models.B)
-        self.c = actions.CActions(self, models.C)
-        self.d = actions.DActions(self, models.D)
-        self.e = actions.EActions(self, models.E)
+        self.post = actions.PostActions[models.Post](self, models.Post)
+        self.user = actions.UserActions[models.User](self, models.User)
+        self.m = actions.MActions[models.M](self, models.M)
+        self.n = actions.NActions[models.N](self, models.N)
+        self.oneoptional = actions.OneOptionalActions[models.OneOptional](self, models.OneOptional)
+        self.manyrequired = actions.ManyRequiredActions[models.ManyRequired](self, models.ManyRequired)
+        self.lists = actions.ListsActions[models.Lists](self, models.Lists)
+        self.a = actions.AActions[models.A](self, models.A)
+        self.b = actions.BActions[models.B](self, models.B)
+        self.c = actions.CActions[models.C](self, models.C)
+        self.d = actions.DActions[models.D](self, models.D)
+        self.e = actions.EActions[models.E](self, models.E)
         self.__engine: Optional[AbstractEngine] = None
         self._active_provider = 'postgresql'
         self._log_queries = log_queries

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[models.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[models.py].raw
@@ -62,41 +62,6 @@ class Config(BaseConfig):
 log: logging.Logger = logging.getLogger(__name__)
 _created_partial_types: Set[str] = set()
 
-# packages that implicitly subclass models
-# this should not raise any warnings as users
-# of these packages cannot do anything about it
-_implicit_subclass_packages: Set[str] = {
-    'fastapi',
-}
-
-
-def _maybe_warn_subclassing(new_model: str, base_model: str, *, stacklevel: int = 3) -> None:
-    # at least 3 frames are guaranteed to exist if we are being called from __init_subclass__
-    # stack: 1 = __init_subclass__, 2 = abc, 3 = <caller>
-    try:
-        frame = inspect.stack()[stacklevel]
-        module = inspect.getmodule(frame[0])
-        if module is not None:
-            name, *_ = module.__name__.split('.')
-            if name in _implicit_subclass_packages:
-                return
-    except Exception as exc:
-        # disabling subclass warnings depending on the caller module is not a mission critical
-        # feature, users can disable these warnings themselves
-        # https://github.com/RobertCraigie/prisma-client-py/issues/278#issuecomment-1031421561
-        log.debug('Ignoring exception encountered during stack inspection check: %s', str(exc))
-
-    message = (
-        'Subclassing models while using pseudo-recursive types may cause unexpected '
-        'errors when static type checking;\n'
-        'You can disable this warning by generating fully recursive types: \n'
-        'https://prisma-client-py.readthedocs.io/en/stable/reference/config/#recursive\n'
-        'or if that is not possible you can pass warn_subclass=False e.g.\n'
-        f'  class {new_model}(prisma.models.{base_model}, warn_subclass=False):'
-    )
-    warnings.warn(message, errors.UnsupportedSubclassWarning, stacklevel=4)
-
-
 class Post(BaseModel):
     """Post model documentation
     """
@@ -119,21 +84,25 @@ class Post(BaseModel):
     Config = Config
 
     @classmethod
-    def prisma(cls) -> 'actions.PostActions':
+    def prisma(cls: Type[BaseModelT]) -> 'actions.PostActions[BaseModelT]':
         from .client import get_client
 
-        return actions.PostActions(get_client(), cls)
+        return actions.PostActions[BaseModelT](get_client(), cls)
 
     # take *args and **kwargs so that other metaclasses can define arguments
     def __init_subclass__(
         cls,
         *args: Any,
-        warn_subclass: bool = True,
+        warn_subclass: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         super().__init_subclass__()
-        if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'Post', stacklevel=3)
+        if warn_subclass is not None:
+            warnings.warn(
+                'The `warn_subclass` argument is deprecated as it is no longer necessary and will be removed in the next release',
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
 
     @staticmethod
@@ -264,21 +233,25 @@ class User(BaseModel):
     Config = Config
 
     @classmethod
-    def prisma(cls) -> 'actions.UserActions':
+    def prisma(cls: Type[BaseModelT]) -> 'actions.UserActions[BaseModelT]':
         from .client import get_client
 
-        return actions.UserActions(get_client(), cls)
+        return actions.UserActions[BaseModelT](get_client(), cls)
 
     # take *args and **kwargs so that other metaclasses can define arguments
     def __init_subclass__(
         cls,
         *args: Any,
-        warn_subclass: bool = True,
+        warn_subclass: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         super().__init_subclass__()
-        if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'User', stacklevel=3)
+        if warn_subclass is not None:
+            warnings.warn(
+                'The `warn_subclass` argument is deprecated as it is no longer necessary and will be removed in the next release',
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
 
     @staticmethod
@@ -405,21 +378,25 @@ class M(BaseModel):
     Config = Config
 
     @classmethod
-    def prisma(cls) -> 'actions.MActions':
+    def prisma(cls: Type[BaseModelT]) -> 'actions.MActions[BaseModelT]':
         from .client import get_client
 
-        return actions.MActions(get_client(), cls)
+        return actions.MActions[BaseModelT](get_client(), cls)
 
     # take *args and **kwargs so that other metaclasses can define arguments
     def __init_subclass__(
         cls,
         *args: Any,
-        warn_subclass: bool = True,
+        warn_subclass: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         super().__init_subclass__()
-        if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'M', stacklevel=3)
+        if warn_subclass is not None:
+            warnings.warn(
+                'The `warn_subclass` argument is deprecated as it is no longer necessary and will be removed in the next release',
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
 
     @staticmethod
@@ -548,21 +525,25 @@ class N(BaseModel):
     Config = Config
 
     @classmethod
-    def prisma(cls) -> 'actions.NActions':
+    def prisma(cls: Type[BaseModelT]) -> 'actions.NActions[BaseModelT]':
         from .client import get_client
 
-        return actions.NActions(get_client(), cls)
+        return actions.NActions[BaseModelT](get_client(), cls)
 
     # take *args and **kwargs so that other metaclasses can define arguments
     def __init_subclass__(
         cls,
         *args: Any,
-        warn_subclass: bool = True,
+        warn_subclass: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         super().__init_subclass__()
-        if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'N', stacklevel=3)
+        if warn_subclass is not None:
+            warnings.warn(
+                'The `warn_subclass` argument is deprecated as it is no longer necessary and will be removed in the next release',
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
 
     @staticmethod
@@ -689,21 +670,25 @@ class OneOptional(BaseModel):
     Config = Config
 
     @classmethod
-    def prisma(cls) -> 'actions.OneOptionalActions':
+    def prisma(cls: Type[BaseModelT]) -> 'actions.OneOptionalActions[BaseModelT]':
         from .client import get_client
 
-        return actions.OneOptionalActions(get_client(), cls)
+        return actions.OneOptionalActions[BaseModelT](get_client(), cls)
 
     # take *args and **kwargs so that other metaclasses can define arguments
     def __init_subclass__(
         cls,
         *args: Any,
-        warn_subclass: bool = True,
+        warn_subclass: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         super().__init_subclass__()
-        if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'OneOptional', stacklevel=3)
+        if warn_subclass is not None:
+            warnings.warn(
+                'The `warn_subclass` argument is deprecated as it is no longer necessary and will be removed in the next release',
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
 
     @staticmethod
@@ -831,21 +816,25 @@ class ManyRequired(BaseModel):
     Config = Config
 
     @classmethod
-    def prisma(cls) -> 'actions.ManyRequiredActions':
+    def prisma(cls: Type[BaseModelT]) -> 'actions.ManyRequiredActions[BaseModelT]':
         from .client import get_client
 
-        return actions.ManyRequiredActions(get_client(), cls)
+        return actions.ManyRequiredActions[BaseModelT](get_client(), cls)
 
     # take *args and **kwargs so that other metaclasses can define arguments
     def __init_subclass__(
         cls,
         *args: Any,
-        warn_subclass: bool = True,
+        warn_subclass: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         super().__init_subclass__()
-        if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'ManyRequired', stacklevel=3)
+        if warn_subclass is not None:
+            warnings.warn(
+                'The `warn_subclass` argument is deprecated as it is no longer necessary and will be removed in the next release',
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
 
     @staticmethod
@@ -970,21 +959,25 @@ class Lists(BaseModel):
     Config = Config
 
     @classmethod
-    def prisma(cls) -> 'actions.ListsActions':
+    def prisma(cls: Type[BaseModelT]) -> 'actions.ListsActions[BaseModelT]':
         from .client import get_client
 
-        return actions.ListsActions(get_client(), cls)
+        return actions.ListsActions[BaseModelT](get_client(), cls)
 
     # take *args and **kwargs so that other metaclasses can define arguments
     def __init_subclass__(
         cls,
         *args: Any,
-        warn_subclass: bool = True,
+        warn_subclass: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         super().__init_subclass__()
-        if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'Lists', stacklevel=3)
+        if warn_subclass is not None:
+            warnings.warn(
+                'The `warn_subclass` argument is deprecated as it is no longer necessary and will be removed in the next release',
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
     @validator('strings', 'bytes', 'dates', 'bools', 'ints', 'floats', 'bigints', 'json_objects', 'decimals', pre=True, allow_reuse=True)
     @classmethod
@@ -1097,21 +1090,25 @@ class A(BaseModel):
     Config = Config
 
     @classmethod
-    def prisma(cls) -> 'actions.AActions':
+    def prisma(cls: Type[BaseModelT]) -> 'actions.AActions[BaseModelT]':
         from .client import get_client
 
-        return actions.AActions(get_client(), cls)
+        return actions.AActions[BaseModelT](get_client(), cls)
 
     # take *args and **kwargs so that other metaclasses can define arguments
     def __init_subclass__(
         cls,
         *args: Any,
-        warn_subclass: bool = True,
+        warn_subclass: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         super().__init_subclass__()
-        if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'A', stacklevel=3)
+        if warn_subclass is not None:
+            warnings.warn(
+                'The `warn_subclass` argument is deprecated as it is no longer necessary and will be removed in the next release',
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
 
     @staticmethod
@@ -1207,21 +1204,25 @@ class B(BaseModel):
     Config = Config
 
     @classmethod
-    def prisma(cls) -> 'actions.BActions':
+    def prisma(cls: Type[BaseModelT]) -> 'actions.BActions[BaseModelT]':
         from .client import get_client
 
-        return actions.BActions(get_client(), cls)
+        return actions.BActions[BaseModelT](get_client(), cls)
 
     # take *args and **kwargs so that other metaclasses can define arguments
     def __init_subclass__(
         cls,
         *args: Any,
-        warn_subclass: bool = True,
+        warn_subclass: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         super().__init_subclass__()
-        if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'B', stacklevel=3)
+        if warn_subclass is not None:
+            warnings.warn(
+                'The `warn_subclass` argument is deprecated as it is no longer necessary and will be removed in the next release',
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
 
     @staticmethod
@@ -1318,21 +1319,25 @@ class C(BaseModel):
     Config = Config
 
     @classmethod
-    def prisma(cls) -> 'actions.CActions':
+    def prisma(cls: Type[BaseModelT]) -> 'actions.CActions[BaseModelT]':
         from .client import get_client
 
-        return actions.CActions(get_client(), cls)
+        return actions.CActions[BaseModelT](get_client(), cls)
 
     # take *args and **kwargs so that other metaclasses can define arguments
     def __init_subclass__(
         cls,
         *args: Any,
-        warn_subclass: bool = True,
+        warn_subclass: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         super().__init_subclass__()
-        if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'C', stacklevel=3)
+        if warn_subclass is not None:
+            warnings.warn(
+                'The `warn_subclass` argument is deprecated as it is no longer necessary and will be removed in the next release',
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
 
     @staticmethod
@@ -1429,21 +1434,25 @@ class D(BaseModel):
     Config = Config
 
     @classmethod
-    def prisma(cls) -> 'actions.DActions':
+    def prisma(cls: Type[BaseModelT]) -> 'actions.DActions[BaseModelT]':
         from .client import get_client
 
-        return actions.DActions(get_client(), cls)
+        return actions.DActions[BaseModelT](get_client(), cls)
 
     # take *args and **kwargs so that other metaclasses can define arguments
     def __init_subclass__(
         cls,
         *args: Any,
-        warn_subclass: bool = True,
+        warn_subclass: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         super().__init_subclass__()
-        if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'D', stacklevel=3)
+        if warn_subclass is not None:
+            warnings.warn(
+                'The `warn_subclass` argument is deprecated as it is no longer necessary and will be removed in the next release',
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
 
     @staticmethod
@@ -1538,21 +1547,25 @@ class E(BaseModel):
     Config = Config
 
     @classmethod
-    def prisma(cls) -> 'actions.EActions':
+    def prisma(cls: Type[BaseModelT]) -> 'actions.EActions[BaseModelT]':
         from .client import get_client
 
-        return actions.EActions(get_client(), cls)
+        return actions.EActions[BaseModelT](get_client(), cls)
 
     # take *args and **kwargs so that other metaclasses can define arguments
     def __init_subclass__(
         cls,
         *args: Any,
-        warn_subclass: bool = True,
+        warn_subclass: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         super().__init_subclass__()
-        if warn_subclass:
-            _maybe_warn_subclassing(cls.__name__, 'E', stacklevel=3)
+        if warn_subclass is not None:
+            warnings.warn(
+                'The `warn_subclass` argument is deprecated as it is no longer necessary and will be removed in the next release',
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
 
     @staticmethod

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import pytest
 
 from prisma.models import User

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,44 +1,31 @@
 import pytest
-from fastapi import FastAPI
 
 from prisma.models import User
-from prisma.errors import UnsupportedSubclassWarning
 
 
 # pyright: reportUnusedClass=false
 
 
-def test_subclassing_warns() -> None:
-    """Subclassing a prisma model without using recursive types should raise a
-    warning as it will cause unexpected behaviour when static type checking as
-    action methods will be typed to return the base class, not the sub class.
-    """
-    with pytest.warns(UnsupportedSubclassWarning):
+def test_subclass_warn_subclass_argument_deprecated() -> None:
+    """The class argument `wan_subclass` is deprecated"""
+    # For some indiscernible reason, this code causes mypy to crash...
+    #
+    # The `exclude` option doesn't help us because of the way mypy works it still causes it to crash.
+    #
+    # I do not have the time nor the willpower to investigate why this happens so we resort to this solution.
+    if not TYPE_CHECKING:
+        with pytest.warns(
+            DeprecationWarning,
+            match='The `warn_subclass` argument is deprecated',
+        ):
 
-        class MyUser(User):
-            pass
+            class MyUser(User, warn_subclass=False):
+                pass
 
-    class MyUser2(User, warn_subclass=False):
-        pass
+        with pytest.warns(
+            DeprecationWarning,
+            match='The `warn_subclass` argument is deprecated',
+        ):
 
-    # ensure other arguments can be passed to support multiple inheritance
-    class MyUser3(User, warn_subclass=False, foo=1):
-        pass
-
-
-# NOTE: we only include a FastAPI test here as it is a small dependency
-# if we need to ignore warnings for other packages, we do not need unit tests
-
-
-def test_subclass_ignores_fastapi_response_model() -> None:
-    """FastAPI implicitly creates new types from the model passed to response_model.
-    This calls __init_subclass__ which will raise warnings that users cannot do anything about.
-    """
-    # this test may look like it does not test anything but as we turn
-    # warnings into errors when running pytest, this will catch any
-    # warnings we raise
-    app = FastAPI()
-
-    @app.get('/', response_model=User)
-    async def _() -> None:  # pragma: no cover
-        ...
+            class MyUser2(User, warn_subclass=True):
+                pass


### PR DESCRIPTION
## Change Summary

This restriction is no longer needed as mypy has fixed a lot of performance issues and this change no longer results in a ridiculous runtime for mypy.

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
