### PR TITLE
feat(client): time params accept `datetime.timedelta`

### DIFF
--- a/databases/sync_tests/test_transactions.py
+++ b/databases/sync_tests/test_transactions.py
@@ -12,7 +12,7 @@ from ..utils import CURRENT_DATABASE
 
 def test_model_query(client: Prisma) -> None:
     """Basic usage within model queries"""
-    with client.tx(timeout=timedelta(milliseconds=1_000)) as tx:
+    with client.tx(timeout=timedelta(milliseconds=1000)) as tx:
         user = User.prisma(tx).create({'name': 'Robert'})
         assert user.name == 'Robert'
 
@@ -42,7 +42,7 @@ def test_model_query(client: Prisma) -> None:
 
 def test_context_manager(client: Prisma) -> None:
     """Basic usage within a context manager"""
-    with client.tx(timeout=timedelta(milliseconds=1_000)) as transaction:
+    with client.tx(timeout=timedelta(milliseconds=1000)) as transaction:
         user = transaction.user.create({'name': 'Robert'})
         assert user.name == 'Robert'
 
@@ -88,7 +88,7 @@ def test_context_manager_auto_rollback(client: Prisma) -> None:
 
 def test_batch_within_transaction(client: Prisma) -> None:
     """Query batching can be used within transactions"""
-    with client.tx(timeout=timedelta(milliseconds=10_000)) as transaction:
+    with client.tx(timeout=timedelta(milliseconds=10000)) as transaction:
         with transaction.batch_() as batcher:
             batcher.user.create({'name': 'Tegan'})
             batcher.user.create({'name': 'Robert'})
@@ -118,7 +118,7 @@ def test_timeout(client: Prisma) -> None:
 )
 def test_concurrent_transactions(client: Prisma) -> None:
     """Two separate transactions can be used independently of each other at the same time"""
-    timeout = timedelta(milliseconds=15_000)
+    timeout = timedelta(milliseconds=15000)
     with client.tx(timeout=timeout) as tx1, client.tx(timeout=timeout) as tx2:
         user1 = tx1.user.create({'name': 'Tegan'})
         user2 = tx2.user.create({'name': 'Robert'})

--- a/databases/sync_tests/test_transactions.py
+++ b/databases/sync_tests/test_transactions.py
@@ -1,4 +1,5 @@
 import time
+from datetime import timedelta
 from typing import Optional
 
 import pytest
@@ -11,7 +12,7 @@ from ..utils import CURRENT_DATABASE
 
 def test_model_query(client: Prisma) -> None:
     """Basic usage within model queries"""
-    with client.tx(timeout=10 * 100) as tx:
+    with client.tx(timeout=timedelta(milliseconds=1_000)) as tx:
         user = User.prisma(tx).create({'name': 'Robert'})
         assert user.name == 'Robert'
 
@@ -41,7 +42,7 @@ def test_model_query(client: Prisma) -> None:
 
 def test_context_manager(client: Prisma) -> None:
     """Basic usage within a context manager"""
-    with client.tx(timeout=10 * 100) as transaction:
+    with client.tx(timeout=timedelta(milliseconds=1_000)) as transaction:
         user = transaction.user.create({'name': 'Robert'})
         assert user.name == 'Robert'
 
@@ -87,7 +88,7 @@ def test_context_manager_auto_rollback(client: Prisma) -> None:
 
 def test_batch_within_transaction(client: Prisma) -> None:
     """Query batching can be used within transactions"""
-    with client.tx(timeout=10000) as transaction:
+    with client.tx(timeout=timedelta(milliseconds=10_000)) as transaction:
         with transaction.batch_() as batcher:
             batcher.user.create({'name': 'Tegan'})
             batcher.user.create({'name': 'Robert'})
@@ -103,7 +104,7 @@ def test_timeout(client: Prisma) -> None:
     # this outer block is necessary becuse to the context manager it appears that no error
     # ocurred so it will attempt to commit the transaction, triggering the expired error again
     with pytest.raises(prisma.errors.TransactionExpiredError):
-        with client.tx(timeout=50) as transaction:
+        with client.tx(timeout=timedelta(milliseconds=50)) as transaction:
             time.sleep(0.05)
 
             with pytest.raises(prisma.errors.TransactionExpiredError) as exc:
@@ -117,7 +118,7 @@ def test_timeout(client: Prisma) -> None:
 )
 def test_concurrent_transactions(client: Prisma) -> None:
     """Two separate transactions can be used independently of each other at the same time"""
-    timeout = 15000
+    timeout = timedelta(milliseconds=15_000)
     with client.tx(timeout=timeout) as tx1, client.tx(timeout=timeout) as tx2:
         user1 = tx1.user.create({'name': 'Tegan'})
         user2 = tx2.user.create({'name': 'Robert'})

--- a/databases/tests/test_transactions.py
+++ b/databases/tests/test_transactions.py
@@ -92,9 +92,7 @@ async def test_context_manager_auto_rollback(client: Prisma) -> None:
 @pytest.mark.asyncio
 async def test_batch_within_transaction(client: Prisma) -> None:
     """Query batching can be used within transactions"""
-    async with client.tx(
-        timeout=timedelta(milliseconds=10000)
-    ) as transaction:
+    async with client.tx(timeout=timedelta(milliseconds=10000)) as transaction:
         async with transaction.batch_() as batcher:
             batcher.user.create({'name': 'Tegan'})
             batcher.user.create({'name': 'Robert'})

--- a/databases/tests/test_transactions.py
+++ b/databases/tests/test_transactions.py
@@ -92,7 +92,9 @@ async def test_context_manager_auto_rollback(client: Prisma) -> None:
 @pytest.mark.asyncio
 async def test_batch_within_transaction(client: Prisma) -> None:
     """Query batching can be used within transactions"""
-    async with client.tx(timeout=timedelta(milliseconds=10_000)) as transaction:
+    async with client.tx(
+        timeout=timedelta(milliseconds=10_000)
+    ) as transaction:
         async with transaction.batch_() as batcher:
             batcher.user.create({'name': 'Tegan'})
             batcher.user.create({'name': 'Robert'})
@@ -109,7 +111,9 @@ async def test_timeout(client: Prisma) -> None:
     # this outer block is necessary becuse to the context manager it appears that no error
     # ocurred so it will attempt to commit the transaction, triggering the expired error again
     with pytest.raises(prisma.errors.TransactionExpiredError):
-        async with client.tx(timeout=timedelta(milliseconds=50)) as transaction:
+        async with client.tx(
+            timeout=timedelta(milliseconds=50)
+        ) as transaction:
             await asyncio.sleep(0.05)
 
             with pytest.raises(prisma.errors.TransactionExpiredError) as exc:

--- a/databases/tests/test_transactions.py
+++ b/databases/tests/test_transactions.py
@@ -13,7 +13,7 @@ from ..utils import CURRENT_DATABASE
 @pytest.mark.asyncio
 async def test_model_query(client: Prisma) -> None:
     """Basic usage within model queries"""
-    async with client.tx(timeout=timedelta(milliseconds=1_000)) as tx:
+    async with client.tx(timeout=timedelta(milliseconds=1000)) as tx:
         user = await User.prisma(tx).create({'name': 'Robert'})
         assert user.name == 'Robert'
 
@@ -44,7 +44,7 @@ async def test_model_query(client: Prisma) -> None:
 @pytest.mark.asyncio
 async def test_context_manager(client: Prisma) -> None:
     """Basic usage within a context manager"""
-    async with client.tx(timeout=timedelta(milliseconds=1_000)) as transaction:
+    async with client.tx(timeout=timedelta(milliseconds=1000)) as transaction:
         user = await transaction.user.create({'name': 'Robert'})
         assert user.name == 'Robert'
 
@@ -93,7 +93,7 @@ async def test_context_manager_auto_rollback(client: Prisma) -> None:
 async def test_batch_within_transaction(client: Prisma) -> None:
     """Query batching can be used within transactions"""
     async with client.tx(
-        timeout=timedelta(milliseconds=10_000)
+        timeout=timedelta(milliseconds=10000)
     ) as transaction:
         async with transaction.batch_() as batcher:
             batcher.user.create({'name': 'Tegan'})
@@ -128,7 +128,7 @@ async def test_timeout(client: Prisma) -> None:
 )
 async def test_concurrent_transactions(client: Prisma) -> None:
     """Two separate transactions can be used independently of each other at the same time"""
