### PR TITLE
feat(client) - decorator to provide auto-connecting and auto-disconnecting Prisma client

### DIFF
--- a/src/prisma/decorator.py
+++ b/src/prisma/decorator.py
@@ -1,0 +1,66 @@
+import asyncio
+from prisma import Prisma
+from functools import wraps
+from datetime import timedelta
+from typing import Any, Callable
+
+
+__all__ = ('use_prisma',)
+
+CLIENT_NAME_DEFAULT_VALUE: str = 'db'
+
+
+def use_prisma(*args: Any, **kwargs: Any) -> Callable[..., Any]:
+    """Decorator to provide an auto-connecting and auto-disconnecting Prisma client."""
+    _CLIENT_NAME_KEY: str = 'name'
+
+    def get_client_settings():
+        """Return the appropriate settings based on provided arguments."""
+        settings = {  # default client settings
+            'connect_timeout': timedelta(seconds=30),
+            'http': {'timeout': 600},
+        }
+        if not kwargs:
+            return settings
+        settings.update(kwargs)
+        if _CLIENT_NAME_KEY in settings:
+            del settings[_CLIENT_NAME_KEY]
+        return settings
+
+    def should_bypass(*f_args, **f_kwargs):
+        """
+        Check if the decorated function was called with a Prisma instance in the args or kwargs.
+        If yes, return True, otherwise return False.
+        In case of yes, we won't create a new Prisma instance.
+        """
+        for arg_list in [f_args, f_kwargs.values()]:
+            for arg in arg_list:
+                if isinstance(arg, Prisma):
+                    return True
+        return False
+
+    def outer_wrapper(func):
+        @wraps(func)
+        async def wrapper(*f_args, **f_kwargs):
+            if should_bypass(*f_args, **f_kwargs):
+                return await func(*f_args, **f_kwargs)
+            prisma = Prisma(**get_client_settings())
+            await prisma.connect()
+            try:
+                f_kwargs[
+                    kwargs.get(_CLIENT_NAME_KEY, CLIENT_NAME_DEFAULT_VALUE)
+                ] = prisma
+                return await func(*f_args, **f_kwargs)
+            except (KeyboardInterrupt, asyncio.CancelledError):
+                await prisma.disconnect()
+            finally:
+                await prisma.disconnect()
+
+        return wrapper
+
+    # distinguish between decorator usage with and without arguments
+    if args and callable(args[0]):
+        # no decorator arguments were provided
+        return outer_wrapper(args[0])
+    # decorator arguments were provided
+    return outer_wrapper

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -23,8 +23,10 @@ async def test_use_prisma_decorator():
     await _create_user()
     await _get_user()
     await _delete_user()
-    await _with_client_name_arg()
-    await _with_connect_timeout_arg()
+    await _with_custom_client_name()
+    await _with_custom_client_name_and_timeout()
+    await _with_multiple_args(1, True)
+    await _with_multiple_args_and_custom_client_name(1, True, arg_3='test')
     await _with_invalid_prisma_arg()
 
 
@@ -45,16 +47,33 @@ async def _delete_user(db: Prisma):
 
 
 @use_prisma(name='client')
-async def _with_client_name_arg(client: Prisma):
+async def _with_custom_client_name(client: Prisma):
     assert isinstance(client, Prisma)
     assert client.is_connected()
 
 
 @use_prisma(connect_timeout=timedelta(seconds=42), name='prisma')
-async def _with_connect_timeout_arg(prisma: Prisma):
+async def _with_custom_client_name_and_timeout(prisma: Prisma):
     assert isinstance(prisma, Prisma)
     assert prisma.is_connected()
     assert prisma._connect_timeout == timedelta(seconds=42)
+
+
+@use_prisma
+async def _with_multiple_args(arg_1: int, arg_2: bool, db: Prisma):
+    assert arg_1 == 1 and arg_2 is True and isinstance(db, Prisma)
+
+
+@use_prisma(name='client')
+async def _with_multiple_args_and_custom_client_name(
+    arg_1: int, arg_2: bool, client: Prisma, arg_3: str
+):
+    assert (
+        arg_1 == 1
+        and arg_2 is True
+        and arg_3 == 'test'
+        and isinstance(client, Prisma)
+    )
 
 
 async def _with_invalid_prisma_arg():

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,0 +1,78 @@
+# pyright: reportGeneralTypeIssues=false
+# pyright: reportUnknownLambdaType=false
+
+import pytest
+from datetime import timedelta
+from unittest.mock import patch
+from prisma import Prisma, models
+from prisma.decorator import use_prisma
+
+
+_USER_ID: str = 'user_123_id'
+_USER_NAME: str = 'user_123_name'
+
+
+@pytest.mark.asyncio
+async def test_use_prisma_decorator():
+    """
+    Testing the use_prisma decorator which provides an auto-connecting and
+    auto-disconnecting Prisma client to the function it decorates.
+    """
+    # The reason for why we call all tests like this, is because we cannot stack
+    # the @use_prisma decorator together with the @pytest.mark.asyncio decorator.
+    await _create_user()
+    await _get_user()
+    await _delete_user()
+    await _with_client_name_arg()
+    await _with_connect_timeout_arg()
+    await _with_invalid_prisma_arg()
+
+
+@use_prisma
+async def _create_user(db: Prisma):
+    await db.user.create(data={'id': _USER_ID, 'name': _USER_NAME})
+
+
+@use_prisma
+async def _get_user(db: Prisma):
+    user: models.User = await db.user.find_first(where={'id': _USER_ID})
+    assert user.name == _USER_NAME
+
+
+@use_prisma
+async def _delete_user(db: Prisma):
+    await db.user.delete(where={'id': _USER_ID})
+
+
+@use_prisma(name='client')
+async def _with_client_name_arg(client: Prisma):
+    assert isinstance(client, Prisma)
+    assert client.is_connected()
+
+
+@use_prisma(connect_timeout=timedelta(seconds=42), name='prisma')
+async def _with_connect_timeout_arg(prisma: Prisma):
+    assert isinstance(prisma, Prisma)
+    assert prisma.is_connected()
+    assert prisma._connect_timeout == timedelta(seconds=42)
+
+
+async def _with_invalid_prisma_arg():
+    # the patch below will prevent the effect of garbage collection of the Prisma instance
+    # which would lead to an additional AttributeError
+    with patch.object(Prisma, '__del__', lambda _: None):
+
+        with pytest.raises(TypeError) as exc:
+
+            @use_prisma(
+                invalid_arg='random'
+            )  # provide an invalid argument name 'invalid_arg' to Prisma
+            async def _(db: Prisma):
+                await db.user.create(data={'id': _USER_ID, 'name': _USER_NAME})
+
+            await _()
+
+        assert (
+            "__init__() got an unexpected keyword argument 'invalid_arg'"
+            in str(exc)
+        )


### PR DESCRIPTION
## Change Summary

Added a decorator **use_prisma** which provides an auto-connecting and auto-disconnecting prisma client to the function it decorates. It is a simple way to use the Prisma client.

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass without significant drop in coverage
- [x] Documentation reflects changes where applicable
- [x] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
