### PR TITLE
refactor(builder): work with python method name instead of graphql name

### DIFF
--- a/src/prisma/__init__.py
+++ b/src/prisma/__init__.py
@@ -12,6 +12,7 @@ from ._config import config as config
 from .utils import setup_logging
 from . import errors as errors
 from .validator import *
+from ._types import PrismaMethod as PrismaMethod
 
 
 try:

--- a/src/prisma/_types.py
+++ b/src/prisma/_types.py
@@ -26,3 +26,27 @@ class InheritsGeneric(Protocol):
 
 class _GenericAlias(Protocol):
     __origin__: Type[object]
+
+
+PrismaMethod = Literal[
+    # raw queries
+    'query_raw',
+    'query_first',
+    'execute_raw',
+    # mutatitive queries
+    'create',
+    'delete',
+    'update',
+    'upsert',
+    'create_many',
+    'delete_many',
+    'update_many',
+    # read queries
+    'count',
+    'group_by',
+    'find_many',
+    'find_first',
+    'find_first_or_raise',
+    'find_unique',
+    'find_unique_or_raise',
+]

--- a/src/prisma/generator/templates/_utils.py.jinja
+++ b/src/prisma/generator/templates/_utils.py.jinja
@@ -18,48 +18,6 @@ time.sleep({{ duration }})
 {% endif %}
 {%- endmacro %}
 
-{% set operations = {
-    'create': 'mutation',
-    'delete': 'mutation',
-    'update': 'mutation',
-    'upsert': 'mutation',
-    'query_raw': 'mutation',
-    'create_many': 'mutation',
-    'execute_raw': 'mutation',
-    'delete_many': 'mutation',
-    'update_many': 'mutation',
-
-    'count': 'query',
-    'group_by': 'query',
-    'find_many': 'query',
-    'find_first': 'query',
-    'find_first_or_raise': 'query',
-    'find_unique': 'query',
-    'find_unique_or_raise': 'query',
-}
-%}
-
-{% set methods = {
-    'create': 'createOne{model}',
-    'delete': 'deleteOne{model}',
-    'update': 'updateOne{model}',
-    'upsert': 'upsertOne{model}',
-    'query_raw': 'queryRaw{model}',
-    'create_many': 'createMany{model}',
-    'execute_raw': 'executeRaw{model}',
-    'delete_many': 'deleteMany{model}',
-    'update_many': 'updateMany{model}',
-
-    'count': 'aggregate{model}',
-    'group_by': 'groupBy{model}',
-    'find_many': 'findMany{model}',
-    'find_first': 'findFirst{model}',
-    'find_first_or_raise': 'findFirst{model}OrThrow',
-    'find_unique': 'findUnique{model}',
-    'find_unique_or_raise': 'findUnique{model}OrThrow',
-}
-%}
-
 {% set active_provider = datasources[0].active_provider %}
 
 {% macro query_methods(name) %}

--- a/src/prisma/generator/templates/actions.py.jinja
+++ b/src/prisma/generator/templates/actions.py.jinja
@@ -1,6 +1,6 @@
 {% set annotations = true %}
 {% include '_header.py.jinja' %}
-{% from '_utils.py.jinja' import is_async, maybe_async_def, maybe_await, methods, operations, recursive_types, active_provider with context %}
+{% from '_utils.py.jinja' import is_async, maybe_async_def, maybe_await, recursive_types, active_provider with context %}
 # -- template actions.py.jinja --
 from typing import TypeVar
 import warnings