-    timeout = timedelta(milliseconds=15_000)
+    timeout = timedelta(milliseconds=15000)
     async with client.tx(timeout=timeout) as tx1, client.tx(
         timeout=timeout
     ) as tx2:

--- a/src/prisma/_constants.py
+++ b/src/prisma/_constants.py
@@ -1,5 +1,10 @@
+from datetime import timedelta
 from typing import Dict
 
+
+DEFAULT_CONNECT_TIMEOUT: timedelta = timedelta(seconds=10)
+DEFAULT_TX_MAX_WAIT: timedelta = timedelta(milliseconds=2000)
+DEFAULT_TX_TIMEOUT: timedelta = timedelta(milliseconds=5000)
 
 # key aliases to transform query arguments to make them more pythonic
 QUERY_BUILDER_ALIASES: Dict[str, str] = {

--- a/src/prisma/_constants.py
+++ b/src/prisma/_constants.py
@@ -3,8 +3,8 @@ from typing import Dict
 
 
 DEFAULT_CONNECT_TIMEOUT: timedelta = timedelta(seconds=10)
-DEFAULT_TX_MAX_WAIT: timedelta = timedelta(milliseconds=2000)
-DEFAULT_TX_TIMEOUT: timedelta = timedelta(milliseconds=5000)
+DEFAULT_TX_MAX_WAIT: timedelta = timedelta(milliseconds=2_000)
+DEFAULT_TX_TIMEOUT: timedelta = timedelta(milliseconds=5_000)
 
 # key aliases to transform query arguments to make them more pythonic
 QUERY_BUILDER_ALIASES: Dict[str, str] = {

--- a/src/prisma/_constants.py
+++ b/src/prisma/_constants.py
@@ -3,8 +3,8 @@ from typing import Dict
 
 
 DEFAULT_CONNECT_TIMEOUT: timedelta = timedelta(seconds=10)
-DEFAULT_TX_MAX_WAIT: timedelta = timedelta(milliseconds=2_000)
-DEFAULT_TX_TIMEOUT: timedelta = timedelta(milliseconds=5_000)
+DEFAULT_TX_MAX_WAIT: timedelta = timedelta(milliseconds=2000)
+DEFAULT_TX_TIMEOUT: timedelta = timedelta(milliseconds=5000)
 
 # key aliases to transform query arguments to make them more pythonic
 QUERY_BUILDER_ALIASES: Dict[str, str] = {

--- a/src/prisma/generator/templates/client.py.jinja
+++ b/src/prisma/generator/templates/client.py.jinja
@@ -267,11 +267,18 @@ class Prisma:
             datasources=datasources,
         )
 
-    {{ maybe_async_def }}disconnect(self, timeout: Optional[float] = None) -> None:
+    {{ maybe_async_def }}disconnect(self, timeout: Union[float, timedelta, None] = None) -> None:
         """Disconnect the Prisma query engine."""
         if self.__engine is not None:
             engine = self.__engine
             self.__engine = None
+            if isinstance(timeout, float):
+                warnings.warn(
+                    'Passing a float as `timeout` argument is deprecated. Use datetime.timedelta instance instead.',
+                    DeprecationWarning,
+                    stacklevel=3,
+                )
+                timeout = timedelta(seconds=timeout)
             {% if is_async %}
             await engine.aclose(timeout=timeout)
             {% else %}

--- a/src/prisma/generator/templates/client.py.jinja
+++ b/src/prisma/generator/templates/client.py.jinja
@@ -161,11 +161,12 @@ class Prisma:
         self._log_queries = log_queries
         self._datasource = datasource
         if isinstance(connect_timeout, int):
-            warnings.warn(
-                'Passing a int as `connect_timeout` argument is deprecated. Use datetime.timedelta instance instead.',
-                DeprecationWarning,
-                stacklevel=3,
+            message = (
+                'Passing a int as `connect_timeout` argument is deprecated'
+                ' and will be removed in the next major release.\n'
+                'Use datetime.timedelta instance instead.'
             )
+            warnings.warn(message, DeprecationWarning, stacklevel=4)
             connect_timeout = timedelta(seconds=connect_timeout)
         self._connect_timeout = connect_timeout
         self._http_config: HttpConfig = http or {}
@@ -240,11 +241,12 @@ class Prisma:
             timeout = self._connect_timeout
 
         if isinstance(timeout, int):
-            warnings.warn(
-                'Passing a int as `timeout` argument is deprecated. Use datetime.timedelta instance instead.',
-                DeprecationWarning,
-                stacklevel=3,
+            message = (
+                'Passing a int as `timeout` argument is deprecated'
+                ' and will be removed in the next major release.\n'
+                'Use datetime.timedelta instance instead.'
             )
+            warnings.warn(message, DeprecationWarning, stacklevel=4)
             timeout = timedelta(seconds=timeout)
 
         if self.__engine is None:
@@ -273,11 +275,12 @@ class Prisma:
             engine = self.__engine
             self.__engine = None
             if isinstance(timeout, float):
-                warnings.warn(
-                    'Passing a float as `timeout` argument is deprecated. Use datetime.timedelta instance instead.',
-                    DeprecationWarning,
-                    stacklevel=3,
+                message = (
+                    'Passing a float as `timeout` argument is deprecated'
+                    ' and will be removed in the next major release.\n'
+                    'Use datetime.timedelta instance instead.'
                 )
+                warnings.warn(message, DeprecationWarning, stacklevel=4)
                 timeout = timedelta(seconds=timeout)
             {% if is_async %}
             await engine.aclose(timeout=timeout)
@@ -511,19 +514,21 @@ class TransactionManager:
     def __init__(self, *, client: Prisma, max_wait: Union[int, timedelta], timeout: Union[int, timedelta]) -> None:
         self.__client = client
         if isinstance(max_wait, int):
-            warnings.warn(
-                'Passing a int as `max_wait` argument is deprecated. Use datetime.timedelta instance instead.',
-                DeprecationWarning,
-                stacklevel=3,
+            message = (
+                'Passing a int as `max_wait` argument is deprecated'
+                ' and will be removed in the next major release.\n'
+                'Use datetime.timedelta instance instead.'
             )
+            warnings.warn(message, DeprecationWarning, stacklevel=4)
             max_wait = timedelta(milliseconds=max_wait)
         self._max_wait = max_wait
         if isinstance(timeout, int):
-            warnings.warn(
-                'Passing a int as `timeout` argument is deprecated. Use datetime.timedelta instance instead.',
-                DeprecationWarning,
-                stacklevel=3,
+            message = (
+                'Passing a int as `timeout` argument is deprecated'
+                ' and will be removed in the next major release.\n'
+                'Use datetime.timedelta instance instead.'
             )
+            warnings.warn(message, DeprecationWarning, stacklevel=4)
             timeout = timedelta(milliseconds=timeout)
         self._timeout = timeout
         self._tx_id: Optional[TransactionId] = None

--- a/src/prisma/generator/templates/client.py.jinja
+++ b/src/prisma/generator/templates/client.py.jinja
@@ -4,6 +4,7 @@
 # -- template client.py.jinja --
 import warnings
 import logging
+from datetime import timedelta
 from pathlib import Path
 from types import TracebackType
 
@@ -17,6 +18,7 @@ from .engine import AbstractEngine, QueryEngine, TransactionId
 from .builder import QueryBuilder, dumps
 from .generator.models import EngineType, OptionalValueFromEnvVar, BinaryPaths
 from ._compat import removeprefix
+from ._constants import DEFAULT_CONNECT_TIMEOUT, DEFAULT_TX_MAX_WAIT, DEFAULT_TX_TIMEOUT
 from ._raw_query import deserialize_raw_results
 
 __all__ = (
@@ -47,13 +49,13 @@ class UseClientDefault:
     by typing the parameter with this class rather than using None, for example:
 
     ```py
-    def connect(timeout: Union[int, UseClientDefault] = UseClientDefault()) -> None: ...
+    def connect(timeout: Union[int, timedelta, UseClientDefault] = UseClientDefault()) -> None: ...
     ```
 
     relays the intention more clearly than:
 
     ```py
-    def connect(timeout: Optional[int] = None) -> None: ...
+    def connect(timeout: Union[int, timedelta, None] = None) -> None: ...
     ```
 
     This solution also allows us to indicate an "unset" state that is uniquely distinct
@@ -145,7 +147,7 @@ class Prisma:
         log_queries: bool = False,
         auto_register: bool = False,
         datasource: Optional[DatasourceOverride] = None,
-        connect_timeout: int = 10,
+        connect_timeout: Union[int, timedelta] = DEFAULT_CONNECT_TIMEOUT,
         http: Optional[HttpConfig] = None,
     ) -> None:
         {% for model in dmmf.datamodel.models %}
@@ -158,6 +160,13 @@ class Prisma:
         self._active_provider = '{{ active_provider }}'
         self._log_queries = log_queries
         self._datasource = datasource
+        if isinstance(connect_timeout, int):
+            warnings.warn(
+                'Passing a int as `connect_timeout` argument is deprecated. Use datetime.timedelta instance instead.',
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            connect_timeout = timedelta(seconds=connect_timeout)
         self._connect_timeout = connect_timeout
         self._http_config: HttpConfig = http or {}
         self._tx_id: Optional[TransactionId] = None
@@ -221,7 +230,7 @@ class Prisma:
 
     {{ maybe_async_def }}connect(
         self,
-        timeout: Union[int, UseClientDefault] = _USE_CLIENT_DEFAULT,
+        timeout: Union[int, timedelta, UseClientDefault] = _USE_CLIENT_DEFAULT,
     ) -> None:
         """Connect to the Prisma query engine.
 
@@ -229,6 +238,14 @@ class Prisma:
         """
         if isinstance(timeout, UseClientDefault):
             timeout = self._connect_timeout
+
+        if isinstance(timeout, int):
+            warnings.warn(
+                'Passing a int as `timeout` argument is deprecated. Use datetime.timedelta instance instead.',
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            timeout = timedelta(seconds=timeout)
 
         if self.__engine is None:
             self.__engine = self._create_engine(dml_path=PACKAGED_SCHEMA_PATH)
@@ -360,7 +377,12 @@ class Prisma:
         """Returns a context manager for grouping write queries into a single transaction."""
         return Batch(client=self)
 
-    def tx(self, *, max_wait: int = 2000, timeout: int = 5000) -> 'TransactionManager':
+    def tx(
+        self,
+        *,
+        max_wait: Union[int, timedelta] = DEFAULT_TX_MAX_WAIT,
+        timeout: Union[int, timedelta] = DEFAULT_TX_TIMEOUT,
+    ) -> 'TransactionManager':
         """Returns a context manager for executing queries within a database transaction.
 
         Entering the context manager returns a new Prisma instance wrapping all
@@ -368,10 +390,10 @@ class Prisma:
         will not be commited to the database until the context manager exits.
 
         By default, Prisma will wait a maximum of 2 seconds to acquire a transaction from the database. You can modify this
-        defualt with the `max_wait` argument which accepts a value in milliseconds.
+        defualt with the `max_wait` argument which accepts a value in milliseconds or `datetime.timedelta`.
 
         By default, Prisma will cancel and rollback ay transactions that last longer than 5 seconds. You can modify this timeout
-        with the `timeout` argument which accepts a value in milliseconds.
+        with the `timeout` argument which accepts a value in milliseconds or `datetime.timedelta`.
 
         Example usage:
 
@@ -479,9 +501,23 @@ class TransactionManager:
     through the Prisma.tx() method.
     """
 
-    def __init__(self, *, client: Prisma, max_wait: int, timeout: int) -> None:
+    def __init__(self, *, client: Prisma, max_wait: Union[int, timedelta], timeout: Union[int, timedelta]) -> None:
         self.__client = client
+        if isinstance(max_wait, int):
+            warnings.warn(
+                'Passing a int as `max_wait` argument is deprecated. Use datetime.timedelta instance instead.',
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            max_wait = timedelta(milliseconds=max_wait)
         self._max_wait = max_wait
+        if isinstance(timeout, int):
+            warnings.warn(
+                'Passing a int as `timeout` argument is deprecated. Use datetime.timedelta instance instead.',
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            timeout = timedelta(milliseconds=timeout)
         self._timeout = timeout
         self._tx_id: Optional[TransactionId] = None
 
@@ -499,8 +535,8 @@ class TransactionManager:
         tx_id = {{ maybe_await }}self.__client._engine.start_transaction(
             content=dumps(
                 {
-                    'timeout': self._timeout,
-                    'max_wait': self._max_wait,
+                    'timeout': int(self._timeout.total_seconds() * 1000),
+                    'max_wait': int(self._max_wait.total_seconds() * 1000),
                 }
             ),
         )

--- a/src/prisma/generator/templates/engine/abstract.py.jinja
+++ b/src/prisma/generator/templates/engine/abstract.py.jinja
@@ -18,11 +18,8 @@ __all__ = (
 class AbstractEngine(ABC):
     dml: str
 
-    def stop(self, *, timeout: Optional[float] = None) -> None:
-        """Wrapper for synchronously calling close() and aclose()
-
-        The `timeout` argument is in seconds.
-        """
+    def stop(self, *, timeout: Optional[timedelta] = None) -> None:
+        """Wrapper for synchronously calling close() and aclose()"""
         self.close(timeout=timeout)
         try:
             loop = get_running_loop()
@@ -34,20 +31,13 @@ class AbstractEngine(ABC):
                 loop.create_task(self.aclose(timeout=timeout))
 
     @abstractmethod
-    def close(self, *, timeout: Optional[float] = None) -> None:
-        """Synchronous method for closing the engine, useful if the underlying engine uses a subprocess
-
-        The `timeout` argument is in seconds.
-        """
+    def close(self, *, timeout: Optional[timedelta] = None) -> None:
+        """Synchronous method for closing the engine, useful if the underlying engine uses a subprocess"""
         ...
 
     @abstractmethod
-    async def aclose(self, *, timeout: Optional[float] = None) -> None:
-        """Asynchronous method for closing the engine, only used if an
-        asynchronous client is generated.
-
-        The `timeout` argument is in seconds.
-        """
+    async def aclose(self, *, timeout: Optional[timedelta] = None) -> None:
+        """Asynchronous method for closing the engine, only used if an asynchronous client is generated"""
         ...
 
     @abstractmethod

--- a/src/prisma/generator/templates/engine/abstract.py.jinja
+++ b/src/prisma/generator/templates/engine/abstract.py.jinja
@@ -3,9 +3,11 @@
 {% from '_utils.py.jinja' import maybe_async_def with context %}
 # -- template engine/abstract.py.jinja --
 from abc import ABC, abstractmethod
+from datetime import timedelta
 from ._types import TransactionId
 from ..types import DatasourceOverride
 from .._compat import get_running_loop
+from .._constants import DEFAULT_CONNECT_TIMEOUT
 
 
 __all__ = (
@@ -51,7 +53,7 @@ class AbstractEngine(ABC):
     @abstractmethod
     {{ maybe_async_def }}connect(
         self,
-        timeout: int = 10,
+        timeout: timedelta = DEFAULT_CONNECT_TIMEOUT,
         datasources: Optional[List[DatasourceOverride]] = None,
     ) -> None:
         """Connect to the engine"""

--- a/src/prisma/generator/templates/engine/http.py.jinja
+++ b/src/prisma/generator/templates/engine/http.py.jinja
@@ -3,6 +3,7 @@
 # -- template engine/http.py.jinja --
 
 import logging
+from datetime import timedelta
 
 from . import utils, errors
 from .abstract import AbstractEngine
@@ -35,16 +36,16 @@ class HTTPEngine(AbstractEngine):
         self.headers = headers if headers is not None else {}
 
     {% if is_async %}
-    def close(self, *, timeout: Optional[float] = None) -> None:
+    def close(self, *, timeout: Optional[timedelta] = None) -> None:
         pass
 
-    async def aclose(self, *, timeout: Optional[float] = None) -> None:
+    async def aclose(self, *, timeout: Optional[timedelta] = None) -> None:
         await self._close_session()
     {% else %}
-    def close(self, *, timeout: Optional[float] = None) -> None:
+    def close(self, *, timeout: Optional[timedelta] = None) -> None:
         self._close_session()
 
-    async def aclose(self, *, timeout: Optional[float] = None) -> None:
+    async def aclose(self, *, timeout: Optional[timedelta] = None) -> None:
         pass
     {% endif %}
 

--- a/src/prisma/generator/templates/engine/query.py.jinja
+++ b/src/prisma/generator/templates/engine/query.py.jinja
@@ -46,8 +46,11 @@ class QueryEngine(HTTPEngine):
         # ensure the query engine process is terminated when we are
         atexit.register(self.stop)
 
-    def close(self, *, timeout: Optional[float] = None) -> None:
+    def close(self, *, timeout: Optional[timedelta] = None) -> None:
         log.debug('Disconnecting query engine...')
+
+        if timeout is not None:
+            timeout = timeout.total_seconds()
 
         if self.process is not None:
             if platform.name() == 'windows':
@@ -67,7 +70,7 @@ class QueryEngine(HTTPEngine):
         {% endif %}
         log.debug('Disconnected query engine')
 
-    async def aclose(self, *, timeout: Optional[float] = None) -> None:
+    async def aclose(self, *, timeout: Optional[timedelta] = None) -> None:
         self.close(timeout=timeout)
         {{ maybe_await }}self._close_session()
 

--- a/src/prisma/generator/templates/engine/query.py.jinja
+++ b/src/prisma/generator/templates/engine/query.py.jinja
@@ -10,6 +10,7 @@ import signal
 import asyncio
 import logging
 import subprocess
+from datetime import timedelta
 from pathlib import Path
 
 from . import utils, errors
@@ -20,6 +21,7 @@ from ..binaries import platform
 from ..utils import time_since, _env_bool
 from ..types import DatasourceOverride
 from ..builder import dumps
+from .._constants import DEFAULT_CONNECT_TIMEOUT
 from ._types import TransactionId
 
 
@@ -81,7 +83,7 @@ class QueryEngine(HTTPEngine):
 
     {{ maybe_async_def }}connect(
         self,
-        timeout: int = 10,
+        timeout: timedelta = DEFAULT_CONNECT_TIMEOUT,
         datasources: Optional[List[DatasourceOverride]] = None,
     ) -> None:
         log.debug('Connecting to query engine')
@@ -102,7 +104,7 @@ class QueryEngine(HTTPEngine):
     {{ maybe_async_def }}spawn(
         self,
         file: Path,
-        timeout: int = 10,
+        timeout: timedelta = DEFAULT_CONNECT_TIMEOUT,
         datasources: Optional[List[DatasourceOverride]] = None,
     ) -> None:
         port = utils.get_open_port()
@@ -154,7 +156,7 @@ class QueryEngine(HTTPEngine):
         )
 
         last_exc = None
-        for _ in range(int(timeout / 0.1)):
+        for _ in range(int(timeout.total_seconds() / 0.1)):
             try:
                 data = {{ maybe_await }}self.request('GET', '/status')
             except Exception as exc:

--- a/src/prisma/generator/templates/engine/query.py.jinja
+++ b/src/prisma/generator/templates/engine/query.py.jinja
@@ -50,16 +50,18 @@ class QueryEngine(HTTPEngine):
         log.debug('Disconnecting query engine...')
 
         if timeout is not None:
-            timeout = timeout.total_seconds()
+            total_seconds = timeout.total_seconds()
+        else:
+            total_seconds = None
 
         if self.process is not None:
             if platform.name() == 'windows':
                 self.process.kill()
-                self.process.wait(timeout=timeout)
+                self.process.wait(timeout=total_seconds)
             else:
                 self.process.send_signal(signal.SIGINT)
                 try:
-                    self.process.wait(timeout=timeout)
+                    self.process.wait(timeout=total_seconds)
                 except subprocess.TimeoutExpired:
                     self.process.send_signal(signal.SIGKILL)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping
 
@@ -54,7 +55,7 @@ async def test_datasource_overwriting(
     other = Prisma(
         datasource={'url': 'file:./tmp.db'},
     )
-    await other.connect(timeout=1)
+    await other.connect(timeout=timedelta(seconds=1))
 
     user = await other.user.create({'name': 'Robert'})
     assert user.name == 'Robert'
@@ -98,7 +99,7 @@ def test_engine_type() -> None:
 @pytest.mark.asyncio
 async def test_connect_timeout(mocker: MockerFixture) -> None:
     """Setting the timeout on a client and a per-call basis works"""
-    client = Prisma(connect_timeout=7)
+    client = Prisma(connect_timeout=timedelta(seconds=7))
     mocked = mocker.patch.object(
         client._engine_class,
         'connect',
@@ -107,14 +108,14 @@ async def test_connect_timeout(mocker: MockerFixture) -> None:
 
     await client.connect()
     mocked.assert_called_once_with(
-        timeout=7,
+        timeout=timedelta(seconds=7),
         datasources=[client._make_sqlite_datasource()],
     )
     mocked.reset_mock()
 
-    await client.connect(timeout=5)
+    await client.connect(timeout=timedelta(seconds=5))
     mocked.assert_called_once_with(
-        timeout=5,
+        timeout=timedelta(seconds=5),
         datasources=[client._make_sqlite_datasource()],
     )
 
@@ -214,7 +215,7 @@ async def test_copy() -> None:
         datasource={
             'url': 'file:foo.db',
         },
-        connect_timeout=15,
+        connect_timeout=timedelta(seconds=15),
         http={
             'trust_env': False,
         },
@@ -223,7 +224,7 @@ async def test_copy() -> None:
     assert not client2.is_connected() is None
     assert client2._log_queries is True
     assert client2._datasource == {'url': 'file:foo.db'}
-    assert client2._connect_timeout == 15
+    assert client2._connect_timeout == timedelta(seconds=15)
     assert client2._http_config == {'trust_env': False}
 
     await client1.connect()

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
@@ -311,11 +311,18 @@ class Prisma:
             datasources=datasources,
         )
 
-    async def disconnect(self, timeout: Optional[float] = None) -> None:
+    async def disconnect(self, timeout: Union[float, timedelta, None] = None) -> None:
         """Disconnect the Prisma query engine."""
         if self.__engine is not None:
             engine = self.__engine
             self.__engine = None
+            if isinstance(timeout, float):
+                warnings.warn(
+                    'Passing a float as `timeout` argument is deprecated. Use datetime.timedelta instance instead.',
+                    DeprecationWarning,
+                    stacklevel=3,
+                )
+                timeout = timedelta(seconds=timeout)
             await engine.aclose(timeout=timeout)
             engine.stop(timeout=timeout)
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
@@ -42,6 +42,7 @@ LiteralString = str
 # -- template client.py.jinja --
 import warnings
 import logging
+from datetime import timedelta
 from pathlib import Path
 from types import TracebackType
 
@@ -55,6 +56,7 @@ from .engine import AbstractEngine, QueryEngine, TransactionId
 from .builder import QueryBuilder, dumps
 from .generator.models import EngineType, OptionalValueFromEnvVar, BinaryPaths
 from ._compat import removeprefix
+from ._constants import DEFAULT_CONNECT_TIMEOUT, DEFAULT_TX_MAX_WAIT, DEFAULT_TX_TIMEOUT
 from ._raw_query import deserialize_raw_results
 
 __all__ = (
@@ -85,13 +87,13 @@ class UseClientDefault:
     by typing the parameter with this class rather than using None, for example:
 
     ```py
-    def connect(timeout: Union[int, UseClientDefault] = UseClientDefault()) -> None: ...
+    def connect(timeout: Union[int, timedelta, UseClientDefault] = UseClientDefault()) -> None: ...
     ```
 
     relays the intention more clearly than:
 
     ```py
-    def connect(timeout: Optional[int] = None) -> None: ...
+    def connect(timeout: Union[int, timedelta, None] = None) -> None: ...
     ```
 
     This solution also allows us to indicate an "unset" state that is uniquely distinct
@@ -201,7 +203,7 @@ class Prisma:
         log_queries: bool = False,
         auto_register: bool = False,
         datasource: Optional[DatasourceOverride] = None,
-        connect_timeout: int = 10,
+        connect_timeout: Union[int, timedelta] = DEFAULT_CONNECT_TIMEOUT,
         http: Optional[HttpConfig] = None,
     ) -> None:
         self.post = actions.PostActions[models.Post](self, models.Post)
@@ -223,6 +225,13 @@ class Prisma:
         self._active_provider = 'postgresql'
         self._log_queries = log_queries
         self._datasource = datasource
+        if isinstance(connect_timeout, int):
+            warnings.warn(
+                'Passing a int as `connect_timeout` argument is deprecated. Use datetime.timedelta instance instead.',
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            connect_timeout = timedelta(seconds=connect_timeout)
         self._connect_timeout = connect_timeout
         self._http_config: HttpConfig = http or {}
         self._tx_id: Optional[TransactionId] = None
@@ -271,7 +280,7 @@ class Prisma:
 
     async def connect(
         self,
-        timeout: Union[int, UseClientDefault] = _USE_CLIENT_DEFAULT,
+        timeout: Union[int, timedelta, UseClientDefault] = _USE_CLIENT_DEFAULT,
     ) -> None:
         """Connect to the Prisma query engine.
 
@@ -279,6 +288,14 @@ class Prisma:
         """
         if isinstance(timeout, UseClientDefault):
             timeout = self._connect_timeout
+
+        if isinstance(timeout, int):
+            warnings.warn(
+                'Passing a int as `timeout` argument is deprecated. Use datetime.timedelta instance instead.',
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            timeout = timedelta(seconds=timeout)
 
         if self.__engine is None:
             self.__engine = self._create_engine(dml_path=PACKAGED_SCHEMA_PATH)
@@ -398,7 +415,12 @@ class Prisma:
         """Returns a context manager for grouping write queries into a single transaction."""
         return Batch(client=self)
 
-    def tx(self, *, max_wait: int = 2000, timeout: int = 5000) -> 'TransactionManager':
+    def tx(
+        self,
+        *,
+        max_wait: Union[int, timedelta] = DEFAULT_TX_MAX_WAIT,
+        timeout: Union[int, timedelta] = DEFAULT_TX_TIMEOUT,
+    ) -> 'TransactionManager':
         """Returns a context manager for executing queries within a database transaction.
 
         Entering the context manager returns a new Prisma instance wrapping all
@@ -406,10 +428,10 @@ class Prisma:
         will not be commited to the database until the context manager exits.
 
         By default, Prisma will wait a maximum of 2 seconds to acquire a transaction from the database. You can modify this
-        defualt with the `max_wait` argument which accepts a value in milliseconds.
+        defualt with the `max_wait` argument which accepts a value in milliseconds or `datetime.timedelta`.
 
         By default, Prisma will cancel and rollback ay transactions that last longer than 5 seconds. You can modify this timeout
-        with the `timeout` argument which accepts a value in milliseconds.
+        with the `timeout` argument which accepts a value in milliseconds or `datetime.timedelta`.
 
         Example usage:
 
@@ -517,9 +539,23 @@ class TransactionManager:
     through the Prisma.tx() method.
     """
 
-    def __init__(self, *, client: Prisma, max_wait: int, timeout: int) -> None:
+    def __init__(self, *, client: Prisma, max_wait: Union[int, timedelta], timeout: Union[int, timedelta]) -> None:
         self.__client = client
+        if isinstance(max_wait, int):
+            warnings.warn(
+                'Passing a int as `max_wait` argument is deprecated. Use datetime.timedelta instance instead.',
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            max_wait = timedelta(milliseconds=max_wait)
         self._max_wait = max_wait
+        if isinstance(timeout, int):
+            warnings.warn(
+                'Passing a int as `timeout` argument is deprecated. Use datetime.timedelta instance instead.',
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            timeout = timedelta(milliseconds=timeout)
         self._timeout = timeout
         self._tx_id: Optional[TransactionId] = None
 
@@ -537,8 +573,8 @@ class TransactionManager:
         tx_id = await self.__client._engine.start_transaction(
             content=dumps(
                 {
-                    'timeout': self._timeout,
-                    'max_wait': self._max_wait,
+                    'timeout': int(self._timeout.total_seconds() * 1000),
+                    'max_wait': int(self._max_wait.total_seconds() * 1000),
                 }
             ),
         )

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
@@ -226,11 +226,12 @@ class Prisma:
         self._log_queries = log_queries
         self._datasource = datasource
         if isinstance(connect_timeout, int):
-            warnings.warn(
-                'Passing a int as `connect_timeout` argument is deprecated. Use datetime.timedelta instance instead.',
-                DeprecationWarning,
-                stacklevel=3,
+            message = (
+                'Passing a int as `connect_timeout` argument is deprecated'
+                ' and will be removed in the next major release.\n'
+                'Use datetime.timedelta instance instead.'
             )
+            warnings.warn(message, DeprecationWarning, stacklevel=4)
             connect_timeout = timedelta(seconds=connect_timeout)
         self._connect_timeout = connect_timeout
         self._http_config: HttpConfig = http or {}
@@ -290,11 +291,12 @@ class Prisma:
             timeout = self._connect_timeout
 
         if isinstance(timeout, int):
-            warnings.warn(
-                'Passing a int as `timeout` argument is deprecated. Use datetime.timedelta instance instead.',
-                DeprecationWarning,
-                stacklevel=3,
+            message = (
+                'Passing a int as `timeout` argument is deprecated'
+                ' and will be removed in the next major release.\n'
+                'Use datetime.timedelta instance instead.'
             )
+            warnings.warn(message, DeprecationWarning, stacklevel=4)
             timeout = timedelta(seconds=timeout)
 
         if self.__engine is None:
@@ -317,11 +319,12 @@ class Prisma:
             engine = self.__engine
             self.__engine = None
             if isinstance(timeout, float):
-                warnings.warn(
-                    'Passing a float as `timeout` argument is deprecated. Use datetime.timedelta instance instead.',
-                    DeprecationWarning,
-                    stacklevel=3,
+                message = (
+                    'Passing a float as `timeout` argument is deprecated'
+                    ' and will be removed in the next major release.\n'
+                    'Use datetime.timedelta instance instead.'
                 )
+                warnings.warn(message, DeprecationWarning, stacklevel=4)
                 timeout = timedelta(seconds=timeout)
             await engine.aclose(timeout=timeout)
             engine.stop(timeout=timeout)
@@ -549,19 +552,21 @@ class TransactionManager:
     def __init__(self, *, client: Prisma, max_wait: Union[int, timedelta], timeout: Union[int, timedelta]) -> None:
         self.__client = client
         if isinstance(max_wait, int):
-            warnings.warn(
-                'Passing a int as `max_wait` argument is deprecated. Use datetime.timedelta instance instead.',
-                DeprecationWarning,
-                stacklevel=3,
+            message = (
+                'Passing a int as `max_wait` argument is deprecated'
+                ' and will be removed in the next major release.\n'
+                'Use datetime.timedelta instance instead.'
             )
+            warnings.warn(message, DeprecationWarning, stacklevel=4)
             max_wait = timedelta(milliseconds=max_wait)
         self._max_wait = max_wait
         if isinstance(timeout, int):
-            warnings.warn(
-                'Passing a int as `timeout` argument is deprecated. Use datetime.timedelta instance instead.',
-                DeprecationWarning,
-                stacklevel=3,
+            message = (
+                'Passing a int as `timeout` argument is deprecated'
+                ' and will be removed in the next major release.\n'
+                'Use datetime.timedelta instance instead.'
             )
+            warnings.warn(message, DeprecationWarning, stacklevel=4)
             timeout = timedelta(milliseconds=timeout)
         self._timeout = timeout
         self._tx_id: Optional[TransactionId] = None

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[engineabstract.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[engineabstract.py].raw
@@ -56,11 +56,8 @@ __all__ = (
 class AbstractEngine(ABC):
     dml: str
 
-    def stop(self, *, timeout: Optional[float] = None) -> None:
-        """Wrapper for synchronously calling close() and aclose()
-
-        The `timeout` argument is in seconds.
-        """
+    def stop(self, *, timeout: Optional[timedelta] = None) -> None:
+        """Wrapper for synchronously calling close() and aclose()"""
         self.close(timeout=timeout)
         try:
             loop = get_running_loop()
@@ -72,20 +69,13 @@ class AbstractEngine(ABC):
                 loop.create_task(self.aclose(timeout=timeout))
 
     @abstractmethod
-    def close(self, *, timeout: Optional[float] = None) -> None:
-        """Synchronous method for closing the engine, useful if the underlying engine uses a subprocess
-
-        The `timeout` argument is in seconds.
-        """
+    def close(self, *, timeout: Optional[timedelta] = None) -> None:
+        """Synchronous method for closing the engine, useful if the underlying engine uses a subprocess"""
         ...
 
     @abstractmethod
-    async def aclose(self, *, timeout: Optional[float] = None) -> None:
-        """Asynchronous method for closing the engine, only used if an
-        asynchronous client is generated.
-
-        The `timeout` argument is in seconds.
-        """
+    async def aclose(self, *, timeout: Optional[timedelta] = None) -> None:
+        """Asynchronous method for closing the engine, only used if an asynchronous client is generated"""
         ...
 
     @abstractmethod

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[engineabstract.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[engineabstract.py].raw
@@ -41,9 +41,11 @@ from typing_extensions import TypedDict, Literal
 LiteralString = str
 # -- template engine/abstract.py.jinja --
 from abc import ABC, abstractmethod
+from datetime import timedelta
 from ._types import TransactionId
 from ..types import DatasourceOverride
 from .._compat import get_running_loop
+from .._constants import DEFAULT_CONNECT_TIMEOUT
 
 
 __all__ = (
@@ -89,7 +91,7 @@ class AbstractEngine(ABC):
     @abstractmethod
     async def connect(
         self,
-        timeout: int = 10,
+        timeout: timedelta = DEFAULT_CONNECT_TIMEOUT,
         datasources: Optional[List[DatasourceOverride]] = None,
     ) -> None:
         """Connect to the engine"""

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enginehttp.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enginehttp.py].raw
@@ -41,6 +41,7 @@ LiteralString = str
 # -- template engine/http.py.jinja --
 
 import logging
+from datetime import timedelta
 
 from . import utils, errors
 from .abstract import AbstractEngine
@@ -72,10 +73,10 @@ class HTTPEngine(AbstractEngine):
         self.session = HTTP(**kwargs)
         self.headers = headers if headers is not None else {}
 
-    def close(self, *, timeout: Optional[float] = None) -> None:
+    def close(self, *, timeout: Optional[timedelta] = None) -> None:
         pass
 
-    async def aclose(self, *, timeout: Optional[float] = None) -> None:
+    async def aclose(self, *, timeout: Optional[timedelta] = None) -> None:
         await self._close_session()
 
     async def _close_session(self) -> None:

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enginequery.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enginequery.py].raw
@@ -88,16 +88,18 @@ class QueryEngine(HTTPEngine):
         log.debug('Disconnecting query engine...')
 
         if timeout is not None:
-            timeout = timeout.total_seconds()
+            total_seconds = timeout.total_seconds()
+        else:
+            total_seconds = None
 
         if self.process is not None:
             if platform.name() == 'windows':
                 self.process.kill()
-                self.process.wait(timeout=timeout)
+                self.process.wait(timeout=total_seconds)
             else:
                 self.process.send_signal(signal.SIGINT)
                 try:
-                    self.process.wait(timeout=timeout)
+                    self.process.wait(timeout=total_seconds)
                 except subprocess.TimeoutExpired:
                     self.process.send_signal(signal.SIGKILL)
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enginequery.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enginequery.py].raw
@@ -84,8 +84,11 @@ class QueryEngine(HTTPEngine):
         # ensure the query engine process is terminated when we are
         atexit.register(self.stop)
 
-    def close(self, *, timeout: Optional[float] = None) -> None:
+    def close(self, *, timeout: Optional[timedelta] = None) -> None:
         log.debug('Disconnecting query engine...')
+
+        if timeout is not None:
+            timeout = timeout.total_seconds()
 
         if self.process is not None:
             if platform.name() == 'windows':
@@ -102,7 +105,7 @@ class QueryEngine(HTTPEngine):
 
         log.debug('Disconnected query engine')
 
-    async def aclose(self, *, timeout: Optional[float] = None) -> None:
+    async def aclose(self, *, timeout: Optional[timedelta] = None) -> None:
         self.close(timeout=timeout)
         await self._close_session()
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enginequery.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[enginequery.py].raw
@@ -48,6 +48,7 @@ import signal
 import asyncio
 import logging
 import subprocess
+from datetime import timedelta
 from pathlib import Path
 
 from . import utils, errors
@@ -58,6 +59,7 @@ from ..binaries import platform
 from ..utils import time_since, _env_bool
 from ..types import DatasourceOverride
 from ..builder import dumps
+from .._constants import DEFAULT_CONNECT_TIMEOUT
 from ._types import TransactionId
 
 
@@ -116,7 +118,7 @@ class QueryEngine(HTTPEngine):
 
     async def connect(
         self,
-        timeout: int = 10,
+        timeout: timedelta = DEFAULT_CONNECT_TIMEOUT,
         datasources: Optional[List[DatasourceOverride]] = None,
     ) -> None:
         log.debug('Connecting to query engine')
@@ -137,7 +139,7 @@ class QueryEngine(HTTPEngine):
     async def spawn(
         self,
         file: Path,
-        timeout: int = 10,
+        timeout: timedelta = DEFAULT_CONNECT_TIMEOUT,
         datasources: Optional[List[DatasourceOverride]] = None,
     ) -> None:
         port = utils.get_open_port()
@@ -189,7 +191,7 @@ class QueryEngine(HTTPEngine):
         )
 
         last_exc = None
-        for _ in range(int(timeout / 0.1)):
+        for _ in range(int(timeout.total_seconds() / 0.1)):
             try:
                 data = await self.request('GET', '/status')
             except Exception as exc:

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
@@ -226,11 +226,12 @@ class Prisma:
         self._log_queries = log_queries
         self._datasource = datasource
         if isinstance(connect_timeout, int):
-            warnings.warn(
-                'Passing a int as `connect_timeout` argument is deprecated. Use datetime.timedelta instance instead.',
-                DeprecationWarning,
-                stacklevel=3,
+            message = (
+                'Passing a int as `connect_timeout` argument is deprecated'
+                ' and will be removed in the next major release.\n'
+                'Use datetime.timedelta instance instead.'
             )
+            warnings.warn(message, DeprecationWarning, stacklevel=4)
             connect_timeout = timedelta(seconds=connect_timeout)
         self._connect_timeout = connect_timeout
         self._http_config: HttpConfig = http or {}
@@ -290,11 +291,12 @@ class Prisma:
             timeout = self._connect_timeout
 
         if isinstance(timeout, int):
-            warnings.warn(
-                'Passing a int as `timeout` argument is deprecated. Use datetime.timedelta instance instead.',
-                DeprecationWarning,
-                stacklevel=3,
+            message = (
+                'Passing a int as `timeout` argument is deprecated'
+                ' and will be removed in the next major release.\n'
+                'Use datetime.timedelta instance instead.'
             )
+            warnings.warn(message, DeprecationWarning, stacklevel=4)
             timeout = timedelta(seconds=timeout)
 
         if self.__engine is None:
@@ -317,11 +319,12 @@ class Prisma:
             engine = self.__engine
             self.__engine = None
             if isinstance(timeout, float):
-                warnings.warn(
-                    'Passing a float as `timeout` argument is deprecated. Use datetime.timedelta instance instead.',
-                    DeprecationWarning,
-                    stacklevel=3,
+                message = (
+                    'Passing a float as `timeout` argument is deprecated'
+                    ' and will be removed in the next major release.\n'
+                    'Use datetime.timedelta instance instead.'
                 )
+                warnings.warn(message, DeprecationWarning, stacklevel=4)
                 timeout = timedelta(seconds=timeout)
             engine.close(timeout=timeout)
             engine.stop(timeout=timeout)
@@ -549,19 +552,21 @@ class TransactionManager:
     def __init__(self, *, client: Prisma, max_wait: Union[int, timedelta], timeout: Union[int, timedelta]) -> None:
         self.__client = client
         if isinstance(max_wait, int):
-            warnings.warn(
-                'Passing a int as `max_wait` argument is deprecated. Use datetime.timedelta instance instead.',
-                DeprecationWarning,
-                stacklevel=3,
+            message = (
+                'Passing a int as `max_wait` argument is deprecated'
+                ' and will be removed in the next major release.\n'
+                'Use datetime.timedelta instance instead.'
             )
+            warnings.warn(message, DeprecationWarning, stacklevel=4)
             max_wait = timedelta(milliseconds=max_wait)
         self._max_wait = max_wait
         if isinstance(timeout, int):
-            warnings.warn(
-                'Passing a int as `timeout` argument is deprecated. Use datetime.timedelta instance instead.',
-                DeprecationWarning,
-                stacklevel=3,
+            message = (
+                'Passing a int as `timeout` argument is deprecated'
+                ' and will be removed in the next major release.\n'
+                'Use datetime.timedelta instance instead.'
             )
+            warnings.warn(message, DeprecationWarning, stacklevel=4)
             timeout = timedelta(milliseconds=timeout)
         self._timeout = timeout
         self._tx_id: Optional[TransactionId] = None

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
@@ -311,11 +311,18 @@ class Prisma:
             datasources=datasources,
         )
 
-    def disconnect(self, timeout: Optional[float] = None) -> None:
+    def disconnect(self, timeout: Union[float, timedelta, None] = None) -> None:
         """Disconnect the Prisma query engine."""
         if self.__engine is not None:
             engine = self.__engine
             self.__engine = None
+            if isinstance(timeout, float):
+                warnings.warn(
+                    'Passing a float as `timeout` argument is deprecated. Use datetime.timedelta instance instead.',
+                    DeprecationWarning,
+                    stacklevel=3,
+                )
+                timeout = timedelta(seconds=timeout)
             engine.close(timeout=timeout)
             engine.stop(timeout=timeout)
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
@@ -42,6 +42,7 @@ LiteralString = str
 # -- template client.py.jinja --
 import warnings
 import logging
+from datetime import timedelta
 from pathlib import Path
 from types import TracebackType
 
@@ -55,6 +56,7 @@ from .engine import AbstractEngine, QueryEngine, TransactionId
 from .builder import QueryBuilder, dumps
 from .generator.models import EngineType, OptionalValueFromEnvVar, BinaryPaths
 from ._compat import removeprefix
+from ._constants import DEFAULT_CONNECT_TIMEOUT, DEFAULT_TX_MAX_WAIT, DEFAULT_TX_TIMEOUT
 from ._raw_query import deserialize_raw_results
 
 __all__ = (
@@ -85,13 +87,13 @@ class UseClientDefault:
     by typing the parameter with this class rather than using None, for example:
 
     ```py
-    def connect(timeout: Union[int, UseClientDefault] = UseClientDefault()) -> None: ...
+    def connect(timeout: Union[int, timedelta, UseClientDefault] = UseClientDefault()) -> None: ...
     ```
 
     relays the intention more clearly than:
 
     ```py
-    def connect(timeout: Optional[int] = None) -> None: ...
+    def connect(timeout: Union[int, timedelta, None] = None) -> None: ...
     ```
 
     This solution also allows us to indicate an "unset" state that is uniquely distinct
@@ -201,7 +203,7 @@ class Prisma:
         log_queries: bool = False,
         auto_register: bool = False,
         datasource: Optional[DatasourceOverride] = None,
-        connect_timeout: int = 10,
+        connect_timeout: Union[int, timedelta] = DEFAULT_CONNECT_TIMEOUT,
         http: Optional[HttpConfig] = None,
     ) -> None:
         self.post = actions.PostActions[models.Post](self, models.Post)
@@ -223,6 +225,13 @@ class Prisma:
         self._active_provider = 'postgresql'
         self._log_queries = log_queries
         self._datasource = datasource
+        if isinstance(connect_timeout, int):
+            warnings.warn(
+                'Passing a int as `connect_timeout` argument is deprecated. Use datetime.timedelta instance instead.',
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            connect_timeout = timedelta(seconds=connect_timeout)
         self._connect_timeout = connect_timeout
         self._http_config: HttpConfig = http or {}
         self._tx_id: Optional[TransactionId] = None
@@ -271,7 +280,7 @@ class Prisma:
 
     def connect(
         self,
-        timeout: Union[int, UseClientDefault] = _USE_CLIENT_DEFAULT,
+        timeout: Union[int, timedelta, UseClientDefault] = _USE_CLIENT_DEFAULT,
     ) -> None:
         """Connect to the Prisma query engine.
 
@@ -279,6 +288,14 @@ class Prisma:
         """
         if isinstance(timeout, UseClientDefault):
             timeout = self._connect_timeout
+
+        if isinstance(timeout, int):
+            warnings.warn(
+                'Passing a int as `timeout` argument is deprecated. Use datetime.timedelta instance instead.',
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            timeout = timedelta(seconds=timeout)
 
         if self.__engine is None:
             self.__engine = self._create_engine(dml_path=PACKAGED_SCHEMA_PATH)
@@ -398,7 +415,12 @@ class Prisma:
         """Returns a context manager for grouping write queries into a single transaction."""
         return Batch(client=self)
 
-    def tx(self, *, max_wait: int = 2000, timeout: int = 5000) -> 'TransactionManager':
+    def tx(
+        self,
+        *,
+        max_wait: Union[int, timedelta] = DEFAULT_TX_MAX_WAIT,
+        timeout: Union[int, timedelta] = DEFAULT_TX_TIMEOUT,
+    ) -> 'TransactionManager':
         """Returns a context manager for executing queries within a database transaction.
 
         Entering the context manager returns a new Prisma instance wrapping all
@@ -406,10 +428,10 @@ class Prisma:
         will not be commited to the database until the context manager exits.
 
         By default, Prisma will wait a maximum of 2 seconds to acquire a transaction from the database. You can modify this
-        defualt with the `max_wait` argument which accepts a value in milliseconds.
+        defualt with the `max_wait` argument which accepts a value in milliseconds or `datetime.timedelta`.
 
         By default, Prisma will cancel and rollback ay transactions that last longer than 5 seconds. You can modify this timeout
-        with the `timeout` argument which accepts a value in milliseconds.
+        with the `timeout` argument which accepts a value in milliseconds or `datetime.timedelta`.
 
         Example usage:
 
@@ -517,9 +539,23 @@ class TransactionManager:
     through the Prisma.tx() method.
     """
 
-    def __init__(self, *, client: Prisma, max_wait: int, timeout: int) -> None:
+    def __init__(self, *, client: Prisma, max_wait: Union[int, timedelta], timeout: Union[int, timedelta]) -> None:
         self.__client = client
+        if isinstance(max_wait, int):
+            warnings.warn(
+                'Passing a int as `max_wait` argument is deprecated. Use datetime.timedelta instance instead.',
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            max_wait = timedelta(milliseconds=max_wait)
         self._max_wait = max_wait
+        if isinstance(timeout, int):
+            warnings.warn(
+                'Passing a int as `timeout` argument is deprecated. Use datetime.timedelta instance instead.',
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            timeout = timedelta(milliseconds=timeout)
         self._timeout = timeout
         self._tx_id: Optional[TransactionId] = None
 
@@ -537,8 +573,8 @@ class TransactionManager:
         tx_id = self.__client._engine.start_transaction(
             content=dumps(
                 {
-                    'timeout': self._timeout,
-                    'max_wait': self._max_wait,
+                    'timeout': int(self._timeout.total_seconds() * 1000),
+                    'max_wait': int(self._max_wait.total_seconds() * 1000),
                 }
             ),
         )

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[engineabstract.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[engineabstract.py].raw
@@ -56,11 +56,8 @@ __all__ = (
 class AbstractEngine(ABC):
     dml: str
 
-    def stop(self, *, timeout: Optional[float] = None) -> None:
-        """Wrapper for synchronously calling close() and aclose()
-
-        The `timeout` argument is in seconds.
-        """
+    def stop(self, *, timeout: Optional[timedelta] = None) -> None:
+        """Wrapper for synchronously calling close() and aclose()"""
         self.close(timeout=timeout)
         try:
             loop = get_running_loop()
@@ -72,20 +69,13 @@ class AbstractEngine(ABC):
                 loop.create_task(self.aclose(timeout=timeout))
 
     @abstractmethod
-    def close(self, *, timeout: Optional[float] = None) -> None:
-        """Synchronous method for closing the engine, useful if the underlying engine uses a subprocess
-
-        The `timeout` argument is in seconds.
-        """
+    def close(self, *, timeout: Optional[timedelta] = None) -> None:
+        """Synchronous method for closing the engine, useful if the underlying engine uses a subprocess"""
         ...
 
     @abstractmethod
-    async def aclose(self, *, timeout: Optional[float] = None) -> None:
-        """Asynchronous method for closing the engine, only used if an
-        asynchronous client is generated.
-
-        The `timeout` argument is in seconds.
-        """
+    async def aclose(self, *, timeout: Optional[timedelta] = None) -> None:
+        """Asynchronous method for closing the engine, only used if an asynchronous client is generated"""
         ...
 
     @abstractmethod

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[engineabstract.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[engineabstract.py].raw
@@ -41,9 +41,11 @@ from typing_extensions import TypedDict, Literal
 LiteralString = str
 # -- template engine/abstract.py.jinja --
 from abc import ABC, abstractmethod
+from datetime import timedelta
 from ._types import TransactionId
 from ..types import DatasourceOverride
 from .._compat import get_running_loop
+from .._constants import DEFAULT_CONNECT_TIMEOUT
 
 
 __all__ = (
@@ -89,7 +91,7 @@ class AbstractEngine(ABC):
     @abstractmethod
     def connect(
         self,
-        timeout: int = 10,
+        timeout: timedelta = DEFAULT_CONNECT_TIMEOUT,
         datasources: Optional[List[DatasourceOverride]] = None,
     ) -> None:
         """Connect to the engine"""

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enginehttp.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enginehttp.py].raw
@@ -41,6 +41,7 @@ LiteralString = str
 # -- template engine/http.py.jinja --
 
 import logging
+from datetime import timedelta
 
 from . import utils, errors
 from .abstract import AbstractEngine
@@ -72,10 +73,10 @@ class HTTPEngine(AbstractEngine):
         self.session = HTTP(**kwargs)
         self.headers = headers if headers is not None else {}
 
-    def close(self, *, timeout: Optional[float] = None) -> None:
+    def close(self, *, timeout: Optional[timedelta] = None) -> None:
         self._close_session()
 
-    async def aclose(self, *, timeout: Optional[float] = None) -> None:
+    async def aclose(self, *, timeout: Optional[timedelta] = None) -> None:
         pass
 
     def _close_session(self) -> None:

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enginequery.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enginequery.py].raw
@@ -88,16 +88,18 @@ class QueryEngine(HTTPEngine):
         log.debug('Disconnecting query engine...')
 
         if timeout is not None:
-            timeout = timeout.total_seconds()
+            total_seconds = timeout.total_seconds()
+        else:
+            total_seconds = None
 
         if self.process is not None:
             if platform.name() == 'windows':
                 self.process.kill()
-                self.process.wait(timeout=timeout)
+                self.process.wait(timeout=total_seconds)
             else:
                 self.process.send_signal(signal.SIGINT)
                 try:
-                    self.process.wait(timeout=timeout)
+                    self.process.wait(timeout=total_seconds)
                 except subprocess.TimeoutExpired:
                     self.process.send_signal(signal.SIGKILL)
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enginequery.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enginequery.py].raw
@@ -48,6 +48,7 @@ import signal
 import asyncio
 import logging
 import subprocess
+from datetime import timedelta
 from pathlib import Path
 
 from . import utils, errors
@@ -58,6 +59,7 @@ from ..binaries import platform
 from ..utils import time_since, _env_bool
 from ..types import DatasourceOverride
 from ..builder import dumps
+from .._constants import DEFAULT_CONNECT_TIMEOUT
 from ._types import TransactionId
 
 
@@ -117,7 +119,7 @@ class QueryEngine(HTTPEngine):
 
     def connect(
         self,
-        timeout: int = 10,
+        timeout: timedelta = DEFAULT_CONNECT_TIMEOUT,
         datasources: Optional[List[DatasourceOverride]] = None,
     ) -> None:
         log.debug('Connecting to query engine')
@@ -138,7 +140,7 @@ class QueryEngine(HTTPEngine):
     def spawn(
         self,
         file: Path,
-        timeout: int = 10,
+        timeout: timedelta = DEFAULT_CONNECT_TIMEOUT,
         datasources: Optional[List[DatasourceOverride]] = None,
     ) -> None:
         port = utils.get_open_port()
@@ -190,7 +192,7 @@ class QueryEngine(HTTPEngine):
         )
 
         last_exc = None
-        for _ in range(int(timeout / 0.1)):
+        for _ in range(int(timeout.total_seconds() / 0.1)):
             try:
                 data = self.request('GET', '/status')
             except Exception as exc:

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enginequery.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[enginequery.py].raw
@@ -84,8 +84,11 @@ class QueryEngine(HTTPEngine):
         # ensure the query engine process is terminated when we are
         atexit.register(self.stop)
 
-    def close(self, *, timeout: Optional[float] = None) -> None:
+    def close(self, *, timeout: Optional[timedelta] = None) -> None:
         log.debug('Disconnecting query engine...')
+
+        if timeout is not None:
+            timeout = timeout.total_seconds()
 
         if self.process is not None:
             if platform.name() == 'windows':
@@ -103,7 +106,7 @@ class QueryEngine(HTTPEngine):
         self._close_session()
         log.debug('Disconnected query engine')
 
-    async def aclose(self, *, timeout: Optional[float] = None) -> None:
+    async def aclose(self, *, timeout: Optional[timedelta] = None) -> None:
         self.close(timeout=timeout)
         self._close_session()
 

--- a/tests/test_typing_warnings.py
+++ b/tests/test_typing_warnings.py
@@ -1,0 +1,60 @@
+import pytest
+
+from prisma import Prisma
+
+
+@pytest.mark.asyncio
+async def test_warn_when_connect_timeout_is_int() -> None:
+    """Ensure that `calling Prisma(connect_timeout:int)` emit a warning
+
+    https://github.com/RobertCraigie/prisma-client-py/issues/167
+    """
+    with pytest.warns(DeprecationWarning):
+        Prisma(connect_timeout=10)
+
+
+@pytest.mark.asyncio
+async def test_warn_when_calling_connect_with_int_timeout() -> None:
+    """Ensure that calling `client.connect(timeout:int)` emit a warning
+
+    https://github.com/RobertCraigie/prisma-client-py/issues/167
+    """
+    client = Prisma()
+    with pytest.warns(DeprecationWarning):
+        await client.connect(timeout=10)
+
+
+@pytest.mark.asyncio
+async def test_warn_when_calling_disconnect_with_float_timeout() -> None:
+    """Ensure that calling `client.disconnect(timeout:int)` emit a warning
+
+    https://github.com/RobertCraigie/prisma-client-py/issues/167
+    """
+    client = Prisma()
+    await client.connect()
+    with pytest.warns(DeprecationWarning):
+        await client.disconnect(timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_warn_when_calling_tx_with_int_max_wait() -> None:
+    """Ensure that calling `client.tx(max_wait:int)` emit a warning
+
+    https://github.com/RobertCraigie/prisma-client-py/issues/167
+    """
+    client = Prisma()
+    await client.connect()
+    with pytest.warns(DeprecationWarning):
+       client.tx(max_wait=2000)
+
+
+@pytest.mark.asyncio
+async def test_warn_when_calling_tx_with_int_timeout() -> None:
+    """Ensure that calling `client.tx(timeout:int)` emit a warning
+
+    https://github.com/RobertCraigie/prisma-client-py/issues/167
+    """
+    client = Prisma()
+    await client.connect()
+    with pytest.warns(DeprecationWarning):
+       client.tx(timeout=5000)

--- a/tests/test_typing_warnings.py
+++ b/tests/test_typing_warnings.py
@@ -26,7 +26,7 @@ async def test_warn_when_calling_connect_with_int_timeout() -> None:
 
 @pytest.mark.asyncio
 async def test_warn_when_calling_disconnect_with_float_timeout() -> None:
-    """Ensure that calling `client.disconnect(timeout:int)` emit a warning
+    """Ensure that calling `client.disconnect(timeout:float)` emit a warning
 
     https://github.com/RobertCraigie/prisma-client-py/issues/167
     """

--- a/tests/test_typing_warnings.py
+++ b/tests/test_typing_warnings.py
@@ -45,7 +45,7 @@ async def test_warn_when_calling_tx_with_int_max_wait() -> None:
     client = Prisma()
     await client.connect()
     with pytest.warns(DeprecationWarning):
-       client.tx(max_wait=2000)
+        client.tx(max_wait=2000)
 
 
 @pytest.mark.asyncio
@@ -57,4 +57,4 @@ async def test_warn_when_calling_tx_with_int_timeout() -> None:
     client = Prisma()
     await client.connect()
     with pytest.warns(DeprecationWarning):
-       client.tx(timeout=5000)
+        client.tx(timeout=5000)


### PR DESCRIPTION
## Change Summary

Updated types and added respective warnings with tests:

* Connect timeout: `int` -> `Union[int, timedelta]`
* Disconnect timeout: `float` -> `Union[float, timedelta]`
* Transaction max wait: `int` -> `Union[int, timedelta]`
* Transaction timeout: `int` -> `Union[int, timedelta]`

Closes https://github.com/RobertCraigie/prisma-client-py/issues/167.

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [x] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
