### PR TITLE
fix(generator): don't truncate datetime field precision

### DIFF
--- a/src/prisma/generator/templates/builder.py.jinja
+++ b/src/prisma/generator/templates/builder.py.jinja
@@ -810,9 +810,6 @@ def serialize_datetime(dt: datetime.datetime) -> str:
     elif dt.tzinfo != timezone.utc:
         dt = dt.astimezone(timezone.utc)
 
-    # truncate microseconds to 3 decimal places
-    # https://github.com/RobertCraigie/prisma-client-py/issues/129
-    dt = dt.replace(microsecond=int(dt.microsecond / 1000) * 1000)
     return dt.isoformat()
 
 


### PR DESCRIPTION
closes #804

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.

## Change Summary

Please summarise the changes this pull request is making here.

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