@@ -171,8 +171,7 @@ class {{ model.name }}Actions(Generic[{{ ModelType }}]):
         ```
         """
         resp = {{ maybe_await }}self._client._execute(
-            operation='{{ operations.create }}',
-            method='{{ methods.create }}',
+            method='create',
             model=self._model,
             arguments={
                 'data': data,
@@ -236,8 +235,7 @@ class {{ model.name }}Actions(Generic[{{ ModelType }}]):
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         resp = {{ maybe_await }}self._client._execute(
-            operation='{{ operations.create_many }}',
-            method='{{ methods.create_many }}',
+            method='create_many',
             model=self._model,
             arguments={
                 'data': data,
@@ -285,8 +283,7 @@ class {{ model.name }}Actions(Generic[{{ ModelType }}]):
         """
         try:
             resp = {{ maybe_await }}self._client._execute(
-                operation='{{ operations.delete }}',
-                method='{{ methods.delete }}',
+                method='delete',
                 model=self._model,
                 arguments={
                     'where': where,
@@ -335,8 +332,7 @@ class {{ model.name }}Actions(Generic[{{ ModelType }}]):
         ```
         """
         resp = {{ maybe_await }}self._client._execute(
-            operation='{{ operations.find_unique }}',
-            method='{{ methods.find_unique }}',
+            method='find_unique',
             model=self._model,
             arguments={
                 'where': where,
@@ -385,8 +381,7 @@ class {{ model.name }}Actions(Generic[{{ ModelType }}]):
         ```
         """
         resp = {{ maybe_await }}self._client._execute(
-            operation='{{ operations.find_unique_or_raise }}',
-            method='{{ methods.find_unique_or_raise }}',
+            method='find_unique_or_raise',
             model=self._model,
             arguments={
                 'where': where,
@@ -452,8 +447,7 @@ class {{ model.name }}Actions(Generic[{{ ModelType }}]):
         ```
         """
         resp = {{ maybe_await }}self._client._execute(
-            operation='{{ operations.find_many }}',
-            method='{{ methods.find_many }}',
+            method='find_many',
             model=self._model,
             arguments={
                 'take': take,
@@ -518,8 +512,7 @@ class {{ model.name }}Actions(Generic[{{ ModelType }}]):
         ```
         """
         resp = {{ maybe_await }}self._client._execute(
-            operation='{{ operations.find_first }}',
-            method='{{ methods.find_first }}',
+            method='find_first',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -586,8 +579,7 @@ class {{ model.name }}Actions(Generic[{{ ModelType }}]):
         ```
         """
         resp = {{ maybe_await }}self._client._execute(
-            operation='{{ operations.find_first_or_raise }}',
-            method='{{ methods.find_first_or_raise }}',
+            method='find_first_or_raise',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -643,8 +635,7 @@ class {{ model.name }}Actions(Generic[{{ ModelType }}]):
         """
         try:
             resp = {{ maybe_await }}self._client._execute(
-                operation='{{ operations["update"] }}',
-                method='{{ methods["update"] }}',
+                method='update',
                 model=self._model,
                 arguments={
                     'data': data,
@@ -729,8 +720,7 @@ class {{ model.name }}Actions(Generic[{{ ModelType }}]):
         ```
         """
         resp = {{ maybe_await }}self._client._execute(
-            operation='{{ operations.upsert }}',
-            method='{{ methods.upsert }}',
+            method='upsert',
             model=self._model,
             arguments={
                 'where': where,
@@ -778,8 +768,7 @@ class {{ model.name }}Actions(Generic[{{ ModelType }}]):
         ```
         """
         resp = {{ maybe_await }}self._client._execute(
-            operation='{{ operations.update_many }}',
-            method='{{ methods.update_many }}',
+            method='update_many',
             model=self._model,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -885,8 +874,7 @@ class {{ model.name }}Actions(Generic[{{ ModelType }}]):
             {% endraw %}
 
         resp = {{ maybe_await }}self._client._execute(
-            operation='{{ operations.count }}',
-            method='{{ methods.count }}',
+            method='count',
             model=self._model,
             arguments={
                 'take': take,
@@ -930,8 +918,7 @@ class {{ model.name }}Actions(Generic[{{ ModelType }}]):
         ```
         """
         resp = {{ maybe_await }}self._client._execute(
-            operation='{{ operations.delete_many }}',
-            method='{{ methods.delete_many }}',
+            method='delete_many',
             model=self._model,
             arguments={'where': where},
             root_selection=['count'],
@@ -1049,8 +1036,7 @@ class {{ model.name }}Actions(Generic[{{ ModelType }}]):
                 root_selection.append(_select_fields('_count', count))
 
         resp = {{ maybe_await }}self._client._execute(
-            operation='{{ operations.group_by }}',
-            method='{{ methods.group_by }}',
+            method='group_by',
             model=self._model,
             arguments={
                 'by': by,
@@ -1078,4 +1064,3 @@ def _select_fields(root: str, select: Mapping[str, Any]) -> str:
 
 
 from . import models
-

--- a/src/prisma/generator/templates/builder.py.jinja
+++ b/src/prisma/generator/templates/builder.py.jinja
@@ -3,16 +3,6 @@
 {% from '_utils.py.jinja' import maybe_async_def, maybe_await with context %}
 # -- template builder.py.jinja --
 
-# TODO: the QueryBuilder should validate and add type information context.
-#       currently we just naively iterate through arguments and encode them
-#       using standard json when we don't have any special casing for it.
-#       this makes it more difficult to add support for non-standard types
-#       such as the `Json` type.
-# TODO: optimise for performance (switch to c / cython?)
-# TODO: pass context around differently, relying on the builder instance is
-#       not ideal, context should be local to each node
-
-
 import json
 import logging
 import inspect
@@ -20,13 +10,17 @@ from textwrap import indent
 from datetime import timezone
 from abc import abstractmethod, ABC
 from functools import singledispatch
+from typing import ForwardRef
+from typing_extensions import TypeGuard
 
+from pydantic import BaseModel
 from pydantic.fields import ModelField
 
 from . import fields
 from .types import Serializable
 from .errors import UnknownModelError, UnknownRelationalFieldError, InvalidModelError
 from ._constants import QUERY_BUILDER_ALIASES
+from ._types import PrismaMethod
 
 if TYPE_CHECKING:
     from .bases import _PrismaModel as PrismaModel
@@ -52,29 +46,80 @@ RELATIONAL_FIELD_MAPPINGS: Dict[str, Dict[str, str]] = {
     {% endfor %}
 }
 
+METHOD_OPERATION_MAPPING: dict[PrismaMethod, Operation] = {
+    'create': 'mutation',
+    'delete': 'mutation',
+    'update': 'mutation',
+    'upsert': 'mutation',
+    'query_raw': 'mutation',
+    'query_first': 'mutation',
+    'create_many': 'mutation',
+    'execute_raw': 'mutation',
+    'delete_many': 'mutation',
+    'update_many': 'mutation',
+
+    'count': 'query',
+    'group_by': 'query',
+    'find_many': 'query',
+    'find_first': 'query',
+    'find_first_or_raise': 'query',
+    'find_unique': 'query',
+    'find_unique_or_raise': 'query',
+}
+
+METHOD_FORMAT_MAPPING: dict[PrismaMethod, str] = {
+    'create': 'createOne{model}',
+    'delete': 'deleteOne{model}',
+    'update': 'updateOne{model}',
+    'upsert': 'upsertOne{model}',
+    'query_raw': 'queryRaw',
+    'query_first': 'queryRaw',
+    'create_many': 'createMany{model}',
+    'execute_raw': 'executeRaw',
+    'delete_many': 'deleteMany{model}',
+    'update_many': 'updateMany{model}',
+
+    'count': 'aggregate{model}',
+    'group_by': 'groupBy{model}',
+    'find_many': 'findMany{model}',
+    'find_first': 'findFirst{model}',
+    'find_first_or_raise': 'findFirst{model}OrThrow',
+    'find_unique': 'findUnique{model}',
+    'find_unique_or_raise': 'findUnique{model}OrThrow',
+}
+
 MISSING = object()
+Operation = Literal['query', 'mutation']
+
 
 
 class QueryBuilder:
-    # prisma method format, e.g. `findUnique{model}`
+    method: PrismaMethod
+    """The name of the actions method that this query is for, e.g. `find_unique`"""
+
     method_format: str
+    """Template denoting how the internal method name should be constructed, e.g. `findUnique{model}`"""
 
-    # GraphQL operation
-    operation: str
+    operation: Operation
+    """The GraphQL operatiom e.g. `query`, `mutation`"""
 
-    # prisma model
-    model: Optional[Type[PrismaModel]]
+    model: type[PrismaModel] | None
+    """The Pydantic model that will be used to parse the response.
 
-    # mapping of relational fields to include in the result
-    include: Optional[Dict[str, Any]]
+    Used to extract the model name & build selections.
+    """
 
-    # arguments to pass to the query
-    arguments: Dict[str, Any]
+    include: dict[str, Any] | None
+    """Mapping of relational fields to include in the result"""
 
-    # list of fields to select
-    root_selection: Optional[List[str]]
+    arguments: dict[str, Any]
+    """Arguments to pass to the query"""
+
+    root_selection: list[str] | None
+    """List of fields to select"""
 
     __slots__ = (
+        'method',
         'method_format',
         'operation',
         'model',
@@ -86,21 +131,29 @@ class QueryBuilder:
     def __init__(
         self,
         *,
-        method: str,
-        operation: str,
-        arguments: Dict[str, Any],
-        model: Optional[Type[PrismaModel]] = None,
-        root_selection: Optional[List[str]] = None
+        method: PrismaMethod,
+        arguments: dict[str, Any],
+        model: type[BaseModel] | None = None,
+        root_selection: list[str] | None = None
     ) -> None:
-        self.model = model
-        self.method_format = method
-        self.operation = operation
+        self.method = method
+        self.method_format = METHOD_FORMAT_MAPPING[method]
+        self.operation = METHOD_OPERATION_MAPPING[method]
         self.root_selection = root_selection
         self.arguments = args = self._transform_aliases(arguments)
         self.include = args.pop('include', None)
 
-        if model is not None and not hasattr(model, '__prisma_model__'):
-            raise InvalidModelError(model)
+        # Note: we ignore the `model` argument for raw queries as users may want to pass in a model
+        # that isn't a `PrismaModel` because they've defined it manually & enforcing that
+        # they subclass `PrismaModel` doesn't bring any real benefits.
+        if model is None or method in {'execute_raw', 'query_raw', 'query_first'}:
+            self.model = None
+        else:
+            if not _is_prisma_model_type(model) or not hasattr(model, '__prisma_model__'):
+                raise InvalidModelError(model)
+
+            self.model = model
+
 
     def build(self) -> str:
         """Build the payload that should be sent to the QueryEngine"""
@@ -151,7 +204,7 @@ class QueryBuilder:
         )
         return root
 
-    def get_default_fields(self, model: Type[PrismaModel]) -> List[str]:
+    def get_default_fields(self, model: type[PrismaModel]) -> list[str]:
         """Returns a list of all the scalar fields of a model
 
         Raises UnknownModelError if the current model cannot be found.
@@ -169,7 +222,7 @@ class QueryBuilder:
         return [
             field
             for field, info in model.__fields__.items()
-            if not _field_is_prisma_model(info)
+            if not _field_is_prisma_model(info, parent=model)
         ]
 
     def get_relational_model(self, current_model: Type[PrismaModel], field: str) -> Type[PrismaModel]:
@@ -197,7 +250,7 @@ class QueryBuilder:
         except KeyError as exc:
             raise UnknownRelationalFieldError(model=current_model.__name__, field=field)
 
-        if not _field_is_prisma_model(info):
+        if not _field_is_prisma_model(info, parent=current_model):
             raise RuntimeError(
                 f'The `{field}` field doesn\'t appear to be a Prisma Model type. ' +
                 'Is the field a pydantic.BaseModel type and does it have a `__prisma_model__` class variable?'
@@ -227,12 +280,24 @@ class QueryBuilder:
         return transformed
 
 
-def _field_is_prisma_model(field: ModelField) -> bool:
+def _field_is_prisma_model(field: ModelField, *, parent: type[BaseModel]) -> bool:
   """Whether or not the given field info represents a model at the database level.
 
   This will return `True` for cases where the field represents a list of models or a single model.
   """
+  if isinstance(field.type_, ForwardRef):
+      cls_name = parent.__name__
+      raise RuntimeError(
+        f'Encountered forward reference for {cls_name}.{field.name}; Forward references must be evaluated using {cls_name}.update_forward_refs()'
+      )
+
   return hasattr(field.type_, '__prisma_model__')
+
+
+def _is_prisma_model_type(type_: type[BaseModel]) -> TypeGuard[type[PrismaModel]]:
+    from .bases import _PrismaModel
+
+    return issubclass(type_, _PrismaModel)
 
 
 class AbstractNode(ABC):
@@ -473,11 +538,11 @@ class Arguments(Node):
                     Key(arg, node=Data.create(self.builder, data=value))
                 )
             elif isinstance(value, ITERABLES):
-                # NOTE: we have a special case for execute_raw and query_raw
+                # NOTE: we have a special case for execute_raw, query_raw and query_first
                 # here as prisma expects parameters to be passed as a json string
                 # value like "[\"John\",\"123\"]", and we encode twice to ensure
                 # that only the inner quotes are escaped
-                if self.builder.method_format in {'queryRaw{model}', 'executeRaw{model}'}:
+                if self.builder.method in {'query_raw', 'query_first', 'execute_raw'}:
                     children.append(f'{arg}: {dumps(dumps(value))}')
                 else:
                     children.append(Key(arg, node=ListNode.create(self.builder, data=value)))
@@ -600,9 +665,9 @@ class Selection(Node):
         }
     }
     """
-    model: Optional[Type[PrismaModel]]
-    include: Optional[Dict[str, Any]]
-    root_selection: Optional[List[str]]
+    model: type[PrismaModel] | None
+    include: dict[str, Any] | None
+    root_selection: list[str] | None
 
     __slots__ = (
         'model',
@@ -612,9 +677,9 @@ class Selection(Node):
 
     def __init__(
         self,
-        model: Optional[Type[PrismaModel]] = None,
-        include: Optional[Dict[str, Any]] = None,
-        root_selection: Optional[List[str]] = None,
+        model: type[PrismaModel] | None = None,
+        include: dict[str, Any] | None = None,
+        root_selection: list[str] | None = None,
         **kwargs: Any
     ) -> None:
         super().__init__(**kwargs)

--- a/src/prisma/generator/templates/builder.py.jinja
+++ b/src/prisma/generator/templates/builder.py.jinja
@@ -157,7 +157,7 @@ class QueryBuilder:
 
     def build(self) -> str:
         """Build the payload that should be sent to the QueryEngine"""
-        data = {
+        data: dict[str, object] = {
             'variables': {},
             'operation_name': self.operation,
             'query': self.build_query(),

--- a/src/prisma/generator/templates/client.py.jinja
+++ b/src/prisma/generator/templates/client.py.jinja
@@ -340,9 +340,9 @@ class Prisma:
     {{ maybe_async_def }}_execute(
         self,
         method: PrismaMethod,
-        arguments: Dict[str, Any],
-        model: Optional[Type['_PrismaModel']] = None,
-        root_selection: Optional[List[str]] = None
+        arguments: dict[str, Any],
+        model: type[BaseModel] | None = None,
+        root_selection: list[str] | None = None
     ) -> Any:
         builder = QueryBuilder(
             method=method,

--- a/src/prisma/generator/templates/client.py.jinja
+++ b/src/prisma/generator/templates/client.py.jinja
@@ -1,13 +1,15 @@
 {% set annotations = true %}
 {% include '_header.py.jinja' %}
-{% from '_utils.py.jinja' import is_async, maybe_async_def, maybe_await, methods, operations, recursive_types, active_provider with context %}
+{% from '_utils.py.jinja' import is_async, maybe_async_def, maybe_await, recursive_types, active_provider with context %}
 # -- template client.py.jinja --
 from pathlib import Path
 from types import TracebackType
 
+from pydantic import BaseModel
+
 from . import types, models, errors, actions
 from .types import DatasourceOverride, HttpConfig
-from ._types import BaseModelT
+from ._types import BaseModelT, PrismaMethod
 from .bases import _PrismaModel
 from .engine import AbstractEngine, QueryEngine
 from .builder import QueryBuilder
@@ -239,12 +241,12 @@ class Prisma:
     {% if active_provider != 'mongodb' %}
     {{ maybe_async_def }}execute_raw(self, query: LiteralString, *args: Any) -> int:
         resp = {{ maybe_await }}self._execute(
-            operation='{{ operations.execute_raw }}',
-            method='{{ methods.execute_raw }}',
+            method='execute_raw',
             arguments={
                 'query': query,
                 'parameters': args,
-            }
+            },
+            model=None,
         )
         return int(resp['data']['result'])
 
@@ -316,12 +318,12 @@ class Prisma:
         otherwise results will be raw dictionaries.
         """
         resp = {{ maybe_await }}self._execute(
-            operation='{{ operations.query_raw }}',
-            method='{{ methods.query_raw }}',
+            method='query_raw',
             arguments={
                 'query': query,
                 'parameters': args,
-            }
+            },
+            model=model,
         )
         result = resp['data']['result']
         if model is not None:
@@ -337,14 +339,12 @@ class Prisma:
     # TODO: don't return Any
     {{ maybe_async_def }}_execute(
         self,
-        method: str,
-        operation: str,
+        method: PrismaMethod,
         arguments: Dict[str, Any],
         model: Optional[Type['_PrismaModel']] = None,
         root_selection: Optional[List[str]] = None
     ) -> Any:
         builder = QueryBuilder(
-            operation=operation,
             method=method,
             model=model,
             arguments=arguments,
@@ -438,8 +438,7 @@ class Batch:
     {% if active_provider != 'mongodb' %}
     def execute_raw(self, query: LiteralString, *args: Any) -> None:
         self._add(
-            operation='{{ operations.execute_raw }}',
-            method='{{ methods.execute_raw }}',
+            method='execute_raw',
             arguments={
                 'query': query,
                 'parameters': args,
@@ -487,8 +486,7 @@ class {{ model.name }}BatchActions:
         include: Optional[types.{{ model.name}}Include] = None
     ) -> None:
         self._batcher._add(
-            operation='{{ operations.create }}',
-            method='{{ methods.create }}',
+            method='create',
             model=models.{{ model.name }},
             arguments={
                 'data': data,
@@ -506,8 +504,7 @@ class {{ model.name }}BatchActions:
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         self._batcher._add(
-            operation='{{ operations.create_many }}',
-            method='{{ methods.create_many }}',
+            method='create_many',
             model=models.{{ model.name }},
             arguments={
                 'data': data,
@@ -522,8 +519,7 @@ class {{ model.name }}BatchActions:
         include: Optional[types.{{ model.name}}Include] = None,
     ) -> None:
         self._batcher._add(
-            operation='{{ operations.delete }}',
-            method='{{ methods.delete }}',
+            method='delete',
             model=models.{{ model.name }},
             arguments={
                 'where': where,
@@ -538,8 +534,7 @@ class {{ model.name }}BatchActions:
         include: Optional[types.{{ model.name}}Include] = None
     ) -> None:
         self._batcher._add(
-            operation='{{ operations["update"] }}',
-            method='{{ methods["update"] }}',
+            method='update',
             model=models.{{ model.name }},
             arguments={
                 'data': data,
@@ -555,8 +550,7 @@ class {{ model.name }}BatchActions:
         include: Optional[types.{{ model.name}}Include] = None,
     ) -> None:
         self._batcher._add(
-            operation='{{ operations.upsert }}',
-            method='{{ methods.upsert }}',
+            method='upsert',
             model=models.{{ model.name }},
             arguments={
                 'where': where,
@@ -572,8 +566,7 @@ class {{ model.name }}BatchActions:
         where: types.{{ model.name }}WhereInput,
     ) -> None:
         self._batcher._add(
-            operation='{{ operations.update_many }}',
-            method='{{ methods.update_many }}',
+            method='update_many',
             model=models.{{ model.name }},
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -584,8 +577,7 @@ class {{ model.name }}BatchActions:
         where: Optional[types.{{ model.name }}WhereInput] = None,
     ) -> None:
         self._batcher._add(
-            operation='{{ operations.delete_many }}',
-            method='{{ methods.delete_many }}',
+            method='delete_many',
             model=models.{{ model.name }},
             arguments={'where': where},
             root_selection=['count'],

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[actions.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[actions.py].raw
@@ -181,8 +181,7 @@ class PostActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=self._model,
             arguments={
                 'data': data,
@@ -248,8 +247,7 @@ class PostActions(Generic[_PrismaModelT]):
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         resp = await self._client._execute(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=self._model,
             arguments={
                 'data': data,
@@ -299,8 +297,7 @@ class PostActions(Generic[_PrismaModelT]):
         """
         try:
             resp = await self._client._execute(
-                operation='mutation',
-                method='deleteOne{model}',
+                method='delete',
                 model=self._model,
                 arguments={
                     'where': where,
@@ -351,8 +348,7 @@ class PostActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findUnique{model}',
+            method='find_unique',
             model=self._model,
             arguments={
                 'where': where,
@@ -403,8 +399,7 @@ class PostActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findUnique{model}OrThrow',
+            method='find_unique_or_raise',
             model=self._model,
             arguments={
                 'where': where,
@@ -470,8 +465,7 @@ class PostActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findMany{model}',
+            method='find_many',
             model=self._model,
             arguments={
                 'take': take,
@@ -536,8 +530,7 @@ class PostActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findFirst{model}',
+            method='find_first',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -604,8 +597,7 @@ class PostActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findFirst{model}OrThrow',
+            method='find_first_or_raise',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -662,8 +654,7 @@ class PostActions(Generic[_PrismaModelT]):
         """
         try:
             resp = await self._client._execute(
-                operation='mutation',
-                method='updateOne{model}',
+                method='update',
                 model=self._model,
                 arguments={
                     'data': data,
@@ -727,8 +718,7 @@ class PostActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=self._model,
             arguments={
                 'where': where,
@@ -776,8 +766,7 @@ class PostActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=self._model,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -921,8 +910,7 @@ class PostActions(Generic[_PrismaModelT]):
             ]
 
         resp = await self._client._execute(
-            operation='query',
-            method='aggregate{model}',
+            method='count',
             model=self._model,
             arguments={
                 'take': take,
@@ -967,8 +955,7 @@ class PostActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=self._model,
             arguments={'where': where},
             root_selection=['count'],
@@ -1078,8 +1065,7 @@ class PostActions(Generic[_PrismaModelT]):
                 root_selection.append(_select_fields('_count', count))
 
         resp = await self._client._execute(
-            operation='query',
-            method='groupBy{model}',
+            method='group_by',
             model=self._model,
             arguments={
                 'by': by,
@@ -1226,8 +1212,7 @@ class UserActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=self._model,
             arguments={
                 'data': data,
@@ -1301,8 +1286,7 @@ class UserActions(Generic[_PrismaModelT]):
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         resp = await self._client._execute(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=self._model,
             arguments={
                 'data': data,
@@ -1352,8 +1336,7 @@ class UserActions(Generic[_PrismaModelT]):
         """
         try:
             resp = await self._client._execute(
-                operation='mutation',
-                method='deleteOne{model}',
+                method='delete',
                 model=self._model,
                 arguments={
                     'where': where,
@@ -1404,8 +1387,7 @@ class UserActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findUnique{model}',
+            method='find_unique',
             model=self._model,
             arguments={
                 'where': where,
@@ -1456,8 +1438,7 @@ class UserActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findUnique{model}OrThrow',
+            method='find_unique_or_raise',
             model=self._model,
             arguments={
                 'where': where,
@@ -1523,8 +1504,7 @@ class UserActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findMany{model}',
+            method='find_many',
             model=self._model,
             arguments={
                 'take': take,
@@ -1589,8 +1569,7 @@ class UserActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findFirst{model}',
+            method='find_first',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -1657,8 +1636,7 @@ class UserActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findFirst{model}OrThrow',
+            method='find_first_or_raise',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -1715,8 +1693,7 @@ class UserActions(Generic[_PrismaModelT]):
         """
         try:
             resp = await self._client._execute(
-                operation='mutation',
-                method='updateOne{model}',
+                method='update',
                 model=self._model,
                 arguments={
                     'data': data,
@@ -1788,8 +1765,7 @@ class UserActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=self._model,
             arguments={
                 'where': where,
@@ -1837,8 +1813,7 @@ class UserActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=self._model,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -1982,8 +1957,7 @@ class UserActions(Generic[_PrismaModelT]):
             ]
 
         resp = await self._client._execute(
-            operation='query',
-            method='aggregate{model}',
+            method='count',
             model=self._model,
             arguments={
                 'take': take,
@@ -2028,8 +2002,7 @@ class UserActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=self._model,
             arguments={'where': where},
             root_selection=['count'],
@@ -2139,8 +2112,7 @@ class UserActions(Generic[_PrismaModelT]):
                 root_selection.append(_select_fields('_count', count))
 
         resp = await self._client._execute(
-            operation='query',
-            method='groupBy{model}',
+            method='group_by',
             model=self._model,
             arguments={
                 'by': by,
@@ -2286,8 +2258,7 @@ class MActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=self._model,
             arguments={
                 'data': data,
@@ -2359,8 +2330,7 @@ class MActions(Generic[_PrismaModelT]):
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         resp = await self._client._execute(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=self._model,
             arguments={
                 'data': data,
@@ -2410,8 +2380,7 @@ class MActions(Generic[_PrismaModelT]):
         """
         try:
             resp = await self._client._execute(
-                operation='mutation',
-                method='deleteOne{model}',
+                method='delete',
                 model=self._model,
                 arguments={
                     'where': where,
@@ -2462,8 +2431,7 @@ class MActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findUnique{model}',
+            method='find_unique',
             model=self._model,
             arguments={
                 'where': where,
@@ -2514,8 +2482,7 @@ class MActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findUnique{model}OrThrow',
+            method='find_unique_or_raise',
             model=self._model,
             arguments={
                 'where': where,
@@ -2581,8 +2548,7 @@ class MActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findMany{model}',
+            method='find_many',
             model=self._model,
             arguments={
                 'take': take,
@@ -2647,8 +2613,7 @@ class MActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findFirst{model}',
+            method='find_first',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -2715,8 +2680,7 @@ class MActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findFirst{model}OrThrow',
+            method='find_first_or_raise',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -2773,8 +2737,7 @@ class MActions(Generic[_PrismaModelT]):
         """
         try:
             resp = await self._client._execute(
-                operation='mutation',
-                method='updateOne{model}',
+                method='update',
                 model=self._model,
                 arguments={
                     'data': data,
@@ -2844,8 +2807,7 @@ class MActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=self._model,
             arguments={
                 'where': where,
@@ -2893,8 +2855,7 @@ class MActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=self._model,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -3038,8 +2999,7 @@ class MActions(Generic[_PrismaModelT]):
             ]
 
         resp = await self._client._execute(
-            operation='query',
-            method='aggregate{model}',
+            method='count',
             model=self._model,
             arguments={
                 'take': take,
@@ -3084,8 +3044,7 @@ class MActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=self._model,
             arguments={'where': where},
             root_selection=['count'],
@@ -3195,8 +3154,7 @@ class MActions(Generic[_PrismaModelT]):
                 root_selection.append(_select_fields('_count', count))
 
         resp = await self._client._execute(
-            operation='query',
-            method='groupBy{model}',
+            method='group_by',
             model=self._model,
             arguments={
                 'by': by,
@@ -3343,8 +3301,7 @@ class NActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=self._model,
             arguments={
                 'data': data,
@@ -3418,8 +3375,7 @@ class NActions(Generic[_PrismaModelT]):
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         resp = await self._client._execute(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=self._model,
             arguments={
                 'data': data,
@@ -3469,8 +3425,7 @@ class NActions(Generic[_PrismaModelT]):
         """
         try:
             resp = await self._client._execute(
-                operation='mutation',
-                method='deleteOne{model}',
+                method='delete',
                 model=self._model,
                 arguments={
                     'where': where,
@@ -3521,8 +3476,7 @@ class NActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findUnique{model}',
+            method='find_unique',
             model=self._model,
             arguments={
                 'where': where,
@@ -3573,8 +3527,7 @@ class NActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findUnique{model}OrThrow',
+            method='find_unique_or_raise',
             model=self._model,
             arguments={
                 'where': where,
@@ -3640,8 +3593,7 @@ class NActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findMany{model}',
+            method='find_many',
             model=self._model,
             arguments={
                 'take': take,
@@ -3706,8 +3658,7 @@ class NActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findFirst{model}',
+            method='find_first',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -3774,8 +3725,7 @@ class NActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findFirst{model}OrThrow',
+            method='find_first_or_raise',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -3832,8 +3782,7 @@ class NActions(Generic[_PrismaModelT]):
         """
         try:
             resp = await self._client._execute(
-                operation='mutation',
-                method='updateOne{model}',
+                method='update',
                 model=self._model,
                 arguments={
                     'data': data,
@@ -3905,8 +3854,7 @@ class NActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=self._model,
             arguments={
                 'where': where,
@@ -3954,8 +3902,7 @@ class NActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=self._model,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -4099,8 +4046,7 @@ class NActions(Generic[_PrismaModelT]):
             ]
 
         resp = await self._client._execute(
-            operation='query',
-            method='aggregate{model}',
+            method='count',
             model=self._model,
             arguments={
                 'take': take,
@@ -4145,8 +4091,7 @@ class NActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=self._model,
             arguments={'where': where},
             root_selection=['count'],
@@ -4256,8 +4201,7 @@ class NActions(Generic[_PrismaModelT]):
                 root_selection.append(_select_fields('_count', count))
 
         resp = await self._client._execute(
-            operation='query',
-            method='groupBy{model}',
+            method='group_by',
             model=self._model,
             arguments={
                 'by': by,
@@ -4403,8 +4347,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=self._model,
             arguments={
                 'data': data,
@@ -4476,8 +4419,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         resp = await self._client._execute(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=self._model,
             arguments={
                 'data': data,
@@ -4527,8 +4469,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
         """
         try:
             resp = await self._client._execute(
-                operation='mutation',
-                method='deleteOne{model}',
+                method='delete',
                 model=self._model,
                 arguments={
                     'where': where,
@@ -4579,8 +4520,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findUnique{model}',
+            method='find_unique',
             model=self._model,
             arguments={
                 'where': where,
@@ -4631,8 +4571,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findUnique{model}OrThrow',
+            method='find_unique_or_raise',
             model=self._model,
             arguments={
                 'where': where,
@@ -4698,8 +4637,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findMany{model}',
+            method='find_many',
             model=self._model,
             arguments={
                 'take': take,
@@ -4764,8 +4702,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findFirst{model}',
+            method='find_first',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -4832,8 +4769,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findFirst{model}OrThrow',
+            method='find_first_or_raise',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -4890,8 +4826,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
         """
         try:
             resp = await self._client._execute(
-                operation='mutation',
-                method='updateOne{model}',
+                method='update',
                 model=self._model,
                 arguments={
                     'data': data,
@@ -4961,8 +4896,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=self._model,
             arguments={
                 'where': where,
@@ -5010,8 +4944,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=self._model,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -5155,8 +5088,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
             ]
 
         resp = await self._client._execute(
-            operation='query',
-            method='aggregate{model}',
+            method='count',
             model=self._model,
             arguments={
                 'take': take,
@@ -5201,8 +5133,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=self._model,
             arguments={'where': where},
             root_selection=['count'],
@@ -5312,8 +5243,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
                 root_selection.append(_select_fields('_count', count))
 
         resp = await self._client._execute(
-            operation='query',
-            method='groupBy{model}',
+            method='group_by',
             model=self._model,
             arguments={
                 'by': by,
@@ -5459,8 +5389,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=self._model,
             arguments={
                 'data': data,
@@ -5532,8 +5461,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         resp = await self._client._execute(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=self._model,
             arguments={
                 'data': data,
@@ -5583,8 +5511,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
         """
         try:
             resp = await self._client._execute(
-                operation='mutation',
-                method='deleteOne{model}',
+                method='delete',
                 model=self._model,
                 arguments={
                     'where': where,
@@ -5635,8 +5562,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findUnique{model}',
+            method='find_unique',
             model=self._model,
             arguments={
                 'where': where,
@@ -5687,8 +5613,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findUnique{model}OrThrow',
+            method='find_unique_or_raise',
             model=self._model,
             arguments={
                 'where': where,
@@ -5754,8 +5679,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findMany{model}',
+            method='find_many',
             model=self._model,
             arguments={
                 'take': take,
@@ -5820,8 +5744,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findFirst{model}',
+            method='find_first',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -5888,8 +5811,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findFirst{model}OrThrow',
+            method='find_first_or_raise',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -5946,8 +5868,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
         """
         try:
             resp = await self._client._execute(
-                operation='mutation',
-                method='updateOne{model}',
+                method='update',
                 model=self._model,
                 arguments={
                     'data': data,
@@ -6017,8 +5938,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=self._model,
             arguments={
                 'where': where,
@@ -6066,8 +5986,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=self._model,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -6211,8 +6130,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
             ]
 
         resp = await self._client._execute(
-            operation='query',
-            method='aggregate{model}',
+            method='count',
             model=self._model,
             arguments={
                 'take': take,
@@ -6257,8 +6175,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=self._model,
             arguments={'where': where},
             root_selection=['count'],
@@ -6368,8 +6285,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
                 root_selection.append(_select_fields('_count', count))
 
         resp = await self._client._execute(
-            operation='query',
-            method='groupBy{model}',
+            method='group_by',
             model=self._model,
             arguments={
                 'by': by,
@@ -6510,8 +6426,7 @@ class ListsActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=self._model,
             arguments={
                 'data': data,
@@ -6573,8 +6488,7 @@ class ListsActions(Generic[_PrismaModelT]):
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         resp = await self._client._execute(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=self._model,
             arguments={
                 'data': data,
@@ -6624,8 +6538,7 @@ class ListsActions(Generic[_PrismaModelT]):
         """
         try:
             resp = await self._client._execute(
-                operation='mutation',
-                method='deleteOne{model}',
+                method='delete',
                 model=self._model,
                 arguments={
                     'where': where,
@@ -6676,8 +6589,7 @@ class ListsActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findUnique{model}',
+            method='find_unique',
             model=self._model,
             arguments={
                 'where': where,
@@ -6728,8 +6640,7 @@ class ListsActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findUnique{model}OrThrow',
+            method='find_unique_or_raise',
             model=self._model,
             arguments={
                 'where': where,
@@ -6795,8 +6706,7 @@ class ListsActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findMany{model}',
+            method='find_many',
             model=self._model,
             arguments={
                 'take': take,
@@ -6861,8 +6771,7 @@ class ListsActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findFirst{model}',
+            method='find_first',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -6929,8 +6838,7 @@ class ListsActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findFirst{model}OrThrow',
+            method='find_first_or_raise',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -6987,8 +6895,7 @@ class ListsActions(Generic[_PrismaModelT]):
         """
         try:
             resp = await self._client._execute(
-                operation='mutation',
-                method='updateOne{model}',
+                method='update',
                 model=self._model,
                 arguments={
                     'data': data,
@@ -7048,8 +6955,7 @@ class ListsActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=self._model,
             arguments={
                 'where': where,
@@ -7097,8 +7003,7 @@ class ListsActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=self._model,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -7242,8 +7147,7 @@ class ListsActions(Generic[_PrismaModelT]):
             ]
 
         resp = await self._client._execute(
-            operation='query',
-            method='aggregate{model}',
+            method='count',
             model=self._model,
             arguments={
                 'take': take,
@@ -7288,8 +7192,7 @@ class ListsActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=self._model,
             arguments={'where': where},
             root_selection=['count'],
@@ -7399,8 +7302,7 @@ class ListsActions(Generic[_PrismaModelT]):
                 root_selection.append(_select_fields('_count', count))
 
         resp = await self._client._execute(
-            operation='query',
-            method='groupBy{model}',
+            method='group_by',
             model=self._model,
             arguments={
                 'by': by,
@@ -7545,8 +7447,7 @@ class AActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=self._model,
             arguments={
                 'data': data,
@@ -7616,8 +7517,7 @@ class AActions(Generic[_PrismaModelT]):
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         resp = await self._client._execute(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=self._model,
             arguments={
                 'data': data,
@@ -7667,8 +7567,7 @@ class AActions(Generic[_PrismaModelT]):
         """
         try:
             resp = await self._client._execute(
-                operation='mutation',
-                method='deleteOne{model}',
+                method='delete',
                 model=self._model,
                 arguments={
                     'where': where,
@@ -7719,8 +7618,7 @@ class AActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findUnique{model}',
+            method='find_unique',
             model=self._model,
             arguments={
                 'where': where,
@@ -7771,8 +7669,7 @@ class AActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findUnique{model}OrThrow',
+            method='find_unique_or_raise',
             model=self._model,
             arguments={
                 'where': where,
@@ -7838,8 +7735,7 @@ class AActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findMany{model}',
+            method='find_many',
             model=self._model,
             arguments={
                 'take': take,
@@ -7904,8 +7800,7 @@ class AActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findFirst{model}',
+            method='find_first',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -7972,8 +7867,7 @@ class AActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findFirst{model}OrThrow',
+            method='find_first_or_raise',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -8030,8 +7924,7 @@ class AActions(Generic[_PrismaModelT]):
         """
         try:
             resp = await self._client._execute(
-                operation='mutation',
-                method='updateOne{model}',
+                method='update',
                 model=self._model,
                 arguments={
                     'data': data,
@@ -8097,8 +7990,7 @@ class AActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=self._model,
             arguments={
                 'where': where,
@@ -8146,8 +8038,7 @@ class AActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=self._model,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -8291,8 +8182,7 @@ class AActions(Generic[_PrismaModelT]):
             ]
 
         resp = await self._client._execute(
-            operation='query',
-            method='aggregate{model}',
+            method='count',
             model=self._model,
             arguments={
                 'take': take,
@@ -8337,8 +8227,7 @@ class AActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=self._model,
             arguments={'where': where},
             root_selection=['count'],
@@ -8448,8 +8337,7 @@ class AActions(Generic[_PrismaModelT]):
                 root_selection.append(_select_fields('_count', count))
 
         resp = await self._client._execute(
-            operation='query',
-            method='groupBy{model}',
+            method='group_by',
             model=self._model,
             arguments={
                 'by': by,
@@ -8594,8 +8482,7 @@ class BActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=self._model,
             arguments={
                 'data': data,
@@ -8665,8 +8552,7 @@ class BActions(Generic[_PrismaModelT]):
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         resp = await self._client._execute(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=self._model,
             arguments={
                 'data': data,
@@ -8716,8 +8602,7 @@ class BActions(Generic[_PrismaModelT]):
         """
         try:
             resp = await self._client._execute(
-                operation='mutation',
-                method='deleteOne{model}',
+                method='delete',
                 model=self._model,
                 arguments={
                     'where': where,
@@ -8768,8 +8653,7 @@ class BActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findUnique{model}',
+            method='find_unique',
             model=self._model,
             arguments={
                 'where': where,
@@ -8820,8 +8704,7 @@ class BActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findUnique{model}OrThrow',
+            method='find_unique_or_raise',
             model=self._model,
             arguments={
                 'where': where,
@@ -8887,8 +8770,7 @@ class BActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findMany{model}',
+            method='find_many',
             model=self._model,
             arguments={
                 'take': take,
@@ -8953,8 +8835,7 @@ class BActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findFirst{model}',
+            method='find_first',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -9021,8 +8902,7 @@ class BActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findFirst{model}OrThrow',
+            method='find_first_or_raise',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -9079,8 +8959,7 @@ class BActions(Generic[_PrismaModelT]):
         """
         try:
             resp = await self._client._execute(
-                operation='mutation',
-                method='updateOne{model}',
+                method='update',
                 model=self._model,
                 arguments={
                     'data': data,
@@ -9148,8 +9027,7 @@ class BActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=self._model,
             arguments={
                 'where': where,
@@ -9197,8 +9075,7 @@ class BActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=self._model,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -9342,8 +9219,7 @@ class BActions(Generic[_PrismaModelT]):
             ]
 
         resp = await self._client._execute(
-            operation='query',
-            method='aggregate{model}',
+            method='count',
             model=self._model,
             arguments={
                 'take': take,
@@ -9388,8 +9264,7 @@ class BActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=self._model,
             arguments={'where': where},
             root_selection=['count'],
@@ -9499,8 +9374,7 @@ class BActions(Generic[_PrismaModelT]):
                 root_selection.append(_select_fields('_count', count))
 
         resp = await self._client._execute(
-            operation='query',
-            method='groupBy{model}',
+            method='group_by',
             model=self._model,
             arguments={
                 'by': by,
@@ -9647,8 +9521,7 @@ class CActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=self._model,
             arguments={
                 'data': data,
@@ -9722,8 +9595,7 @@ class CActions(Generic[_PrismaModelT]):
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         resp = await self._client._execute(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=self._model,
             arguments={
                 'data': data,
@@ -9774,8 +9646,7 @@ class CActions(Generic[_PrismaModelT]):
         """
         try:
             resp = await self._client._execute(
-                operation='mutation',
-                method='deleteOne{model}',
+                method='delete',
                 model=self._model,
                 arguments={
                     'where': where,
@@ -9827,8 +9698,7 @@ class CActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findUnique{model}',
+            method='find_unique',
             model=self._model,
             arguments={
                 'where': where,
@@ -9880,8 +9750,7 @@ class CActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findUnique{model}OrThrow',
+            method='find_unique_or_raise',
             model=self._model,
             arguments={
                 'where': where,
@@ -9947,8 +9816,7 @@ class CActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findMany{model}',
+            method='find_many',
             model=self._model,
             arguments={
                 'take': take,
@@ -10013,8 +9881,7 @@ class CActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findFirst{model}',
+            method='find_first',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -10081,8 +9948,7 @@ class CActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findFirst{model}OrThrow',
+            method='find_first_or_raise',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -10140,8 +10006,7 @@ class CActions(Generic[_PrismaModelT]):
         """
         try:
             resp = await self._client._execute(
-                operation='mutation',
-                method='updateOne{model}',
+                method='update',
                 model=self._model,
                 arguments={
                     'data': data,
@@ -10202,8 +10067,7 @@ class CActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=self._model,
             arguments={
                 'where': where,
@@ -10251,8 +10115,7 @@ class CActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=self._model,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -10396,8 +10259,7 @@ class CActions(Generic[_PrismaModelT]):
             ]
 
         resp = await self._client._execute(
-            operation='query',
-            method='aggregate{model}',
+            method='count',
             model=self._model,
             arguments={
                 'take': take,
@@ -10442,8 +10304,7 @@ class CActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=self._model,
             arguments={'where': where},
             root_selection=['count'],
@@ -10553,8 +10414,7 @@ class CActions(Generic[_PrismaModelT]):
                 root_selection.append(_select_fields('_count', count))
 
         resp = await self._client._execute(
-            operation='query',
-            method='groupBy{model}',
+            method='group_by',
             model=self._model,
             arguments={
                 'by': by,
@@ -10700,8 +10560,7 @@ class DActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=self._model,
             arguments={
                 'data': data,
@@ -10773,8 +10632,7 @@ class DActions(Generic[_PrismaModelT]):
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         resp = await self._client._execute(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=self._model,
             arguments={
                 'data': data,
@@ -10824,8 +10682,7 @@ class DActions(Generic[_PrismaModelT]):
         """
         try:
             resp = await self._client._execute(
-                operation='mutation',
-                method='deleteOne{model}',
+                method='delete',
                 model=self._model,
                 arguments={
                     'where': where,
@@ -10876,8 +10733,7 @@ class DActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findUnique{model}',
+            method='find_unique',
             model=self._model,
             arguments={
                 'where': where,
@@ -10928,8 +10784,7 @@ class DActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findUnique{model}OrThrow',
+            method='find_unique_or_raise',
             model=self._model,
             arguments={
                 'where': where,
@@ -10995,8 +10850,7 @@ class DActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findMany{model}',
+            method='find_many',
             model=self._model,
             arguments={
                 'take': take,
@@ -11061,8 +10915,7 @@ class DActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findFirst{model}',
+            method='find_first',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -11129,8 +10982,7 @@ class DActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findFirst{model}OrThrow',
+            method='find_first_or_raise',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -11187,8 +11039,7 @@ class DActions(Generic[_PrismaModelT]):
         """
         try:
             resp = await self._client._execute(
-                operation='mutation',
-                method='updateOne{model}',
+                method='update',
                 model=self._model,
                 arguments={
                     'data': data,
@@ -11258,8 +11109,7 @@ class DActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=self._model,
             arguments={
                 'where': where,
@@ -11307,8 +11157,7 @@ class DActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=self._model,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -11452,8 +11301,7 @@ class DActions(Generic[_PrismaModelT]):
             ]
 
         resp = await self._client._execute(
-            operation='query',
-            method='aggregate{model}',
+            method='count',
             model=self._model,
             arguments={
                 'take': take,
@@ -11498,8 +11346,7 @@ class DActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=self._model,
             arguments={'where': where},
             root_selection=['count'],
@@ -11609,8 +11456,7 @@ class DActions(Generic[_PrismaModelT]):
                 root_selection.append(_select_fields('_count', count))
 
         resp = await self._client._execute(
-            operation='query',
-            method='groupBy{model}',
+            method='group_by',
             model=self._model,
             arguments={
                 'by': by,
@@ -11754,8 +11600,7 @@ class EActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=self._model,
             arguments={
                 'data': data,
@@ -11823,8 +11668,7 @@ class EActions(Generic[_PrismaModelT]):
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         resp = await self._client._execute(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=self._model,
             arguments={
                 'data': data,
@@ -11874,8 +11718,7 @@ class EActions(Generic[_PrismaModelT]):
         """
         try:
             resp = await self._client._execute(
-                operation='mutation',
-                method='deleteOne{model}',
+                method='delete',
                 model=self._model,
                 arguments={
                     'where': where,
@@ -11926,8 +11769,7 @@ class EActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findUnique{model}',
+            method='find_unique',
             model=self._model,
             arguments={
                 'where': where,
@@ -11978,8 +11820,7 @@ class EActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findUnique{model}OrThrow',
+            method='find_unique_or_raise',
             model=self._model,
             arguments={
                 'where': where,
@@ -12045,8 +11886,7 @@ class EActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findMany{model}',
+            method='find_many',
             model=self._model,
             arguments={
                 'take': take,
@@ -12111,8 +11951,7 @@ class EActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findFirst{model}',
+            method='find_first',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -12179,8 +12018,7 @@ class EActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='query',
-            method='findFirst{model}OrThrow',
+            method='find_first_or_raise',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -12237,8 +12075,7 @@ class EActions(Generic[_PrismaModelT]):
         """
         try:
             resp = await self._client._execute(
-                operation='mutation',
-                method='updateOne{model}',
+                method='update',
                 model=self._model,
                 arguments={
                     'data': data,
@@ -12304,8 +12141,7 @@ class EActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=self._model,
             arguments={
                 'where': where,
@@ -12353,8 +12189,7 @@ class EActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=self._model,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -12498,8 +12333,7 @@ class EActions(Generic[_PrismaModelT]):
             ]
 
         resp = await self._client._execute(
-            operation='query',
-            method='aggregate{model}',
+            method='count',
             model=self._model,
             arguments={
                 'take': take,
@@ -12544,8 +12378,7 @@ class EActions(Generic[_PrismaModelT]):
         ```
         """
         resp = await self._client._execute(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=self._model,
             arguments={'where': where},
             root_selection=['count'],
@@ -12655,8 +12488,7 @@ class EActions(Generic[_PrismaModelT]):
                 root_selection.append(_select_fields('_count', count))
 
         resp = await self._client._execute(
-            operation='query',
-            method='groupBy{model}',
+            method='group_by',
             model=self._model,
             arguments={
                 'by': by,
@@ -12682,5 +12514,4 @@ def _select_fields(root: str, select: Mapping[str, Any]) -> str:
 
 
 from . import models
-
 '''

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[builder.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[builder.py].raw
@@ -227,7 +227,7 @@ class QueryBuilder:
 
     def build(self) -> str:
         """Build the payload that should be sent to the QueryEngine"""
-        data = {
+        data: dict[str, object] = {
             'variables': {},
             'operation_name': self.operation,
             'query': self.build_query(),

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[builder.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[builder.py].raw
@@ -41,16 +41,6 @@ from typing_extensions import TypedDict, Literal
 LiteralString = str
 # -- template builder.py.jinja --
 
-# TODO: the QueryBuilder should validate and add type information context.
-#       currently we just naively iterate through arguments and encode them
-#       using standard json when we don't have any special casing for it.
-#       this makes it more difficult to add support for non-standard types
-#       such as the `Json` type.
-# TODO: optimise for performance (switch to c / cython?)
-# TODO: pass context around differently, relying on the builder instance is
-#       not ideal, context should be local to each node
-
-
 import json
 import logging
 import inspect
@@ -58,13 +48,17 @@ from textwrap import indent
 from datetime import timezone
 from abc import abstractmethod, ABC
 from functools import singledispatch
+from typing import ForwardRef
+from typing_extensions import TypeGuard
 
+from pydantic import BaseModel
 from pydantic.fields import ModelField
 
 from . import fields
 from .types import Serializable
 from .errors import UnknownModelError, UnknownRelationalFieldError, InvalidModelError
 from ._constants import QUERY_BUILDER_ALIASES
+from ._types import PrismaMethod
 
 if TYPE_CHECKING:
     from .bases import _PrismaModel as PrismaModel
@@ -122,29 +116,80 @@ RELATIONAL_FIELD_MAPPINGS: Dict[str, Dict[str, str]] = {
     },
 }
 
+METHOD_OPERATION_MAPPING: dict[PrismaMethod, Operation] = {
+    'create': 'mutation',
+    'delete': 'mutation',
+    'update': 'mutation',
+    'upsert': 'mutation',
+    'query_raw': 'mutation',
+    'query_first': 'mutation',
+    'create_many': 'mutation',
+    'execute_raw': 'mutation',
+    'delete_many': 'mutation',
+    'update_many': 'mutation',
+
+    'count': 'query',
+    'group_by': 'query',
+    'find_many': 'query',
+    'find_first': 'query',
+    'find_first_or_raise': 'query',
+    'find_unique': 'query',
+    'find_unique_or_raise': 'query',
+}
+
+METHOD_FORMAT_MAPPING: dict[PrismaMethod, str] = {
+    'create': 'createOne{model}',
+    'delete': 'deleteOne{model}',
+    'update': 'updateOne{model}',
+    'upsert': 'upsertOne{model}',
+    'query_raw': 'queryRaw',
+    'query_first': 'queryRaw',
+    'create_many': 'createMany{model}',
+    'execute_raw': 'executeRaw',
+    'delete_many': 'deleteMany{model}',
+    'update_many': 'updateMany{model}',
+
+    'count': 'aggregate{model}',
+    'group_by': 'groupBy{model}',
+    'find_many': 'findMany{model}',
+    'find_first': 'findFirst{model}',
+    'find_first_or_raise': 'findFirst{model}OrThrow',
+    'find_unique': 'findUnique{model}',
+    'find_unique_or_raise': 'findUnique{model}OrThrow',
+}
+
 MISSING = object()
+Operation = Literal['query', 'mutation']
+
 
 
 class QueryBuilder:
-    # prisma method format, e.g. `findUnique{model}`
+    method: PrismaMethod
+    """The name of the actions method that this query is for, e.g. `find_unique`"""
+
     method_format: str
+    """Template denoting how the internal method name should be constructed, e.g. `findUnique{model}`"""
 
-    # GraphQL operation
-    operation: str
+    operation: Operation
+    """The GraphQL operatiom e.g. `query`, `mutation`"""
 
-    # prisma model
-    model: Optional[Type[PrismaModel]]
+    model: type[PrismaModel] | None
+    """The Pydantic model that will be used to parse the response.
 
-    # mapping of relational fields to include in the result
-    include: Optional[Dict[str, Any]]
+    Used to extract the model name & build selections.
+    """
 
-    # arguments to pass to the query
-    arguments: Dict[str, Any]
+    include: dict[str, Any] | None
+    """Mapping of relational fields to include in the result"""
 
-    # list of fields to select
-    root_selection: Optional[List[str]]
+    arguments: dict[str, Any]
+    """Arguments to pass to the query"""
+
+    root_selection: list[str] | None
+    """List of fields to select"""
 
     __slots__ = (
+        'method',
         'method_format',
         'operation',
         'model',
@@ -156,21 +201,29 @@ class QueryBuilder:
     def __init__(
         self,
         *,
-        method: str,
-        operation: str,
-        arguments: Dict[str, Any],
-        model: Optional[Type[PrismaModel]] = None,
-        root_selection: Optional[List[str]] = None
+        method: PrismaMethod,
+        arguments: dict[str, Any],
+        model: type[BaseModel] | None = None,
+        root_selection: list[str] | None = None
     ) -> None:
-        self.model = model
-        self.method_format = method
-        self.operation = operation
+        self.method = method
+        self.method_format = METHOD_FORMAT_MAPPING[method]
+        self.operation = METHOD_OPERATION_MAPPING[method]
         self.root_selection = root_selection
         self.arguments = args = self._transform_aliases(arguments)
         self.include = args.pop('include', None)
 
-        if model is not None and not hasattr(model, '__prisma_model__'):
-            raise InvalidModelError(model)
+        # Note: we ignore the `model` argument for raw queries as users may want to pass in a model
+        # that isn't a `PrismaModel` because they've defined it manually & enforcing that
+        # they subclass `PrismaModel` doesn't bring any real benefits.
+        if model is None or method in {'execute_raw', 'query_raw', 'query_first'}:
+            self.model = None
+        else:
+            if not _is_prisma_model_type(model) or not hasattr(model, '__prisma_model__'):
+                raise InvalidModelError(model)
+
+            self.model = model
+
 
     def build(self) -> str:
         """Build the payload that should be sent to the QueryEngine"""
@@ -221,7 +274,7 @@ class QueryBuilder:
         )
         return root
 
-    def get_default_fields(self, model: Type[PrismaModel]) -> List[str]:
+    def get_default_fields(self, model: type[PrismaModel]) -> list[str]:
         """Returns a list of all the scalar fields of a model
 
         Raises UnknownModelError if the current model cannot be found.
@@ -239,7 +292,7 @@ class QueryBuilder:
         return [
             field
             for field, info in model.__fields__.items()
-            if not _field_is_prisma_model(info)
+            if not _field_is_prisma_model(info, parent=model)
         ]
 
     def get_relational_model(self, current_model: Type[PrismaModel], field: str) -> Type[PrismaModel]:
@@ -267,7 +320,7 @@ class QueryBuilder:
         except KeyError as exc:
             raise UnknownRelationalFieldError(model=current_model.__name__, field=field)
 
-        if not _field_is_prisma_model(info):
+        if not _field_is_prisma_model(info, parent=current_model):
             raise RuntimeError(
                 f'The `{field}` field doesn\'t appear to be a Prisma Model type. ' +
                 'Is the field a pydantic.BaseModel type and does it have a `__prisma_model__` class variable?'
@@ -297,12 +350,24 @@ class QueryBuilder:
         return transformed
 
 
-def _field_is_prisma_model(field: ModelField) -> bool:
+def _field_is_prisma_model(field: ModelField, *, parent: type[BaseModel]) -> bool:
   """Whether or not the given field info represents a model at the database level.
 
   This will return `True` for cases where the field represents a list of models or a single model.
   """
+  if isinstance(field.type_, ForwardRef):
+      cls_name = parent.__name__
+      raise RuntimeError(
+        f'Encountered forward reference for {cls_name}.{field.name}; Forward references must be evaluated using {cls_name}.update_forward_refs()'
+      )
+
   return hasattr(field.type_, '__prisma_model__')
+
+
+def _is_prisma_model_type(type_: type[BaseModel]) -> TypeGuard[type[PrismaModel]]:
+    from .bases import _PrismaModel
+
+    return issubclass(type_, _PrismaModel)
 
 
 class AbstractNode(ABC):
@@ -542,11 +607,11 @@ class Arguments(Node):
                     Key(arg, node=Data.create(self.builder, data=value))
                 )
             elif isinstance(value, ITERABLES):
-                # NOTE: we have a special case for execute_raw and query_raw
+                # NOTE: we have a special case for execute_raw, query_raw and query_first
                 # here as prisma expects parameters to be passed as a json string
                 # value like "[\"John\",\"123\"]", and we encode twice to ensure
                 # that only the inner quotes are escaped
-                if self.builder.method_format in {'queryRaw{model}', 'executeRaw{model}'}:
+                if self.builder.method in {'query_raw', 'query_first', 'execute_raw'}:
                     children.append(f'{arg}: {dumps(dumps(value))}')
                 else:
                     children.append(Key(arg, node=ListNode.create(self.builder, data=value)))
@@ -669,9 +734,9 @@ class Selection(Node):
         }
     }
     """
-    model: Optional[Type[PrismaModel]]
-    include: Optional[Dict[str, Any]]
-    root_selection: Optional[List[str]]
+    model: type[PrismaModel] | None
+    include: dict[str, Any] | None
+    root_selection: list[str] | None
 
     __slots__ = (
         'model',
@@ -681,9 +746,9 @@ class Selection(Node):
 
     def __init__(
         self,
-        model: Optional[Type[PrismaModel]] = None,
-        include: Optional[Dict[str, Any]] = None,
-        root_selection: Optional[List[str]] = None,
+        model: type[PrismaModel] | None = None,
+        include: dict[str, Any] | None = None,
+        root_selection: list[str] | None = None,
         **kwargs: Any
     ) -> None:
         super().__init__(**kwargs)

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
@@ -50,8 +50,7 @@ from .types import DatasourceOverride, HttpConfig
 from ._types import BaseModelT, PrismaMethod
 from .bases import _PrismaModel
 from .engine import AbstractEngine, QueryEngine
-from .builder import QueryBuilder, Operation
-from .middleware import MiddlewareFunc, MiddlewareParams, MiddlewareResult
+from .builder import QueryBuilder
 from .generator.models import EngineType, OptionalValueFromEnvVar, BinaryPaths
 from ._compat import removeprefix
 from ._raw_query import deserialize_raw_results
@@ -187,7 +186,6 @@ class Prisma:
         '_datasource',
         '_connect_timeout',
         '_http_config',
-        '_middlewares',
     )
 
     def __init__(
@@ -218,7 +216,6 @@ class Prisma:
         self._datasource = datasource
         self._connect_timeout = connect_timeout
         self._http_config: HttpConfig = http or {}
-        self._middlewares: List[MiddlewareFunc] = []
 
         if use_dotenv:
             load_env()
@@ -281,15 +278,6 @@ class Prisma:
             self.__engine.stop(timeout=timeout)
             self.__engine = None
 
-    # TODO: add support for clearing middlewares
-
-    def use(self, *middlewares: MiddlewareFunc) -> None:
-        """Setup a middleware function to be called before each query is executed.
-
-        TODO: link to docs
-        """
-        self._middlewares.extend(middlewares)
-
     async def execute_raw(self, query: LiteralString, *args: Any) -> int:
         resp = await self._execute(
             method='execute_raw',
@@ -331,18 +319,9 @@ class Prisma:
         """
         results: Sequence[Union[BaseModelT, dict[str, Any]]]
         if model is not None:
-            results = await self._execute_raw_query(
-                query,
-                *args,
-                model=model,
-                _from_method='query_first',
-            )
+            results = await self.query_raw(query, *args, model=model)
         else:
-            results = await self._execute_raw_query(
-                query,
-                *args,
-                _from_method='query_first',
-            )
+            results = await self.query_raw(query, *args)
 
         if not results:
             return None
@@ -377,44 +356,8 @@ class Prisma:
         If model is given, each returned record is converted to the pydantic model first,
         otherwise results will be raw dictionaries.
         """
-        if model is not None:
-            return await self._execute_raw_query(
-                query, *args, model=model, _from_method='query_raw'
-            )
-
-        return await self._execute_raw_query(
-            query, *args, _from_method='query_raw'
-        )
-
-
-    @overload
-    async def _execute_raw_query(
-        self,
-        query: LiteralString,
-        *args: Any,
-        _from_method: PrismaMethod,
-    ) -> list[dict[str, Any]]:
-        ...
-
-    @overload
-    async def _execute_raw_query(
-        self,
-        query: LiteralString,
-        *args: Any,
-        _from_method: PrismaMethod,
-        model: Type[BaseModelT],
-    ) -> list[BaseModelT]:
-        ...
-
-    async def _execute_raw_query(
-        self,
-        query: LiteralString,
-        *args: Any,
-        _from_method: PrismaMethod,
-        model: Type[BaseModelT] | None = None,
-    ) -> list[BaseModelT] | list[dict[str, Any]]:
         resp = await self._execute(
-            method=_from_method,
+            method='query_raw',
             arguments={
                 'query': query,
                 'parameters': args,
@@ -427,7 +370,6 @@ class Prisma:
 
         return deserialize_raw_results(result)
 
-
     def batch_(self) -> 'Batch':
         """Returns a context manager for grouping write queries into a single transaction."""
         return Batch(client=self)
@@ -435,42 +377,18 @@ class Prisma:
     # TODO: don't return Any
     async def _execute(
         self,
-        *,
         method: PrismaMethod,
-        arguments: dict[str, Any],
-        model: type[BaseModel] | None,
-        root_selection: list[str] | None = None
+        arguments: Dict[str, Any],
+        model: Optional[Type['_PrismaModel']] = None,
+        root_selection: Optional[List[str]] = None
     ) -> Any:
-        async def executor(params: MiddlewareParams) -> MiddlewareResult:
-            builder = QueryBuilder(
-                method=params.method,
-                model=params.model,
-                arguments=params.arguments,
-                # TODO: move this to middleware params too
-                root_selection=root_selection,
-            )
-            return await self._engine.query(builder.build())
-
-        # TODO: should this also operate on the parsed return type? (yes)
-        async def get_result(params: MiddlewareParams) -> MiddlewareResult:
-            try:
-                middleware = next(iterator)
-            except StopIteration:
-                return await executor(params)
-
-            return await middleware(params, get_result)
-
-        params = MiddlewareParams(
+        builder = QueryBuilder(
             method=method,
             model=model,
             arguments=arguments,
+            root_selection=root_selection,
         )
-        if not self._middlewares:
-            return await executor(params)
-
-        first, *rest = self._middlewares
-        iterator = iter(rest)
-        return await first(params, get_result)
+        return await self._engine.query(builder.build())
 
     def _create_engine(self, dml_path: Path = PACKAGED_SCHEMA_PATH) -> AbstractEngine:
         if ENGINE_TYPE == EngineType.binary:

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
@@ -378,9 +378,9 @@ class Prisma:
     async def _execute(
         self,
         method: PrismaMethod,
-        arguments: Dict[str, Any],
-        model: Optional[Type['_PrismaModel']] = None,
-        root_selection: Optional[List[str]] = None
+        arguments: dict[str, Any],
+        model: type[BaseModel] | None = None,
+        root_selection: list[str] | None = None
     ) -> Any:
         builder = QueryBuilder(
             method=method,

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
@@ -43,12 +43,15 @@ LiteralString = str
 from pathlib import Path
 from types import TracebackType
 
+from pydantic import BaseModel
+
 from . import types, models, errors, actions
 from .types import DatasourceOverride, HttpConfig
-from ._types import BaseModelT
+from ._types import BaseModelT, PrismaMethod
 from .bases import _PrismaModel
 from .engine import AbstractEngine, QueryEngine
-from .builder import QueryBuilder
+from .builder import QueryBuilder, Operation
+from .middleware import MiddlewareFunc, MiddlewareParams, MiddlewareResult
 from .generator.models import EngineType, OptionalValueFromEnvVar, BinaryPaths
 from ._compat import removeprefix
 from ._raw_query import deserialize_raw_results
@@ -184,6 +187,7 @@ class Prisma:
         '_datasource',
         '_connect_timeout',
         '_http_config',
+        '_middlewares',
     )
 
     def __init__(
@@ -214,6 +218,7 @@ class Prisma:
         self._datasource = datasource
         self._connect_timeout = connect_timeout
         self._http_config: HttpConfig = http or {}
+        self._middlewares: List[MiddlewareFunc] = []
 
         if use_dotenv:
             load_env()
@@ -276,14 +281,23 @@ class Prisma:
             self.__engine.stop(timeout=timeout)
             self.__engine = None
 
+    # TODO: add support for clearing middlewares
+
+    def use(self, *middlewares: MiddlewareFunc) -> None:
+        """Setup a middleware function to be called before each query is executed.
+
+        TODO: link to docs
+        """
+        self._middlewares.extend(middlewares)
+
     async def execute_raw(self, query: LiteralString, *args: Any) -> int:
         resp = await self._execute(
-            operation='mutation',
-            method='executeRaw{model}',
+            method='execute_raw',
             arguments={
                 'query': query,
                 'parameters': args,
-            }
+            },
+            model=None,
         )
         return int(resp['data']['result'])
 
@@ -317,9 +331,18 @@ class Prisma:
         """
         results: Sequence[Union[BaseModelT, dict[str, Any]]]
         if model is not None:
-            results = await self.query_raw(query, *args, model=model)
+            results = await self._execute_raw_query(
+                query,
+                *args,
+                model=model,
+                _from_method='query_first',
+            )
         else:
-            results = await self.query_raw(query, *args)
+            results = await self._execute_raw_query(
+                query,
+                *args,
+                _from_method='query_first',
+            )
 
         if not results:
             return None
@@ -354,19 +377,56 @@ class Prisma:
         If model is given, each returned record is converted to the pydantic model first,
         otherwise results will be raw dictionaries.
         """
+        if model is not None:
+            return await self._execute_raw_query(
+                query, *args, model=model, _from_method='query_raw'
+            )
+
+        return await self._execute_raw_query(
+            query, *args, _from_method='query_raw'
+        )
+
+
+    @overload
+    async def _execute_raw_query(
+        self,
+        query: LiteralString,
+        *args: Any,
+        _from_method: PrismaMethod,
+    ) -> list[dict[str, Any]]:
+        ...
+
+    @overload
+    async def _execute_raw_query(
+        self,
+        query: LiteralString,
+        *args: Any,
+        _from_method: PrismaMethod,
+        model: Type[BaseModelT],
+    ) -> list[BaseModelT]:
+        ...
+
+    async def _execute_raw_query(
+        self,
+        query: LiteralString,
+        *args: Any,
+        _from_method: PrismaMethod,
+        model: Type[BaseModelT] | None = None,
+    ) -> list[BaseModelT] | list[dict[str, Any]]:
         resp = await self._execute(
-            operation='mutation',
-            method='queryRaw{model}',
+            method=_from_method,
             arguments={
                 'query': query,
                 'parameters': args,
-            }
+            },
+            model=model,
         )
         result = resp['data']['result']
         if model is not None:
             return deserialize_raw_results(result, model=model)
 
         return deserialize_raw_results(result)
+
 
     def batch_(self) -> 'Batch':
         """Returns a context manager for grouping write queries into a single transaction."""
@@ -375,20 +435,42 @@ class Prisma:
     # TODO: don't return Any
     async def _execute(
         self,
-        method: str,
-        operation: str,
-        arguments: Dict[str, Any],
-        model: Optional[Type['_PrismaModel']] = None,
-        root_selection: Optional[List[str]] = None
+        *,
+        method: PrismaMethod,
+        arguments: dict[str, Any],
+        model: type[BaseModel] | None,
+        root_selection: list[str] | None = None
     ) -> Any:
-        builder = QueryBuilder(
-            operation=operation,
+        async def executor(params: MiddlewareParams) -> MiddlewareResult:
+            builder = QueryBuilder(
+                method=params.method,
+                model=params.model,
+                arguments=params.arguments,
+                # TODO: move this to middleware params too
+                root_selection=root_selection,
+            )
+            return await self._engine.query(builder.build())
+
+        # TODO: should this also operate on the parsed return type? (yes)
+        async def get_result(params: MiddlewareParams) -> MiddlewareResult:
+            try:
+                middleware = next(iterator)
+            except StopIteration:
+                return await executor(params)
+
+            return await middleware(params, get_result)
+
+        params = MiddlewareParams(
             method=method,
             model=model,
             arguments=arguments,
-            root_selection=root_selection,
         )
-        return await self._engine.query(builder.build())
+        if not self._middlewares:
+            return await executor(params)
+
+        first, *rest = self._middlewares
+        iterator = iter(rest)
+        return await first(params, get_result)
 
     def _create_engine(self, dml_path: Path = PACKAGED_SCHEMA_PATH) -> AbstractEngine:
         if ENGINE_TYPE == EngineType.binary:
@@ -493,8 +575,7 @@ class Batch:
 
     def execute_raw(self, query: LiteralString, *args: Any) -> None:
         self._add(
-            operation='mutation',
-            method='executeRaw{model}',
+            method='execute_raw',
             arguments={
                 'query': query,
                 'parameters': args,
@@ -526,8 +607,7 @@ class PostBatchActions:
         include: Optional[types.PostInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=models.Post,
             arguments={
                 'data': data,
@@ -545,8 +625,7 @@ class PostBatchActions:
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         self._batcher._add(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=models.Post,
             arguments={
                 'data': data,
@@ -561,8 +640,7 @@ class PostBatchActions:
         include: Optional[types.PostInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteOne{model}',
+            method='delete',
             model=models.Post,
             arguments={
                 'where': where,
@@ -577,8 +655,7 @@ class PostBatchActions:
         include: Optional[types.PostInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateOne{model}',
+            method='update',
             model=models.Post,
             arguments={
                 'data': data,
@@ -594,8 +671,7 @@ class PostBatchActions:
         include: Optional[types.PostInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=models.Post,
             arguments={
                 'where': where,
@@ -611,8 +687,7 @@ class PostBatchActions:
         where: types.PostWhereInput,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=models.Post,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -623,8 +698,7 @@ class PostBatchActions:
         where: Optional[types.PostWhereInput] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=models.Post,
             arguments={'where': where},
             root_selection=['count'],
@@ -644,8 +718,7 @@ class UserBatchActions:
         include: Optional[types.UserInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=models.User,
             arguments={
                 'data': data,
@@ -663,8 +736,7 @@ class UserBatchActions:
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         self._batcher._add(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=models.User,
             arguments={
                 'data': data,
@@ -679,8 +751,7 @@ class UserBatchActions:
         include: Optional[types.UserInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteOne{model}',
+            method='delete',
             model=models.User,
             arguments={
                 'where': where,
@@ -695,8 +766,7 @@ class UserBatchActions:
         include: Optional[types.UserInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateOne{model}',
+            method='update',
             model=models.User,
             arguments={
                 'data': data,
@@ -712,8 +782,7 @@ class UserBatchActions:
         include: Optional[types.UserInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=models.User,
             arguments={
                 'where': where,
@@ -729,8 +798,7 @@ class UserBatchActions:
         where: types.UserWhereInput,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=models.User,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -741,8 +809,7 @@ class UserBatchActions:
         where: Optional[types.UserWhereInput] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=models.User,
             arguments={'where': where},
             root_selection=['count'],
@@ -762,8 +829,7 @@ class MBatchActions:
         include: Optional[types.MInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=models.M,
             arguments={
                 'data': data,
@@ -781,8 +847,7 @@ class MBatchActions:
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         self._batcher._add(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=models.M,
             arguments={
                 'data': data,
@@ -797,8 +862,7 @@ class MBatchActions:
         include: Optional[types.MInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteOne{model}',
+            method='delete',
             model=models.M,
             arguments={
                 'where': where,
@@ -813,8 +877,7 @@ class MBatchActions:
         include: Optional[types.MInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateOne{model}',
+            method='update',
             model=models.M,
             arguments={
                 'data': data,
@@ -830,8 +893,7 @@ class MBatchActions:
         include: Optional[types.MInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=models.M,
             arguments={
                 'where': where,
@@ -847,8 +909,7 @@ class MBatchActions:
         where: types.MWhereInput,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=models.M,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -859,8 +920,7 @@ class MBatchActions:
         where: Optional[types.MWhereInput] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=models.M,
             arguments={'where': where},
             root_selection=['count'],
@@ -880,8 +940,7 @@ class NBatchActions:
         include: Optional[types.NInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=models.N,
             arguments={
                 'data': data,
@@ -899,8 +958,7 @@ class NBatchActions:
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         self._batcher._add(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=models.N,
             arguments={
                 'data': data,
@@ -915,8 +973,7 @@ class NBatchActions:
         include: Optional[types.NInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteOne{model}',
+            method='delete',
             model=models.N,
             arguments={
                 'where': where,
@@ -931,8 +988,7 @@ class NBatchActions:
         include: Optional[types.NInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateOne{model}',
+            method='update',
             model=models.N,
             arguments={
                 'data': data,
@@ -948,8 +1004,7 @@ class NBatchActions:
         include: Optional[types.NInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=models.N,
             arguments={
                 'where': where,
@@ -965,8 +1020,7 @@ class NBatchActions:
         where: types.NWhereInput,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=models.N,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -977,8 +1031,7 @@ class NBatchActions:
         where: Optional[types.NWhereInput] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=models.N,
             arguments={'where': where},
             root_selection=['count'],
@@ -998,8 +1051,7 @@ class OneOptionalBatchActions:
         include: Optional[types.OneOptionalInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=models.OneOptional,
             arguments={
                 'data': data,
@@ -1017,8 +1069,7 @@ class OneOptionalBatchActions:
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         self._batcher._add(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=models.OneOptional,
             arguments={
                 'data': data,
@@ -1033,8 +1084,7 @@ class OneOptionalBatchActions:
         include: Optional[types.OneOptionalInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteOne{model}',
+            method='delete',
             model=models.OneOptional,
             arguments={
                 'where': where,
@@ -1049,8 +1099,7 @@ class OneOptionalBatchActions:
         include: Optional[types.OneOptionalInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateOne{model}',
+            method='update',
             model=models.OneOptional,
             arguments={
                 'data': data,
@@ -1066,8 +1115,7 @@ class OneOptionalBatchActions:
         include: Optional[types.OneOptionalInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=models.OneOptional,
             arguments={
                 'where': where,
@@ -1083,8 +1131,7 @@ class OneOptionalBatchActions:
         where: types.OneOptionalWhereInput,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=models.OneOptional,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -1095,8 +1142,7 @@ class OneOptionalBatchActions:
         where: Optional[types.OneOptionalWhereInput] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=models.OneOptional,
             arguments={'where': where},
             root_selection=['count'],
@@ -1116,8 +1162,7 @@ class ManyRequiredBatchActions:
         include: Optional[types.ManyRequiredInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=models.ManyRequired,
             arguments={
                 'data': data,
@@ -1135,8 +1180,7 @@ class ManyRequiredBatchActions:
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         self._batcher._add(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=models.ManyRequired,
             arguments={
                 'data': data,
@@ -1151,8 +1195,7 @@ class ManyRequiredBatchActions:
         include: Optional[types.ManyRequiredInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteOne{model}',
+            method='delete',
             model=models.ManyRequired,
             arguments={
                 'where': where,
@@ -1167,8 +1210,7 @@ class ManyRequiredBatchActions:
         include: Optional[types.ManyRequiredInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateOne{model}',
+            method='update',
             model=models.ManyRequired,
             arguments={
                 'data': data,
@@ -1184,8 +1226,7 @@ class ManyRequiredBatchActions:
         include: Optional[types.ManyRequiredInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=models.ManyRequired,
             arguments={
                 'where': where,
@@ -1201,8 +1242,7 @@ class ManyRequiredBatchActions:
         where: types.ManyRequiredWhereInput,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=models.ManyRequired,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -1213,8 +1253,7 @@ class ManyRequiredBatchActions:
         where: Optional[types.ManyRequiredWhereInput] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=models.ManyRequired,
             arguments={'where': where},
             root_selection=['count'],
@@ -1234,8 +1273,7 @@ class ListsBatchActions:
         include: Optional[types.ListsInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=models.Lists,
             arguments={
                 'data': data,
@@ -1253,8 +1291,7 @@ class ListsBatchActions:
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         self._batcher._add(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=models.Lists,
             arguments={
                 'data': data,
@@ -1269,8 +1306,7 @@ class ListsBatchActions:
         include: Optional[types.ListsInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteOne{model}',
+            method='delete',
             model=models.Lists,
             arguments={
                 'where': where,
@@ -1285,8 +1321,7 @@ class ListsBatchActions:
         include: Optional[types.ListsInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateOne{model}',
+            method='update',
             model=models.Lists,
             arguments={
                 'data': data,
@@ -1302,8 +1337,7 @@ class ListsBatchActions:
         include: Optional[types.ListsInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=models.Lists,
             arguments={
                 'where': where,
@@ -1319,8 +1353,7 @@ class ListsBatchActions:
         where: types.ListsWhereInput,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=models.Lists,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -1331,8 +1364,7 @@ class ListsBatchActions:
         where: Optional[types.ListsWhereInput] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=models.Lists,
             arguments={'where': where},
             root_selection=['count'],
@@ -1352,8 +1384,7 @@ class ABatchActions:
         include: Optional[types.AInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=models.A,
             arguments={
                 'data': data,
@@ -1371,8 +1402,7 @@ class ABatchActions:
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         self._batcher._add(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=models.A,
             arguments={
                 'data': data,
@@ -1387,8 +1417,7 @@ class ABatchActions:
         include: Optional[types.AInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteOne{model}',
+            method='delete',
             model=models.A,
             arguments={
                 'where': where,
@@ -1403,8 +1432,7 @@ class ABatchActions:
         include: Optional[types.AInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateOne{model}',
+            method='update',
             model=models.A,
             arguments={
                 'data': data,
@@ -1420,8 +1448,7 @@ class ABatchActions:
         include: Optional[types.AInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=models.A,
             arguments={
                 'where': where,
@@ -1437,8 +1464,7 @@ class ABatchActions:
         where: types.AWhereInput,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=models.A,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -1449,8 +1475,7 @@ class ABatchActions:
         where: Optional[types.AWhereInput] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=models.A,
             arguments={'where': where},
             root_selection=['count'],
@@ -1470,8 +1495,7 @@ class BBatchActions:
         include: Optional[types.BInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=models.B,
             arguments={
                 'data': data,
@@ -1489,8 +1513,7 @@ class BBatchActions:
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         self._batcher._add(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=models.B,
             arguments={
                 'data': data,
@@ -1505,8 +1528,7 @@ class BBatchActions:
         include: Optional[types.BInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteOne{model}',
+            method='delete',
             model=models.B,
             arguments={
                 'where': where,
@@ -1521,8 +1543,7 @@ class BBatchActions:
         include: Optional[types.BInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateOne{model}',
+            method='update',
             model=models.B,
             arguments={
                 'data': data,
@@ -1538,8 +1559,7 @@ class BBatchActions:
         include: Optional[types.BInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=models.B,
             arguments={
                 'where': where,
@@ -1555,8 +1575,7 @@ class BBatchActions:
         where: types.BWhereInput,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=models.B,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -1567,8 +1586,7 @@ class BBatchActions:
         where: Optional[types.BWhereInput] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=models.B,
             arguments={'where': where},
             root_selection=['count'],
@@ -1588,8 +1606,7 @@ class CBatchActions:
         include: Optional[types.CInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=models.C,
             arguments={
                 'data': data,
@@ -1607,8 +1624,7 @@ class CBatchActions:
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         self._batcher._add(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=models.C,
             arguments={
                 'data': data,
@@ -1623,8 +1639,7 @@ class CBatchActions:
         include: Optional[types.CInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteOne{model}',
+            method='delete',
             model=models.C,
             arguments={
                 'where': where,
@@ -1639,8 +1654,7 @@ class CBatchActions:
         include: Optional[types.CInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateOne{model}',
+            method='update',
             model=models.C,
             arguments={
                 'data': data,
@@ -1656,8 +1670,7 @@ class CBatchActions:
         include: Optional[types.CInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=models.C,
             arguments={
                 'where': where,
@@ -1673,8 +1686,7 @@ class CBatchActions:
         where: types.CWhereInput,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=models.C,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -1685,8 +1697,7 @@ class CBatchActions:
         where: Optional[types.CWhereInput] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=models.C,
             arguments={'where': where},
             root_selection=['count'],
@@ -1706,8 +1717,7 @@ class DBatchActions:
         include: Optional[types.DInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=models.D,
             arguments={
                 'data': data,
@@ -1725,8 +1735,7 @@ class DBatchActions:
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         self._batcher._add(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=models.D,
             arguments={
                 'data': data,
@@ -1741,8 +1750,7 @@ class DBatchActions:
         include: Optional[types.DInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteOne{model}',
+            method='delete',
             model=models.D,
             arguments={
                 'where': where,
@@ -1757,8 +1765,7 @@ class DBatchActions:
         include: Optional[types.DInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateOne{model}',
+            method='update',
             model=models.D,
             arguments={
                 'data': data,
@@ -1774,8 +1781,7 @@ class DBatchActions:
         include: Optional[types.DInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=models.D,
             arguments={
                 'where': where,
@@ -1791,8 +1797,7 @@ class DBatchActions:
         where: types.DWhereInput,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=models.D,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -1803,8 +1808,7 @@ class DBatchActions:
         where: Optional[types.DWhereInput] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=models.D,
             arguments={'where': where},
             root_selection=['count'],
@@ -1824,8 +1828,7 @@ class EBatchActions:
         include: Optional[types.EInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=models.E,
             arguments={
                 'data': data,
@@ -1843,8 +1846,7 @@ class EBatchActions:
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         self._batcher._add(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=models.E,
             arguments={
                 'data': data,
@@ -1859,8 +1861,7 @@ class EBatchActions:
         include: Optional[types.EInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteOne{model}',
+            method='delete',
             model=models.E,
             arguments={
                 'where': where,
@@ -1875,8 +1876,7 @@ class EBatchActions:
         include: Optional[types.EInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateOne{model}',
+            method='update',
             model=models.E,
             arguments={
                 'data': data,
@@ -1892,8 +1892,7 @@ class EBatchActions:
         include: Optional[types.EInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=models.E,
             arguments={
                 'where': where,
@@ -1909,8 +1908,7 @@ class EBatchActions:
         where: types.EWhereInput,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=models.E,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -1921,8 +1919,7 @@ class EBatchActions:
         where: Optional[types.EWhereInput] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=models.E,
             arguments={'where': where},
             root_selection=['count'],

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[actions.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[actions.py].raw
@@ -181,8 +181,7 @@ class PostActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=self._model,
             arguments={
                 'data': data,
@@ -248,8 +247,7 @@ class PostActions(Generic[_PrismaModelT]):
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         resp = self._client._execute(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=self._model,
             arguments={
                 'data': data,
@@ -299,8 +297,7 @@ class PostActions(Generic[_PrismaModelT]):
         """
         try:
             resp = self._client._execute(
-                operation='mutation',
-                method='deleteOne{model}',
+                method='delete',
                 model=self._model,
                 arguments={
                     'where': where,
@@ -351,8 +348,7 @@ class PostActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findUnique{model}',
+            method='find_unique',
             model=self._model,
             arguments={
                 'where': where,
@@ -403,8 +399,7 @@ class PostActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findUnique{model}OrThrow',
+            method='find_unique_or_raise',
             model=self._model,
             arguments={
                 'where': where,
@@ -470,8 +465,7 @@ class PostActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findMany{model}',
+            method='find_many',
             model=self._model,
             arguments={
                 'take': take,
@@ -536,8 +530,7 @@ class PostActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findFirst{model}',
+            method='find_first',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -604,8 +597,7 @@ class PostActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findFirst{model}OrThrow',
+            method='find_first_or_raise',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -662,8 +654,7 @@ class PostActions(Generic[_PrismaModelT]):
         """
         try:
             resp = self._client._execute(
-                operation='mutation',
-                method='updateOne{model}',
+                method='update',
                 model=self._model,
                 arguments={
                     'data': data,
@@ -727,8 +718,7 @@ class PostActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=self._model,
             arguments={
                 'where': where,
@@ -776,8 +766,7 @@ class PostActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=self._model,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -921,8 +910,7 @@ class PostActions(Generic[_PrismaModelT]):
             ]
 
         resp = self._client._execute(
-            operation='query',
-            method='aggregate{model}',
+            method='count',
             model=self._model,
             arguments={
                 'take': take,
@@ -967,8 +955,7 @@ class PostActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=self._model,
             arguments={'where': where},
             root_selection=['count'],
@@ -1078,8 +1065,7 @@ class PostActions(Generic[_PrismaModelT]):
                 root_selection.append(_select_fields('_count', count))
 
         resp = self._client._execute(
-            operation='query',
-            method='groupBy{model}',
+            method='group_by',
             model=self._model,
             arguments={
                 'by': by,
@@ -1226,8 +1212,7 @@ class UserActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=self._model,
             arguments={
                 'data': data,
@@ -1301,8 +1286,7 @@ class UserActions(Generic[_PrismaModelT]):
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         resp = self._client._execute(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=self._model,
             arguments={
                 'data': data,
@@ -1352,8 +1336,7 @@ class UserActions(Generic[_PrismaModelT]):
         """
         try:
             resp = self._client._execute(
-                operation='mutation',
-                method='deleteOne{model}',
+                method='delete',
                 model=self._model,
                 arguments={
                     'where': where,
@@ -1404,8 +1387,7 @@ class UserActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findUnique{model}',
+            method='find_unique',
             model=self._model,
             arguments={
                 'where': where,
@@ -1456,8 +1438,7 @@ class UserActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findUnique{model}OrThrow',
+            method='find_unique_or_raise',
             model=self._model,
             arguments={
                 'where': where,
@@ -1523,8 +1504,7 @@ class UserActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findMany{model}',
+            method='find_many',
             model=self._model,
             arguments={
                 'take': take,
@@ -1589,8 +1569,7 @@ class UserActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findFirst{model}',
+            method='find_first',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -1657,8 +1636,7 @@ class UserActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findFirst{model}OrThrow',
+            method='find_first_or_raise',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -1715,8 +1693,7 @@ class UserActions(Generic[_PrismaModelT]):
         """
         try:
             resp = self._client._execute(
-                operation='mutation',
-                method='updateOne{model}',
+                method='update',
                 model=self._model,
                 arguments={
                     'data': data,
@@ -1788,8 +1765,7 @@ class UserActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=self._model,
             arguments={
                 'where': where,
@@ -1837,8 +1813,7 @@ class UserActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=self._model,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -1982,8 +1957,7 @@ class UserActions(Generic[_PrismaModelT]):
             ]
 
         resp = self._client._execute(
-            operation='query',
-            method='aggregate{model}',
+            method='count',
             model=self._model,
             arguments={
                 'take': take,
@@ -2028,8 +2002,7 @@ class UserActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=self._model,
             arguments={'where': where},
             root_selection=['count'],
@@ -2139,8 +2112,7 @@ class UserActions(Generic[_PrismaModelT]):
                 root_selection.append(_select_fields('_count', count))
 
         resp = self._client._execute(
-            operation='query',
-            method='groupBy{model}',
+            method='group_by',
             model=self._model,
             arguments={
                 'by': by,
@@ -2286,8 +2258,7 @@ class MActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=self._model,
             arguments={
                 'data': data,
@@ -2359,8 +2330,7 @@ class MActions(Generic[_PrismaModelT]):
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         resp = self._client._execute(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=self._model,
             arguments={
                 'data': data,
@@ -2410,8 +2380,7 @@ class MActions(Generic[_PrismaModelT]):
         """
         try:
             resp = self._client._execute(
-                operation='mutation',
-                method='deleteOne{model}',
+                method='delete',
                 model=self._model,
                 arguments={
                     'where': where,
@@ -2462,8 +2431,7 @@ class MActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findUnique{model}',
+            method='find_unique',
             model=self._model,
             arguments={
                 'where': where,
@@ -2514,8 +2482,7 @@ class MActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findUnique{model}OrThrow',
+            method='find_unique_or_raise',
             model=self._model,
             arguments={
                 'where': where,
@@ -2581,8 +2548,7 @@ class MActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findMany{model}',
+            method='find_many',
             model=self._model,
             arguments={
                 'take': take,
@@ -2647,8 +2613,7 @@ class MActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findFirst{model}',
+            method='find_first',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -2715,8 +2680,7 @@ class MActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findFirst{model}OrThrow',
+            method='find_first_or_raise',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -2773,8 +2737,7 @@ class MActions(Generic[_PrismaModelT]):
         """
         try:
             resp = self._client._execute(
-                operation='mutation',
-                method='updateOne{model}',
+                method='update',
                 model=self._model,
                 arguments={
                     'data': data,
@@ -2844,8 +2807,7 @@ class MActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=self._model,
             arguments={
                 'where': where,
@@ -2893,8 +2855,7 @@ class MActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=self._model,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -3038,8 +2999,7 @@ class MActions(Generic[_PrismaModelT]):
             ]
 
         resp = self._client._execute(
-            operation='query',
-            method='aggregate{model}',
+            method='count',
             model=self._model,
             arguments={
                 'take': take,
@@ -3084,8 +3044,7 @@ class MActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=self._model,
             arguments={'where': where},
             root_selection=['count'],
@@ -3195,8 +3154,7 @@ class MActions(Generic[_PrismaModelT]):
                 root_selection.append(_select_fields('_count', count))
 
         resp = self._client._execute(
-            operation='query',
-            method='groupBy{model}',
+            method='group_by',
             model=self._model,
             arguments={
                 'by': by,
@@ -3343,8 +3301,7 @@ class NActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=self._model,
             arguments={
                 'data': data,
@@ -3418,8 +3375,7 @@ class NActions(Generic[_PrismaModelT]):
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         resp = self._client._execute(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=self._model,
             arguments={
                 'data': data,
@@ -3469,8 +3425,7 @@ class NActions(Generic[_PrismaModelT]):
         """
         try:
             resp = self._client._execute(
-                operation='mutation',
-                method='deleteOne{model}',
+                method='delete',
                 model=self._model,
                 arguments={
                     'where': where,
@@ -3521,8 +3476,7 @@ class NActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findUnique{model}',
+            method='find_unique',
             model=self._model,
             arguments={
                 'where': where,
@@ -3573,8 +3527,7 @@ class NActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findUnique{model}OrThrow',
+            method='find_unique_or_raise',
             model=self._model,
             arguments={
                 'where': where,
@@ -3640,8 +3593,7 @@ class NActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findMany{model}',
+            method='find_many',
             model=self._model,
             arguments={
                 'take': take,
@@ -3706,8 +3658,7 @@ class NActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findFirst{model}',
+            method='find_first',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -3774,8 +3725,7 @@ class NActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findFirst{model}OrThrow',
+            method='find_first_or_raise',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -3832,8 +3782,7 @@ class NActions(Generic[_PrismaModelT]):
         """
         try:
             resp = self._client._execute(
-                operation='mutation',
-                method='updateOne{model}',
+                method='update',
                 model=self._model,
                 arguments={
                     'data': data,
@@ -3905,8 +3854,7 @@ class NActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=self._model,
             arguments={
                 'where': where,
@@ -3954,8 +3902,7 @@ class NActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=self._model,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -4099,8 +4046,7 @@ class NActions(Generic[_PrismaModelT]):
             ]
 
         resp = self._client._execute(
-            operation='query',
-            method='aggregate{model}',
+            method='count',
             model=self._model,
             arguments={
                 'take': take,
@@ -4145,8 +4091,7 @@ class NActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=self._model,
             arguments={'where': where},
             root_selection=['count'],
@@ -4256,8 +4201,7 @@ class NActions(Generic[_PrismaModelT]):
                 root_selection.append(_select_fields('_count', count))
 
         resp = self._client._execute(
-            operation='query',
-            method='groupBy{model}',
+            method='group_by',
             model=self._model,
             arguments={
                 'by': by,
@@ -4403,8 +4347,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=self._model,
             arguments={
                 'data': data,
@@ -4476,8 +4419,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         resp = self._client._execute(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=self._model,
             arguments={
                 'data': data,
@@ -4527,8 +4469,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
         """
         try:
             resp = self._client._execute(
-                operation='mutation',
-                method='deleteOne{model}',
+                method='delete',
                 model=self._model,
                 arguments={
                     'where': where,
@@ -4579,8 +4520,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findUnique{model}',
+            method='find_unique',
             model=self._model,
             arguments={
                 'where': where,
@@ -4631,8 +4571,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findUnique{model}OrThrow',
+            method='find_unique_or_raise',
             model=self._model,
             arguments={
                 'where': where,
@@ -4698,8 +4637,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findMany{model}',
+            method='find_many',
             model=self._model,
             arguments={
                 'take': take,
@@ -4764,8 +4702,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findFirst{model}',
+            method='find_first',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -4832,8 +4769,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findFirst{model}OrThrow',
+            method='find_first_or_raise',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -4890,8 +4826,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
         """
         try:
             resp = self._client._execute(
-                operation='mutation',
-                method='updateOne{model}',
+                method='update',
                 model=self._model,
                 arguments={
                     'data': data,
@@ -4961,8 +4896,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=self._model,
             arguments={
                 'where': where,
@@ -5010,8 +4944,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=self._model,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -5155,8 +5088,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
             ]
 
         resp = self._client._execute(
-            operation='query',
-            method='aggregate{model}',
+            method='count',
             model=self._model,
             arguments={
                 'take': take,
@@ -5201,8 +5133,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=self._model,
             arguments={'where': where},
             root_selection=['count'],
@@ -5312,8 +5243,7 @@ class OneOptionalActions(Generic[_PrismaModelT]):
                 root_selection.append(_select_fields('_count', count))
 
         resp = self._client._execute(
-            operation='query',
-            method='groupBy{model}',
+            method='group_by',
             model=self._model,
             arguments={
                 'by': by,
@@ -5459,8 +5389,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=self._model,
             arguments={
                 'data': data,
@@ -5532,8 +5461,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         resp = self._client._execute(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=self._model,
             arguments={
                 'data': data,
@@ -5583,8 +5511,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
         """
         try:
             resp = self._client._execute(
-                operation='mutation',
-                method='deleteOne{model}',
+                method='delete',
                 model=self._model,
                 arguments={
                     'where': where,
@@ -5635,8 +5562,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findUnique{model}',
+            method='find_unique',
             model=self._model,
             arguments={
                 'where': where,
@@ -5687,8 +5613,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findUnique{model}OrThrow',
+            method='find_unique_or_raise',
             model=self._model,
             arguments={
                 'where': where,
@@ -5754,8 +5679,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findMany{model}',
+            method='find_many',
             model=self._model,
             arguments={
                 'take': take,
@@ -5820,8 +5744,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findFirst{model}',
+            method='find_first',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -5888,8 +5811,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findFirst{model}OrThrow',
+            method='find_first_or_raise',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -5946,8 +5868,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
         """
         try:
             resp = self._client._execute(
-                operation='mutation',
-                method='updateOne{model}',
+                method='update',
                 model=self._model,
                 arguments={
                     'data': data,
@@ -6017,8 +5938,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=self._model,
             arguments={
                 'where': where,
@@ -6066,8 +5986,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=self._model,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -6211,8 +6130,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
             ]
 
         resp = self._client._execute(
-            operation='query',
-            method='aggregate{model}',
+            method='count',
             model=self._model,
             arguments={
                 'take': take,
@@ -6257,8 +6175,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=self._model,
             arguments={'where': where},
             root_selection=['count'],
@@ -6368,8 +6285,7 @@ class ManyRequiredActions(Generic[_PrismaModelT]):
                 root_selection.append(_select_fields('_count', count))
 
         resp = self._client._execute(
-            operation='query',
-            method='groupBy{model}',
+            method='group_by',
             model=self._model,
             arguments={
                 'by': by,
@@ -6510,8 +6426,7 @@ class ListsActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=self._model,
             arguments={
                 'data': data,
@@ -6573,8 +6488,7 @@ class ListsActions(Generic[_PrismaModelT]):
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         resp = self._client._execute(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=self._model,
             arguments={
                 'data': data,
@@ -6624,8 +6538,7 @@ class ListsActions(Generic[_PrismaModelT]):
         """
         try:
             resp = self._client._execute(
-                operation='mutation',
-                method='deleteOne{model}',
+                method='delete',
                 model=self._model,
                 arguments={
                     'where': where,
@@ -6676,8 +6589,7 @@ class ListsActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findUnique{model}',
+            method='find_unique',
             model=self._model,
             arguments={
                 'where': where,
@@ -6728,8 +6640,7 @@ class ListsActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findUnique{model}OrThrow',
+            method='find_unique_or_raise',
             model=self._model,
             arguments={
                 'where': where,
@@ -6795,8 +6706,7 @@ class ListsActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findMany{model}',
+            method='find_many',
             model=self._model,
             arguments={
                 'take': take,
@@ -6861,8 +6771,7 @@ class ListsActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findFirst{model}',
+            method='find_first',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -6929,8 +6838,7 @@ class ListsActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findFirst{model}OrThrow',
+            method='find_first_or_raise',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -6987,8 +6895,7 @@ class ListsActions(Generic[_PrismaModelT]):
         """
         try:
             resp = self._client._execute(
-                operation='mutation',
-                method='updateOne{model}',
+                method='update',
                 model=self._model,
                 arguments={
                     'data': data,
@@ -7048,8 +6955,7 @@ class ListsActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=self._model,
             arguments={
                 'where': where,
@@ -7097,8 +7003,7 @@ class ListsActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=self._model,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -7242,8 +7147,7 @@ class ListsActions(Generic[_PrismaModelT]):
             ]
 
         resp = self._client._execute(
-            operation='query',
-            method='aggregate{model}',
+            method='count',
             model=self._model,
             arguments={
                 'take': take,
@@ -7288,8 +7192,7 @@ class ListsActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=self._model,
             arguments={'where': where},
             root_selection=['count'],
@@ -7399,8 +7302,7 @@ class ListsActions(Generic[_PrismaModelT]):
                 root_selection.append(_select_fields('_count', count))
 
         resp = self._client._execute(
-            operation='query',
-            method='groupBy{model}',
+            method='group_by',
             model=self._model,
             arguments={
                 'by': by,
@@ -7545,8 +7447,7 @@ class AActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=self._model,
             arguments={
                 'data': data,
@@ -7616,8 +7517,7 @@ class AActions(Generic[_PrismaModelT]):
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         resp = self._client._execute(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=self._model,
             arguments={
                 'data': data,
@@ -7667,8 +7567,7 @@ class AActions(Generic[_PrismaModelT]):
         """
         try:
             resp = self._client._execute(
-                operation='mutation',
-                method='deleteOne{model}',
+                method='delete',
                 model=self._model,
                 arguments={
                     'where': where,
@@ -7719,8 +7618,7 @@ class AActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findUnique{model}',
+            method='find_unique',
             model=self._model,
             arguments={
                 'where': where,
@@ -7771,8 +7669,7 @@ class AActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findUnique{model}OrThrow',
+            method='find_unique_or_raise',
             model=self._model,
             arguments={
                 'where': where,
@@ -7838,8 +7735,7 @@ class AActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findMany{model}',
+            method='find_many',
             model=self._model,
             arguments={
                 'take': take,
@@ -7904,8 +7800,7 @@ class AActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findFirst{model}',
+            method='find_first',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -7972,8 +7867,7 @@ class AActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findFirst{model}OrThrow',
+            method='find_first_or_raise',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -8030,8 +7924,7 @@ class AActions(Generic[_PrismaModelT]):
         """
         try:
             resp = self._client._execute(
-                operation='mutation',
-                method='updateOne{model}',
+                method='update',
                 model=self._model,
                 arguments={
                     'data': data,
@@ -8097,8 +7990,7 @@ class AActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=self._model,
             arguments={
                 'where': where,
@@ -8146,8 +8038,7 @@ class AActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=self._model,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -8291,8 +8182,7 @@ class AActions(Generic[_PrismaModelT]):
             ]
 
         resp = self._client._execute(
-            operation='query',
-            method='aggregate{model}',
+            method='count',
             model=self._model,
             arguments={
                 'take': take,
@@ -8337,8 +8227,7 @@ class AActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=self._model,
             arguments={'where': where},
             root_selection=['count'],
@@ -8448,8 +8337,7 @@ class AActions(Generic[_PrismaModelT]):
                 root_selection.append(_select_fields('_count', count))
 
         resp = self._client._execute(
-            operation='query',
-            method='groupBy{model}',
+            method='group_by',
             model=self._model,
             arguments={
                 'by': by,
@@ -8594,8 +8482,7 @@ class BActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=self._model,
             arguments={
                 'data': data,
@@ -8665,8 +8552,7 @@ class BActions(Generic[_PrismaModelT]):
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         resp = self._client._execute(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=self._model,
             arguments={
                 'data': data,
@@ -8716,8 +8602,7 @@ class BActions(Generic[_PrismaModelT]):
         """
         try:
             resp = self._client._execute(
-                operation='mutation',
-                method='deleteOne{model}',
+                method='delete',
                 model=self._model,
                 arguments={
                     'where': where,
@@ -8768,8 +8653,7 @@ class BActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findUnique{model}',
+            method='find_unique',
             model=self._model,
             arguments={
                 'where': where,
@@ -8820,8 +8704,7 @@ class BActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findUnique{model}OrThrow',
+            method='find_unique_or_raise',
             model=self._model,
             arguments={
                 'where': where,
@@ -8887,8 +8770,7 @@ class BActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findMany{model}',
+            method='find_many',
             model=self._model,
             arguments={
                 'take': take,
@@ -8953,8 +8835,7 @@ class BActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findFirst{model}',
+            method='find_first',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -9021,8 +8902,7 @@ class BActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findFirst{model}OrThrow',
+            method='find_first_or_raise',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -9079,8 +8959,7 @@ class BActions(Generic[_PrismaModelT]):
         """
         try:
             resp = self._client._execute(
-                operation='mutation',
-                method='updateOne{model}',
+                method='update',
                 model=self._model,
                 arguments={
                     'data': data,
@@ -9148,8 +9027,7 @@ class BActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=self._model,
             arguments={
                 'where': where,
@@ -9197,8 +9075,7 @@ class BActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=self._model,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -9342,8 +9219,7 @@ class BActions(Generic[_PrismaModelT]):
             ]
 
         resp = self._client._execute(
-            operation='query',
-            method='aggregate{model}',
+            method='count',
             model=self._model,
             arguments={
                 'take': take,
@@ -9388,8 +9264,7 @@ class BActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=self._model,
             arguments={'where': where},
             root_selection=['count'],
@@ -9499,8 +9374,7 @@ class BActions(Generic[_PrismaModelT]):
                 root_selection.append(_select_fields('_count', count))
 
         resp = self._client._execute(
-            operation='query',
-            method='groupBy{model}',
+            method='group_by',
             model=self._model,
             arguments={
                 'by': by,
@@ -9647,8 +9521,7 @@ class CActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=self._model,
             arguments={
                 'data': data,
@@ -9722,8 +9595,7 @@ class CActions(Generic[_PrismaModelT]):
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         resp = self._client._execute(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=self._model,
             arguments={
                 'data': data,
@@ -9774,8 +9646,7 @@ class CActions(Generic[_PrismaModelT]):
         """
         try:
             resp = self._client._execute(
-                operation='mutation',
-                method='deleteOne{model}',
+                method='delete',
                 model=self._model,
                 arguments={
                     'where': where,
@@ -9827,8 +9698,7 @@ class CActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findUnique{model}',
+            method='find_unique',
             model=self._model,
             arguments={
                 'where': where,
@@ -9880,8 +9750,7 @@ class CActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findUnique{model}OrThrow',
+            method='find_unique_or_raise',
             model=self._model,
             arguments={
                 'where': where,
@@ -9947,8 +9816,7 @@ class CActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findMany{model}',
+            method='find_many',
             model=self._model,
             arguments={
                 'take': take,
@@ -10013,8 +9881,7 @@ class CActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findFirst{model}',
+            method='find_first',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -10081,8 +9948,7 @@ class CActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findFirst{model}OrThrow',
+            method='find_first_or_raise',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -10140,8 +10006,7 @@ class CActions(Generic[_PrismaModelT]):
         """
         try:
             resp = self._client._execute(
-                operation='mutation',
-                method='updateOne{model}',
+                method='update',
                 model=self._model,
                 arguments={
                     'data': data,
@@ -10202,8 +10067,7 @@ class CActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=self._model,
             arguments={
                 'where': where,
@@ -10251,8 +10115,7 @@ class CActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=self._model,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -10396,8 +10259,7 @@ class CActions(Generic[_PrismaModelT]):
             ]
 
         resp = self._client._execute(
-            operation='query',
-            method='aggregate{model}',
+            method='count',
             model=self._model,
             arguments={
                 'take': take,
@@ -10442,8 +10304,7 @@ class CActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=self._model,
             arguments={'where': where},
             root_selection=['count'],
@@ -10553,8 +10414,7 @@ class CActions(Generic[_PrismaModelT]):
                 root_selection.append(_select_fields('_count', count))
 
         resp = self._client._execute(
-            operation='query',
-            method='groupBy{model}',
+            method='group_by',
             model=self._model,
             arguments={
                 'by': by,
@@ -10700,8 +10560,7 @@ class DActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=self._model,
             arguments={
                 'data': data,
@@ -10773,8 +10632,7 @@ class DActions(Generic[_PrismaModelT]):
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         resp = self._client._execute(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=self._model,
             arguments={
                 'data': data,
@@ -10824,8 +10682,7 @@ class DActions(Generic[_PrismaModelT]):
         """
         try:
             resp = self._client._execute(
-                operation='mutation',
-                method='deleteOne{model}',
+                method='delete',
                 model=self._model,
                 arguments={
                     'where': where,
@@ -10876,8 +10733,7 @@ class DActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findUnique{model}',
+            method='find_unique',
             model=self._model,
             arguments={
                 'where': where,
@@ -10928,8 +10784,7 @@ class DActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findUnique{model}OrThrow',
+            method='find_unique_or_raise',
             model=self._model,
             arguments={
                 'where': where,
@@ -10995,8 +10850,7 @@ class DActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findMany{model}',
+            method='find_many',
             model=self._model,
             arguments={
                 'take': take,
@@ -11061,8 +10915,7 @@ class DActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findFirst{model}',
+            method='find_first',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -11129,8 +10982,7 @@ class DActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findFirst{model}OrThrow',
+            method='find_first_or_raise',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -11187,8 +11039,7 @@ class DActions(Generic[_PrismaModelT]):
         """
         try:
             resp = self._client._execute(
-                operation='mutation',
-                method='updateOne{model}',
+                method='update',
                 model=self._model,
                 arguments={
                     'data': data,
@@ -11258,8 +11109,7 @@ class DActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=self._model,
             arguments={
                 'where': where,
@@ -11307,8 +11157,7 @@ class DActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=self._model,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -11452,8 +11301,7 @@ class DActions(Generic[_PrismaModelT]):
             ]
 
         resp = self._client._execute(
-            operation='query',
-            method='aggregate{model}',
+            method='count',
             model=self._model,
             arguments={
                 'take': take,
@@ -11498,8 +11346,7 @@ class DActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=self._model,
             arguments={'where': where},
             root_selection=['count'],
@@ -11609,8 +11456,7 @@ class DActions(Generic[_PrismaModelT]):
                 root_selection.append(_select_fields('_count', count))
 
         resp = self._client._execute(
-            operation='query',
-            method='groupBy{model}',
+            method='group_by',
             model=self._model,
             arguments={
                 'by': by,
@@ -11754,8 +11600,7 @@ class EActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=self._model,
             arguments={
                 'data': data,
@@ -11823,8 +11668,7 @@ class EActions(Generic[_PrismaModelT]):
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         resp = self._client._execute(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=self._model,
             arguments={
                 'data': data,
@@ -11874,8 +11718,7 @@ class EActions(Generic[_PrismaModelT]):
         """
         try:
             resp = self._client._execute(
-                operation='mutation',
-                method='deleteOne{model}',
+                method='delete',
                 model=self._model,
                 arguments={
                     'where': where,
@@ -11926,8 +11769,7 @@ class EActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findUnique{model}',
+            method='find_unique',
             model=self._model,
             arguments={
                 'where': where,
@@ -11978,8 +11820,7 @@ class EActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findUnique{model}OrThrow',
+            method='find_unique_or_raise',
             model=self._model,
             arguments={
                 'where': where,
@@ -12045,8 +11886,7 @@ class EActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findMany{model}',
+            method='find_many',
             model=self._model,
             arguments={
                 'take': take,
@@ -12111,8 +11951,7 @@ class EActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findFirst{model}',
+            method='find_first',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -12179,8 +12018,7 @@ class EActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='query',
-            method='findFirst{model}OrThrow',
+            method='find_first_or_raise',
             model=self._model,
             arguments={
                 'skip': skip,
@@ -12237,8 +12075,7 @@ class EActions(Generic[_PrismaModelT]):
         """
         try:
             resp = self._client._execute(
-                operation='mutation',
-                method='updateOne{model}',
+                method='update',
                 model=self._model,
                 arguments={
                     'data': data,
@@ -12304,8 +12141,7 @@ class EActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=self._model,
             arguments={
                 'where': where,
@@ -12353,8 +12189,7 @@ class EActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=self._model,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -12498,8 +12333,7 @@ class EActions(Generic[_PrismaModelT]):
             ]
 
         resp = self._client._execute(
-            operation='query',
-            method='aggregate{model}',
+            method='count',
             model=self._model,
             arguments={
                 'take': take,
@@ -12544,8 +12378,7 @@ class EActions(Generic[_PrismaModelT]):
         ```
         """
         resp = self._client._execute(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=self._model,
             arguments={'where': where},
             root_selection=['count'],
@@ -12655,8 +12488,7 @@ class EActions(Generic[_PrismaModelT]):
                 root_selection.append(_select_fields('_count', count))
 
         resp = self._client._execute(
-            operation='query',
-            method='groupBy{model}',
+            method='group_by',
             model=self._model,
             arguments={
                 'by': by,
@@ -12682,5 +12514,4 @@ def _select_fields(root: str, select: Mapping[str, Any]) -> str:
 
 
 from . import models
-
 '''

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[builder.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[builder.py].raw
@@ -227,7 +227,7 @@ class QueryBuilder:
 
     def build(self) -> str:
         """Build the payload that should be sent to the QueryEngine"""
-        data = {
+        data: dict[str, object] = {
             'variables': {},
             'operation_name': self.operation,
             'query': self.build_query(),

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[builder.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[builder.py].raw
@@ -41,16 +41,6 @@ from typing_extensions import TypedDict, Literal
 LiteralString = str
 # -- template builder.py.jinja --
 
-# TODO: the QueryBuilder should validate and add type information context.
-#       currently we just naively iterate through arguments and encode them
-#       using standard json when we don't have any special casing for it.
-#       this makes it more difficult to add support for non-standard types
-#       such as the `Json` type.
-# TODO: optimise for performance (switch to c / cython?)
-# TODO: pass context around differently, relying on the builder instance is
-#       not ideal, context should be local to each node
-
-
 import json
 import logging
 import inspect
@@ -58,13 +48,17 @@ from textwrap import indent
 from datetime import timezone
 from abc import abstractmethod, ABC
 from functools import singledispatch
+from typing import ForwardRef
+from typing_extensions import TypeGuard
 
+from pydantic import BaseModel
 from pydantic.fields import ModelField
 
 from . import fields
 from .types import Serializable
 from .errors import UnknownModelError, UnknownRelationalFieldError, InvalidModelError
 from ._constants import QUERY_BUILDER_ALIASES
+from ._types import PrismaMethod
 
 if TYPE_CHECKING:
     from .bases import _PrismaModel as PrismaModel
@@ -122,29 +116,80 @@ RELATIONAL_FIELD_MAPPINGS: Dict[str, Dict[str, str]] = {
     },
 }
 
+METHOD_OPERATION_MAPPING: dict[PrismaMethod, Operation] = {
+    'create': 'mutation',
+    'delete': 'mutation',
+    'update': 'mutation',
+    'upsert': 'mutation',
+    'query_raw': 'mutation',
+    'query_first': 'mutation',
+    'create_many': 'mutation',
+    'execute_raw': 'mutation',
+    'delete_many': 'mutation',
+    'update_many': 'mutation',
+
+    'count': 'query',
+    'group_by': 'query',
+    'find_many': 'query',
+    'find_first': 'query',
+    'find_first_or_raise': 'query',
+    'find_unique': 'query',
+    'find_unique_or_raise': 'query',
+}
+
+METHOD_FORMAT_MAPPING: dict[PrismaMethod, str] = {
+    'create': 'createOne{model}',
+    'delete': 'deleteOne{model}',
+    'update': 'updateOne{model}',
+    'upsert': 'upsertOne{model}',
+    'query_raw': 'queryRaw',
+    'query_first': 'queryRaw',
+    'create_many': 'createMany{model}',
+    'execute_raw': 'executeRaw',
+    'delete_many': 'deleteMany{model}',
+    'update_many': 'updateMany{model}',
+
+    'count': 'aggregate{model}',
+    'group_by': 'groupBy{model}',
+    'find_many': 'findMany{model}',
+    'find_first': 'findFirst{model}',
+    'find_first_or_raise': 'findFirst{model}OrThrow',
+    'find_unique': 'findUnique{model}',
+    'find_unique_or_raise': 'findUnique{model}OrThrow',
+}
+
 MISSING = object()
+Operation = Literal['query', 'mutation']
+
 
 
 class QueryBuilder:
-    # prisma method format, e.g. `findUnique{model}`
+    method: PrismaMethod
+    """The name of the actions method that this query is for, e.g. `find_unique`"""
+
     method_format: str
+    """Template denoting how the internal method name should be constructed, e.g. `findUnique{model}`"""
 
-    # GraphQL operation
-    operation: str
+    operation: Operation
+    """The GraphQL operatiom e.g. `query`, `mutation`"""
 
-    # prisma model
-    model: Optional[Type[PrismaModel]]
+    model: type[PrismaModel] | None
+    """The Pydantic model that will be used to parse the response.
 
-    # mapping of relational fields to include in the result
-    include: Optional[Dict[str, Any]]
+    Used to extract the model name & build selections.
+    """
 
-    # arguments to pass to the query
-    arguments: Dict[str, Any]
+    include: dict[str, Any] | None
+    """Mapping of relational fields to include in the result"""
 
-    # list of fields to select
-    root_selection: Optional[List[str]]
+    arguments: dict[str, Any]
+    """Arguments to pass to the query"""
+
+    root_selection: list[str] | None
+    """List of fields to select"""
 
     __slots__ = (
+        'method',
         'method_format',
         'operation',
         'model',
@@ -156,21 +201,29 @@ class QueryBuilder:
     def __init__(
         self,
         *,
-        method: str,
-        operation: str,
-        arguments: Dict[str, Any],
-        model: Optional[Type[PrismaModel]] = None,
-        root_selection: Optional[List[str]] = None
+        method: PrismaMethod,
+        arguments: dict[str, Any],
+        model: type[BaseModel] | None = None,
+        root_selection: list[str] | None = None
     ) -> None:
-        self.model = model
-        self.method_format = method
-        self.operation = operation
+        self.method = method
+        self.method_format = METHOD_FORMAT_MAPPING[method]
+        self.operation = METHOD_OPERATION_MAPPING[method]
         self.root_selection = root_selection
         self.arguments = args = self._transform_aliases(arguments)
         self.include = args.pop('include', None)
 
-        if model is not None and not hasattr(model, '__prisma_model__'):
-            raise InvalidModelError(model)
+        # Note: we ignore the `model` argument for raw queries as users may want to pass in a model
+        # that isn't a `PrismaModel` because they've defined it manually & enforcing that
+        # they subclass `PrismaModel` doesn't bring any real benefits.
+        if model is None or method in {'execute_raw', 'query_raw', 'query_first'}:
+            self.model = None
+        else:
+            if not _is_prisma_model_type(model) or not hasattr(model, '__prisma_model__'):
+                raise InvalidModelError(model)
+
+            self.model = model
+
 
     def build(self) -> str:
         """Build the payload that should be sent to the QueryEngine"""
@@ -221,7 +274,7 @@ class QueryBuilder:
         )
         return root
 
-    def get_default_fields(self, model: Type[PrismaModel]) -> List[str]:
+    def get_default_fields(self, model: type[PrismaModel]) -> list[str]:
         """Returns a list of all the scalar fields of a model
 
         Raises UnknownModelError if the current model cannot be found.
@@ -239,7 +292,7 @@ class QueryBuilder:
         return [
             field
             for field, info in model.__fields__.items()
-            if not _field_is_prisma_model(info)
+            if not _field_is_prisma_model(info, parent=model)
         ]
 
     def get_relational_model(self, current_model: Type[PrismaModel], field: str) -> Type[PrismaModel]:
@@ -267,7 +320,7 @@ class QueryBuilder:
         except KeyError as exc:
             raise UnknownRelationalFieldError(model=current_model.__name__, field=field)
 
-        if not _field_is_prisma_model(info):
+        if not _field_is_prisma_model(info, parent=current_model):
             raise RuntimeError(
                 f'The `{field}` field doesn\'t appear to be a Prisma Model type. ' +
                 'Is the field a pydantic.BaseModel type and does it have a `__prisma_model__` class variable?'
@@ -297,12 +350,24 @@ class QueryBuilder:
         return transformed
 
 
-def _field_is_prisma_model(field: ModelField) -> bool:
+def _field_is_prisma_model(field: ModelField, *, parent: type[BaseModel]) -> bool:
   """Whether or not the given field info represents a model at the database level.
 
   This will return `True` for cases where the field represents a list of models or a single model.
   """
+  if isinstance(field.type_, ForwardRef):
+      cls_name = parent.__name__
+      raise RuntimeError(
+        f'Encountered forward reference for {cls_name}.{field.name}; Forward references must be evaluated using {cls_name}.update_forward_refs()'
+      )
+
   return hasattr(field.type_, '__prisma_model__')
+
+
+def _is_prisma_model_type(type_: type[BaseModel]) -> TypeGuard[type[PrismaModel]]:
+    from .bases import _PrismaModel
+
+    return issubclass(type_, _PrismaModel)
 
 
 class AbstractNode(ABC):
@@ -542,11 +607,11 @@ class Arguments(Node):
                     Key(arg, node=Data.create(self.builder, data=value))
                 )
             elif isinstance(value, ITERABLES):
-                # NOTE: we have a special case for execute_raw and query_raw
+                # NOTE: we have a special case for execute_raw, query_raw and query_first
                 # here as prisma expects parameters to be passed as a json string
                 # value like "[\"John\",\"123\"]", and we encode twice to ensure
                 # that only the inner quotes are escaped
-                if self.builder.method_format in {'queryRaw{model}', 'executeRaw{model}'}:
+                if self.builder.method in {'query_raw', 'query_first', 'execute_raw'}:
                     children.append(f'{arg}: {dumps(dumps(value))}')
                 else:
                     children.append(Key(arg, node=ListNode.create(self.builder, data=value)))
@@ -669,9 +734,9 @@ class Selection(Node):
         }
     }
     """
-    model: Optional[Type[PrismaModel]]
-    include: Optional[Dict[str, Any]]
-    root_selection: Optional[List[str]]
+    model: type[PrismaModel] | None
+    include: dict[str, Any] | None
+    root_selection: list[str] | None
 
     __slots__ = (
         'model',
@@ -681,9 +746,9 @@ class Selection(Node):
 
     def __init__(
         self,
-        model: Optional[Type[PrismaModel]] = None,
-        include: Optional[Dict[str, Any]] = None,
-        root_selection: Optional[List[str]] = None,
+        model: type[PrismaModel] | None = None,
+        include: dict[str, Any] | None = None,
+        root_selection: list[str] | None = None,
         **kwargs: Any
     ) -> None:
         super().__init__(**kwargs)

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
@@ -378,9 +378,9 @@ class Prisma:
     def _execute(
         self,
         method: PrismaMethod,
-        arguments: Dict[str, Any],
-        model: Optional[Type['_PrismaModel']] = None,
-        root_selection: Optional[List[str]] = None
+        arguments: dict[str, Any],
+        model: type[BaseModel] | None = None,
+        root_selection: list[str] | None = None
     ) -> Any:
         builder = QueryBuilder(
             method=method,

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
@@ -50,8 +50,7 @@ from .types import DatasourceOverride, HttpConfig
 from ._types import BaseModelT, PrismaMethod
 from .bases import _PrismaModel
 from .engine import AbstractEngine, QueryEngine
-from .builder import QueryBuilder, Operation
-from .middleware import MiddlewareFunc, MiddlewareParams, MiddlewareResult
+from .builder import QueryBuilder
 from .generator.models import EngineType, OptionalValueFromEnvVar, BinaryPaths
 from ._compat import removeprefix
 from ._raw_query import deserialize_raw_results
@@ -187,7 +186,6 @@ class Prisma:
         '_datasource',
         '_connect_timeout',
         '_http_config',
-        '_middlewares',
     )
 
     def __init__(
@@ -218,7 +216,6 @@ class Prisma:
         self._datasource = datasource
         self._connect_timeout = connect_timeout
         self._http_config: HttpConfig = http or {}
-        self._middlewares: List[MiddlewareFunc] = []
 
         if use_dotenv:
             load_env()
@@ -281,15 +278,6 @@ class Prisma:
             self.__engine.stop(timeout=timeout)
             self.__engine = None
 
-    # TODO: add support for clearing middlewares
-
-    def use(self, *middlewares: MiddlewareFunc) -> None:
-        """Setup a middleware function to be called before each query is executed.
-
-        TODO: link to docs
-        """
-        self._middlewares.extend(middlewares)
-
     def execute_raw(self, query: LiteralString, *args: Any) -> int:
         resp = self._execute(
             method='execute_raw',
@@ -331,18 +319,9 @@ class Prisma:
         """
         results: Sequence[Union[BaseModelT, dict[str, Any]]]
         if model is not None:
-            results = self._execute_raw_query(
-                query,
-                *args,
-                model=model,
-                _from_method='query_first',
-            )
+            results = self.query_raw(query, *args, model=model)
         else:
-            results = self._execute_raw_query(
-                query,
-                *args,
-                _from_method='query_first',
-            )
+            results = self.query_raw(query, *args)
 
         if not results:
             return None
@@ -377,44 +356,8 @@ class Prisma:
         If model is given, each returned record is converted to the pydantic model first,
         otherwise results will be raw dictionaries.
         """
-        if model is not None:
-            return self._execute_raw_query(
-                query, *args, model=model, _from_method='query_raw'
-            )
-
-        return self._execute_raw_query(
-            query, *args, _from_method='query_raw'
-        )
-
-
-    @overload
-    def _execute_raw_query(
-        self,
-        query: LiteralString,
-        *args: Any,
-        _from_method: PrismaMethod,
-    ) -> list[dict[str, Any]]:
-        ...
-
-    @overload
-    def _execute_raw_query(
-        self,
-        query: LiteralString,
-        *args: Any,
-        _from_method: PrismaMethod,
-        model: Type[BaseModelT],
-    ) -> list[BaseModelT]:
-        ...
-
-    def _execute_raw_query(
-        self,
-        query: LiteralString,
-        *args: Any,
-        _from_method: PrismaMethod,
-        model: Type[BaseModelT] | None = None,
-    ) -> list[BaseModelT] | list[dict[str, Any]]:
         resp = self._execute(
-            method=_from_method,
+            method='query_raw',
             arguments={
                 'query': query,
                 'parameters': args,
@@ -427,7 +370,6 @@ class Prisma:
 
         return deserialize_raw_results(result)
 
-
     def batch_(self) -> 'Batch':
         """Returns a context manager for grouping write queries into a single transaction."""
         return Batch(client=self)
@@ -435,42 +377,18 @@ class Prisma:
     # TODO: don't return Any
     def _execute(
         self,
-        *,
         method: PrismaMethod,
-        arguments: dict[str, Any],
-        model: type[BaseModel] | None,
-        root_selection: list[str] | None = None
+        arguments: Dict[str, Any],
+        model: Optional[Type['_PrismaModel']] = None,
+        root_selection: Optional[List[str]] = None
     ) -> Any:
-        def executor(params: MiddlewareParams) -> MiddlewareResult:
-            builder = QueryBuilder(
-                method=params.method,
-                model=params.model,
-                arguments=params.arguments,
-                # TODO: move this to middleware params too
-                root_selection=root_selection,
-            )
-            return self._engine.query(builder.build())
-
-        # TODO: should this also operate on the parsed return type? (yes)
-        def get_result(params: MiddlewareParams) -> MiddlewareResult:
-            try:
-                middleware = next(iterator)
-            except StopIteration:
-                return executor(params)
-
-            return middleware(params, get_result)
-
-        params = MiddlewareParams(
+        builder = QueryBuilder(
             method=method,
             model=model,
             arguments=arguments,
+            root_selection=root_selection,
         )
-        if not self._middlewares:
-            return executor(params)
-
-        first, *rest = self._middlewares
-        iterator = iter(rest)
-        return first(params, get_result)
+        return self._engine.query(builder.build())
 
     def _create_engine(self, dml_path: Path = PACKAGED_SCHEMA_PATH) -> AbstractEngine:
         if ENGINE_TYPE == EngineType.binary:

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
@@ -43,12 +43,15 @@ LiteralString = str
 from pathlib import Path
 from types import TracebackType
 
+from pydantic import BaseModel
+
 from . import types, models, errors, actions
 from .types import DatasourceOverride, HttpConfig
-from ._types import BaseModelT
+from ._types import BaseModelT, PrismaMethod
 from .bases import _PrismaModel
 from .engine import AbstractEngine, QueryEngine
-from .builder import QueryBuilder
+from .builder import QueryBuilder, Operation
+from .middleware import MiddlewareFunc, MiddlewareParams, MiddlewareResult
 from .generator.models import EngineType, OptionalValueFromEnvVar, BinaryPaths
 from ._compat import removeprefix
 from ._raw_query import deserialize_raw_results
@@ -184,6 +187,7 @@ class Prisma:
         '_datasource',
         '_connect_timeout',
         '_http_config',
+        '_middlewares',
     )
 
     def __init__(
@@ -214,6 +218,7 @@ class Prisma:
         self._datasource = datasource
         self._connect_timeout = connect_timeout
         self._http_config: HttpConfig = http or {}
+        self._middlewares: List[MiddlewareFunc] = []
 
         if use_dotenv:
             load_env()
@@ -276,14 +281,23 @@ class Prisma:
             self.__engine.stop(timeout=timeout)
             self.__engine = None
 
+    # TODO: add support for clearing middlewares
+
+    def use(self, *middlewares: MiddlewareFunc) -> None:
+        """Setup a middleware function to be called before each query is executed.
+
+        TODO: link to docs
+        """
+        self._middlewares.extend(middlewares)
+
     def execute_raw(self, query: LiteralString, *args: Any) -> int:
         resp = self._execute(
-            operation='mutation',
-            method='executeRaw{model}',
+            method='execute_raw',
             arguments={
                 'query': query,
                 'parameters': args,
-            }
+            },
+            model=None,
         )
         return int(resp['data']['result'])
 
@@ -317,9 +331,18 @@ class Prisma:
         """
         results: Sequence[Union[BaseModelT, dict[str, Any]]]
         if model is not None:
-            results = self.query_raw(query, *args, model=model)
+            results = self._execute_raw_query(
+                query,
+                *args,
+                model=model,
+                _from_method='query_first',
+            )
         else:
-            results = self.query_raw(query, *args)
+            results = self._execute_raw_query(
+                query,
+                *args,
+                _from_method='query_first',
+            )
 
         if not results:
             return None
@@ -354,19 +377,56 @@ class Prisma:
         If model is given, each returned record is converted to the pydantic model first,
         otherwise results will be raw dictionaries.
         """
+        if model is not None:
+            return self._execute_raw_query(
+                query, *args, model=model, _from_method='query_raw'
+            )
+
+        return self._execute_raw_query(
+            query, *args, _from_method='query_raw'
+        )
+
+
+    @overload
+    def _execute_raw_query(
+        self,
+        query: LiteralString,
+        *args: Any,
+        _from_method: PrismaMethod,
+    ) -> list[dict[str, Any]]:
+        ...
+
+    @overload
+    def _execute_raw_query(
+        self,
+        query: LiteralString,
+        *args: Any,
+        _from_method: PrismaMethod,
+        model: Type[BaseModelT],
+    ) -> list[BaseModelT]:
+        ...
+
+    def _execute_raw_query(
+        self,
+        query: LiteralString,
+        *args: Any,
+        _from_method: PrismaMethod,
+        model: Type[BaseModelT] | None = None,
+    ) -> list[BaseModelT] | list[dict[str, Any]]:
         resp = self._execute(
-            operation='mutation',
-            method='queryRaw{model}',
+            method=_from_method,
             arguments={
                 'query': query,
                 'parameters': args,
-            }
+            },
+            model=model,
         )
         result = resp['data']['result']
         if model is not None:
             return deserialize_raw_results(result, model=model)
 
         return deserialize_raw_results(result)
+
 
     def batch_(self) -> 'Batch':
         """Returns a context manager for grouping write queries into a single transaction."""
@@ -375,20 +435,42 @@ class Prisma:
     # TODO: don't return Any
     def _execute(
         self,
-        method: str,
-        operation: str,
-        arguments: Dict[str, Any],
-        model: Optional[Type['_PrismaModel']] = None,
-        root_selection: Optional[List[str]] = None
+        *,
+        method: PrismaMethod,
+        arguments: dict[str, Any],
+        model: type[BaseModel] | None,
+        root_selection: list[str] | None = None
     ) -> Any:
-        builder = QueryBuilder(
-            operation=operation,
+        def executor(params: MiddlewareParams) -> MiddlewareResult:
+            builder = QueryBuilder(
+                method=params.method,
+                model=params.model,
+                arguments=params.arguments,
+                # TODO: move this to middleware params too
+                root_selection=root_selection,
+            )
+            return self._engine.query(builder.build())
+
+        # TODO: should this also operate on the parsed return type? (yes)
+        def get_result(params: MiddlewareParams) -> MiddlewareResult:
+            try:
+                middleware = next(iterator)
+            except StopIteration:
+                return executor(params)
+
+            return middleware(params, get_result)
+
+        params = MiddlewareParams(
             method=method,
             model=model,
             arguments=arguments,
-            root_selection=root_selection,
         )
-        return self._engine.query(builder.build())
+        if not self._middlewares:
+            return executor(params)
+
+        first, *rest = self._middlewares
+        iterator = iter(rest)
+        return first(params, get_result)
 
     def _create_engine(self, dml_path: Path = PACKAGED_SCHEMA_PATH) -> AbstractEngine:
         if ENGINE_TYPE == EngineType.binary:
@@ -493,8 +575,7 @@ class Batch:
 
     def execute_raw(self, query: LiteralString, *args: Any) -> None:
         self._add(
-            operation='mutation',
-            method='executeRaw{model}',
+            method='execute_raw',
             arguments={
                 'query': query,
                 'parameters': args,
@@ -526,8 +607,7 @@ class PostBatchActions:
         include: Optional[types.PostInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=models.Post,
             arguments={
                 'data': data,
@@ -545,8 +625,7 @@ class PostBatchActions:
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         self._batcher._add(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=models.Post,
             arguments={
                 'data': data,
@@ -561,8 +640,7 @@ class PostBatchActions:
         include: Optional[types.PostInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteOne{model}',
+            method='delete',
             model=models.Post,
             arguments={
                 'where': where,
@@ -577,8 +655,7 @@ class PostBatchActions:
         include: Optional[types.PostInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateOne{model}',
+            method='update',
             model=models.Post,
             arguments={
                 'data': data,
@@ -594,8 +671,7 @@ class PostBatchActions:
         include: Optional[types.PostInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=models.Post,
             arguments={
                 'where': where,
@@ -611,8 +687,7 @@ class PostBatchActions:
         where: types.PostWhereInput,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=models.Post,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -623,8 +698,7 @@ class PostBatchActions:
         where: Optional[types.PostWhereInput] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=models.Post,
             arguments={'where': where},
             root_selection=['count'],
@@ -644,8 +718,7 @@ class UserBatchActions:
         include: Optional[types.UserInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=models.User,
             arguments={
                 'data': data,
@@ -663,8 +736,7 @@ class UserBatchActions:
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         self._batcher._add(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=models.User,
             arguments={
                 'data': data,
@@ -679,8 +751,7 @@ class UserBatchActions:
         include: Optional[types.UserInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteOne{model}',
+            method='delete',
             model=models.User,
             arguments={
                 'where': where,
@@ -695,8 +766,7 @@ class UserBatchActions:
         include: Optional[types.UserInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateOne{model}',
+            method='update',
             model=models.User,
             arguments={
                 'data': data,
@@ -712,8 +782,7 @@ class UserBatchActions:
         include: Optional[types.UserInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=models.User,
             arguments={
                 'where': where,
@@ -729,8 +798,7 @@ class UserBatchActions:
         where: types.UserWhereInput,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=models.User,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -741,8 +809,7 @@ class UserBatchActions:
         where: Optional[types.UserWhereInput] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=models.User,
             arguments={'where': where},
             root_selection=['count'],
@@ -762,8 +829,7 @@ class MBatchActions:
         include: Optional[types.MInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=models.M,
             arguments={
                 'data': data,
@@ -781,8 +847,7 @@ class MBatchActions:
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         self._batcher._add(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=models.M,
             arguments={
                 'data': data,
@@ -797,8 +862,7 @@ class MBatchActions:
         include: Optional[types.MInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteOne{model}',
+            method='delete',
             model=models.M,
             arguments={
                 'where': where,
@@ -813,8 +877,7 @@ class MBatchActions:
         include: Optional[types.MInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateOne{model}',
+            method='update',
             model=models.M,
             arguments={
                 'data': data,
@@ -830,8 +893,7 @@ class MBatchActions:
         include: Optional[types.MInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=models.M,
             arguments={
                 'where': where,
@@ -847,8 +909,7 @@ class MBatchActions:
         where: types.MWhereInput,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=models.M,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -859,8 +920,7 @@ class MBatchActions:
         where: Optional[types.MWhereInput] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=models.M,
             arguments={'where': where},
             root_selection=['count'],
@@ -880,8 +940,7 @@ class NBatchActions:
         include: Optional[types.NInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=models.N,
             arguments={
                 'data': data,
@@ -899,8 +958,7 @@ class NBatchActions:
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         self._batcher._add(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=models.N,
             arguments={
                 'data': data,
@@ -915,8 +973,7 @@ class NBatchActions:
         include: Optional[types.NInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteOne{model}',
+            method='delete',
             model=models.N,
             arguments={
                 'where': where,
@@ -931,8 +988,7 @@ class NBatchActions:
         include: Optional[types.NInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateOne{model}',
+            method='update',
             model=models.N,
             arguments={
                 'data': data,
@@ -948,8 +1004,7 @@ class NBatchActions:
         include: Optional[types.NInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=models.N,
             arguments={
                 'where': where,
@@ -965,8 +1020,7 @@ class NBatchActions:
         where: types.NWhereInput,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=models.N,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -977,8 +1031,7 @@ class NBatchActions:
         where: Optional[types.NWhereInput] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=models.N,
             arguments={'where': where},
             root_selection=['count'],
@@ -998,8 +1051,7 @@ class OneOptionalBatchActions:
         include: Optional[types.OneOptionalInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=models.OneOptional,
             arguments={
                 'data': data,
@@ -1017,8 +1069,7 @@ class OneOptionalBatchActions:
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         self._batcher._add(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=models.OneOptional,
             arguments={
                 'data': data,
@@ -1033,8 +1084,7 @@ class OneOptionalBatchActions:
         include: Optional[types.OneOptionalInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteOne{model}',
+            method='delete',
             model=models.OneOptional,
             arguments={
                 'where': where,
@@ -1049,8 +1099,7 @@ class OneOptionalBatchActions:
         include: Optional[types.OneOptionalInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateOne{model}',
+            method='update',
             model=models.OneOptional,
             arguments={
                 'data': data,
@@ -1066,8 +1115,7 @@ class OneOptionalBatchActions:
         include: Optional[types.OneOptionalInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=models.OneOptional,
             arguments={
                 'where': where,
@@ -1083,8 +1131,7 @@ class OneOptionalBatchActions:
         where: types.OneOptionalWhereInput,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=models.OneOptional,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -1095,8 +1142,7 @@ class OneOptionalBatchActions:
         where: Optional[types.OneOptionalWhereInput] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=models.OneOptional,
             arguments={'where': where},
             root_selection=['count'],
@@ -1116,8 +1162,7 @@ class ManyRequiredBatchActions:
         include: Optional[types.ManyRequiredInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=models.ManyRequired,
             arguments={
                 'data': data,
@@ -1135,8 +1180,7 @@ class ManyRequiredBatchActions:
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         self._batcher._add(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=models.ManyRequired,
             arguments={
                 'data': data,
@@ -1151,8 +1195,7 @@ class ManyRequiredBatchActions:
         include: Optional[types.ManyRequiredInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteOne{model}',
+            method='delete',
             model=models.ManyRequired,
             arguments={
                 'where': where,
@@ -1167,8 +1210,7 @@ class ManyRequiredBatchActions:
         include: Optional[types.ManyRequiredInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateOne{model}',
+            method='update',
             model=models.ManyRequired,
             arguments={
                 'data': data,
@@ -1184,8 +1226,7 @@ class ManyRequiredBatchActions:
         include: Optional[types.ManyRequiredInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=models.ManyRequired,
             arguments={
                 'where': where,
@@ -1201,8 +1242,7 @@ class ManyRequiredBatchActions:
         where: types.ManyRequiredWhereInput,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=models.ManyRequired,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -1213,8 +1253,7 @@ class ManyRequiredBatchActions:
         where: Optional[types.ManyRequiredWhereInput] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=models.ManyRequired,
             arguments={'where': where},
             root_selection=['count'],
@@ -1234,8 +1273,7 @@ class ListsBatchActions:
         include: Optional[types.ListsInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=models.Lists,
             arguments={
                 'data': data,
@@ -1253,8 +1291,7 @@ class ListsBatchActions:
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         self._batcher._add(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=models.Lists,
             arguments={
                 'data': data,
@@ -1269,8 +1306,7 @@ class ListsBatchActions:
         include: Optional[types.ListsInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteOne{model}',
+            method='delete',
             model=models.Lists,
             arguments={
                 'where': where,
@@ -1285,8 +1321,7 @@ class ListsBatchActions:
         include: Optional[types.ListsInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateOne{model}',
+            method='update',
             model=models.Lists,
             arguments={
                 'data': data,
@@ -1302,8 +1337,7 @@ class ListsBatchActions:
         include: Optional[types.ListsInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=models.Lists,
             arguments={
                 'where': where,
@@ -1319,8 +1353,7 @@ class ListsBatchActions:
         where: types.ListsWhereInput,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=models.Lists,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -1331,8 +1364,7 @@ class ListsBatchActions:
         where: Optional[types.ListsWhereInput] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=models.Lists,
             arguments={'where': where},
             root_selection=['count'],
@@ -1352,8 +1384,7 @@ class ABatchActions:
         include: Optional[types.AInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=models.A,
             arguments={
                 'data': data,
@@ -1371,8 +1402,7 @@ class ABatchActions:
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         self._batcher._add(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=models.A,
             arguments={
                 'data': data,
@@ -1387,8 +1417,7 @@ class ABatchActions:
         include: Optional[types.AInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteOne{model}',
+            method='delete',
             model=models.A,
             arguments={
                 'where': where,
@@ -1403,8 +1432,7 @@ class ABatchActions:
         include: Optional[types.AInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateOne{model}',
+            method='update',
             model=models.A,
             arguments={
                 'data': data,
@@ -1420,8 +1448,7 @@ class ABatchActions:
         include: Optional[types.AInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=models.A,
             arguments={
                 'where': where,
@@ -1437,8 +1464,7 @@ class ABatchActions:
         where: types.AWhereInput,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=models.A,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -1449,8 +1475,7 @@ class ABatchActions:
         where: Optional[types.AWhereInput] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=models.A,
             arguments={'where': where},
             root_selection=['count'],
@@ -1470,8 +1495,7 @@ class BBatchActions:
         include: Optional[types.BInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=models.B,
             arguments={
                 'data': data,
@@ -1489,8 +1513,7 @@ class BBatchActions:
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         self._batcher._add(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=models.B,
             arguments={
                 'data': data,
@@ -1505,8 +1528,7 @@ class BBatchActions:
         include: Optional[types.BInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteOne{model}',
+            method='delete',
             model=models.B,
             arguments={
                 'where': where,
@@ -1521,8 +1543,7 @@ class BBatchActions:
         include: Optional[types.BInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateOne{model}',
+            method='update',
             model=models.B,
             arguments={
                 'data': data,
@@ -1538,8 +1559,7 @@ class BBatchActions:
         include: Optional[types.BInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=models.B,
             arguments={
                 'where': where,
@@ -1555,8 +1575,7 @@ class BBatchActions:
         where: types.BWhereInput,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=models.B,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -1567,8 +1586,7 @@ class BBatchActions:
         where: Optional[types.BWhereInput] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=models.B,
             arguments={'where': where},
             root_selection=['count'],
@@ -1588,8 +1606,7 @@ class CBatchActions:
         include: Optional[types.CInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=models.C,
             arguments={
                 'data': data,
@@ -1607,8 +1624,7 @@ class CBatchActions:
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         self._batcher._add(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=models.C,
             arguments={
                 'data': data,
@@ -1623,8 +1639,7 @@ class CBatchActions:
         include: Optional[types.CInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteOne{model}',
+            method='delete',
             model=models.C,
             arguments={
                 'where': where,
@@ -1639,8 +1654,7 @@ class CBatchActions:
         include: Optional[types.CInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateOne{model}',
+            method='update',
             model=models.C,
             arguments={
                 'data': data,
@@ -1656,8 +1670,7 @@ class CBatchActions:
         include: Optional[types.CInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=models.C,
             arguments={
                 'where': where,
@@ -1673,8 +1686,7 @@ class CBatchActions:
         where: types.CWhereInput,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=models.C,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -1685,8 +1697,7 @@ class CBatchActions:
         where: Optional[types.CWhereInput] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=models.C,
             arguments={'where': where},
             root_selection=['count'],
@@ -1706,8 +1717,7 @@ class DBatchActions:
         include: Optional[types.DInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=models.D,
             arguments={
                 'data': data,
@@ -1725,8 +1735,7 @@ class DBatchActions:
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         self._batcher._add(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=models.D,
             arguments={
                 'data': data,
@@ -1741,8 +1750,7 @@ class DBatchActions:
         include: Optional[types.DInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteOne{model}',
+            method='delete',
             model=models.D,
             arguments={
                 'where': where,
@@ -1757,8 +1765,7 @@ class DBatchActions:
         include: Optional[types.DInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateOne{model}',
+            method='update',
             model=models.D,
             arguments={
                 'data': data,
@@ -1774,8 +1781,7 @@ class DBatchActions:
         include: Optional[types.DInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=models.D,
             arguments={
                 'where': where,
@@ -1791,8 +1797,7 @@ class DBatchActions:
         where: types.DWhereInput,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=models.D,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -1803,8 +1808,7 @@ class DBatchActions:
         where: Optional[types.DWhereInput] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=models.D,
             arguments={'where': where},
             root_selection=['count'],
@@ -1824,8 +1828,7 @@ class EBatchActions:
         include: Optional[types.EInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='createOne{model}',
+            method='create',
             model=models.E,
             arguments={
                 'data': data,
@@ -1843,8 +1846,7 @@ class EBatchActions:
             raise errors.UnsupportedDatabaseError('sqlite', 'create_many()')
 
         self._batcher._add(
-            operation='mutation',
-            method='createMany{model}',
+            method='create_many',
             model=models.E,
             arguments={
                 'data': data,
@@ -1859,8 +1861,7 @@ class EBatchActions:
         include: Optional[types.EInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteOne{model}',
+            method='delete',
             model=models.E,
             arguments={
                 'where': where,
@@ -1875,8 +1876,7 @@ class EBatchActions:
         include: Optional[types.EInclude] = None
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateOne{model}',
+            method='update',
             model=models.E,
             arguments={
                 'data': data,
@@ -1892,8 +1892,7 @@ class EBatchActions:
         include: Optional[types.EInclude] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='upsertOne{model}',
+            method='upsert',
             model=models.E,
             arguments={
                 'where': where,
@@ -1909,8 +1908,7 @@ class EBatchActions:
         where: types.EWhereInput,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='updateMany{model}',
+            method='update_many',
             model=models.E,
             arguments={'data': data, 'where': where,},
             root_selection=['count'],
@@ -1921,8 +1919,7 @@ class EBatchActions:
         where: Optional[types.EWhereInput] = None,
     ) -> None:
         self._batcher._add(
-            operation='mutation',
-            method='deleteMany{model}',
+            method='delete_many',
             model=models.E,
             arguments={'where': where},
             root_selection=['count'],


### PR DESCRIPTION
## Change Summary

This PR refactors the internal `QueryBuilder` to accept the python method name, e.g. `find_unique`, instead of the internal GraphQL operation + method name.

This makes the middleware implementation easier.

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
