### PR TITLE
define module level docstrings

### DIFF
--- a/src/prisma/generator/templates/actions.py.jinja
+++ b/src/prisma/generator/templates/actions.py.jinja
@@ -1,3 +1,13 @@
+"""
+prisma.actions
+~~~~~~~~~~~~~~
+
+A module that lets you perform certain actions - creating, searching, updating 
+and deleting objects - to the database using a ``prisma.Client`` object.
+
+:auto-generated:
+"""
+
 {% set annotations = true %}
 {% include '_header.py.jinja' %}
 {% from '_utils.py.jinja' import is_async, maybe_async_def, maybe_await, methods, operations, recursive_types, active_provider with context %}

--- a/src/prisma/generator/templates/bases.py.jinja
+++ b/src/prisma/generator/templates/bases.py.jinja
@@ -1,3 +1,13 @@
+"""
+prisma.bases
+~~~~~~~~~~~~
+
+A module that defines all the base models to create complete models
+based on the user defined schema.
+
+:auto-generated:
+"""
+
 {% include '_header.py.jinja' %}
 {% from '_utils.py.jinja' import recursive_types with context %}
 # -- template models.py.jinja --

--- a/src/prisma/generator/templates/client.py.jinja
+++ b/src/prisma/generator/templates/client.py.jinja
@@ -1,3 +1,13 @@
+"""
+prisma.client
+~~~~~~~~~~~~~
+
+Main interface for the Client API - handles connecting, disconnecting
+and querying the underlying Prisma Engine.
+
+:auto-generated:
+"""
+
 {% set annotations = true %}
 {% include '_header.py.jinja' %}
 {% from '_utils.py.jinja' import is_async, maybe_async_def, maybe_await, methods, operations, recursive_types, active_provider with context %}

--- a/src/prisma/generator/templates/enums.py.jinja
+++ b/src/prisma/generator/templates/enums.py.jinja
@@ -1,3 +1,13 @@
+"""
+prisma.enums
+~~~~~~~~~~~~
+
+Defines and make usable all the Enum models
+defined by the user in the schema.
+
+:auto-generated:
+"""
+
 {% include '_header.py.jinja' %}
 # -- template enums.py.jinja --
 from enum import Enum

--- a/src/prisma/generator/templates/http.py.jinja
+++ b/src/prisma/generator/templates/http.py.jinja
@@ -1,3 +1,23 @@
+"""
+prisma.http
+~~~~~~~~~~~
+
+Imports an async or sync HTTP client based on the user
+defined interface in the schema.
+
+For example this generator defined in the schema will generate
+an async HTTP client.
+```prisma
+generator client {
+  provider                    = "prisma-client-py"
+  interface                   = "asyncio"
+  recursive_type_depth        = -1
+}
+```
+
+:auto-generated:
+"""
+
 {% include '_header.py.jinja' %}
 # -- template http.py.jinja --
 {% if generator.config.interface == 'asyncio' %}

--- a/src/prisma/generator/templates/models.py.jinja
+++ b/src/prisma/generator/templates/models.py.jinja
@@ -1,3 +1,13 @@
+"""
+prisma.models
+~~~~~~~~~~~~~
+
+A model that defines all the models defined by the user
+in the schema making them usable.
+
+:auto-generated:
+"""
+
 {% include '_header.py.jinja' %}
 {% from '_utils.py.jinja' import recursive_types with context %}
 # -- template models.py.jinja --

--- a/src/prisma/generator/templates/types.py.jinja
+++ b/src/prisma/generator/templates/types.py.jinja
@@ -1,3 +1,13 @@
+"""
+prisma.types
+~~~~~~~~~~~~
+
+Dinamically generated types based on models and on the user defined
+schema.
+
+:auto-generated:
+"""
+
 {% include '_header.py.jinja' %}
 {% from '_utils.py.jinja' import recursive_types, active_provider with context %}
 # -- template types.py.jinja --


### PR DESCRIPTION
## Change Summary

Please summarise the changes this pull request is making here.

- Closes GH-272 defining module level dosctrings

Hi, my wording isn't that great so if someone wants to suggests changes it would be much appreciated.
Furthermore i haven't defined docstrings for

- builder.py.jinja
- fields.py.jinja
- partials.py.jinja

because i'm unsure how to describe them. Additionally i was wondering if we could use examples (in docstrings) where possible and (maybe) generate them dinamycally (using jinja funtionalities) based on models etc...

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
