### PR TITLE
refactor(templates): rely on a constant for model instance names

### DIFF
--- a/src/prisma/generator/models.py
+++ b/src/prisma/generator/models.py
@@ -743,8 +743,16 @@ class Model(BaseModel):
             return True
 
     @property
+    def instance_name(self) -> str:
+        """The name of this model in the generated client class, e.g.
+
+        `User` -> `Prisma().user`
+        """
+        return self.name.lower()
+
+    @property
     def plural_name(self) -> str:
-        name = self.name
+        name = self.instance_name
         if name.endswith('s'):
             return name
         return f'{name}s'

--- a/src/prisma/generator/templates/actions.py.jinja
+++ b/src/prisma/generator/templates/actions.py.jinja
@@ -159,7 +159,7 @@ class {{ model.name }}Actions(Generic[{{ ModelType }}]):
         -------
         ```py
         # create a {{ model.name }} record from just the required fields
-        {{ model.name.lower() }} = {{ maybe_await }}{{ model.name }}.prisma().create(
+        {{ model.instance_name }} = {{ maybe_await }}{{ model.name }}.prisma().create(
             data={
                 # data to create a {{ model.name }} record
                 {% for field in model.scalar_fields %}
@@ -275,7 +275,7 @@ class {{ model.name }}Actions(Generic[{{ ModelType }}]):
         Example
         -------
         ```py
-        {{ model.name.lower() }} = {{ maybe_await }}{{ model.name }}.prisma().delete(
+        {{ model.instance_name }} = {{ maybe_await }}{{ model.name }}.prisma().delete(
             where={
                 {{ sample_where_unique(model) }}
             },
@@ -325,7 +325,7 @@ class {{ model.name }}Actions(Generic[{{ ModelType }}]):
         Example
         -------
         ```py
-        {{ model.name.lower() }} = {{ maybe_await }}{{ model.name }}.prisma().find_unique(
+        {{ model.instance_name }} = {{ maybe_await }}{{ model.name }}.prisma().find_unique(
             where={
                 {{ sample_where_unique(model) }}
             },
@@ -374,7 +374,7 @@ class {{ model.name }}Actions(Generic[{{ ModelType }}]):
         Example
         -------
         ```py
-        {{ model.name.lower() }} = {{ maybe_await }}{{ model.name }}.prisma().find_unique_or_raise(
+        {{ model.instance_name }} = {{ maybe_await }}{{ model.name }}.prisma().find_unique_or_raise(
             where={
                 {{ sample_where_unique(model) }}
             },
@@ -435,11 +435,11 @@ class {{ model.name }}Actions(Generic[{{ ModelType }}]):
         -------
         ```py
         # find the first 10 {{ model.name }} records
-        {{ model.plural_name.lower() }} = {{ maybe_await }}{{ model.name }}.prisma().find_many(take=10)
+        {{ model.plural_name }} = {{ maybe_await }}{{ model.name }}.prisma().find_many(take=10)
 
         {% set field = model.sampler().get_field() %}
         # find the first 5 {{ model.name }} records ordered by the {{ field.name }} field
-        {{ model.plural_name.lower() }} = {{ maybe_await }}{{ model.name }}.prisma().find_many(
+        {{ model.plural_name }} = {{ maybe_await }}{{ model.name }}.prisma().find_many(
             take=5,
             order={
                 '{{ field.name }}': 'desc',
@@ -504,7 +504,7 @@ class {{ model.name }}Actions(Generic[{{ ModelType }}]):
         ```py
         {% set field = model.sampler().get_field() %}
         # find the second {{ model.name }} record ordered by the {{ field.name }} field
-        {{ model.name.lower() }} = {{ maybe_await }}{{ model.name }}.prisma().find_first(
+        {{ model.instance_name }} = {{ maybe_await }}{{ model.name }}.prisma().find_first(
             skip=1,
             order={
                 '{{ field.name }}': 'desc',
@@ -572,7 +572,7 @@ class {{ model.name }}Actions(Generic[{{ ModelType }}]):
         ```py
         {% set field = model.sampler().get_field() %}
         # find the second {{ model.name }} record ordered by the {{ field.name }} field
-        {{ model.name.lower() }} = {{ maybe_await }}{{ model.name }}.prisma().find_first_or_raise(
+        {{ model.instance_name }} = {{ maybe_await }}{{ model.name }}.prisma().find_first_or_raise(
             skip=1,
             order={
                 '{{ field.name }}': 'desc',
@@ -625,7 +625,7 @@ class {{ model.name }}Actions(Generic[{{ ModelType }}]):
         Example
         -------
         ```py
-        {{ model.name.lower() }} = {{ maybe_await }}{{ model.name }}.prisma().update(
+        {{ model.instance_name }} = {{ maybe_await }}{{ model.name }}.prisma().update(
             where={
                 {{ sample_where_unique(model) }}
             },
@@ -682,7 +682,7 @@ class {{ model.name }}Actions(Generic[{{ ModelType }}]):
         ```py
         {% if model.id_field %}
         {% set id_sample = model.id_field.get_sample_data() %}
-        {{ model.name.lower() }} = {{ maybe_await }}{{ model.name }}.prisma().upsert(
+        {{ model.instance_name }} = {{ maybe_await }}{{ model.name }}.prisma().upsert(
             where={
                 '{{ model.id_field.name }}': {{ id_sample }},
             },
@@ -705,7 +705,7 @@ class {{ model.name }}Actions(Generic[{{ ModelType }}]):
             },
         )
         {% else %}
-        {{ model.name.lower() }} = {{ maybe_await }}{{ model.name }}.prisma().upsert(
+        {{ model.instance_name }} = {{ maybe_await }}{{ model.name }}.prisma().upsert(
             where={
                 # {{ model.name }} where unique filter
             },

--- a/src/prisma/generator/templates/client.py.jinja
+++ b/src/prisma/generator/templates/client.py.jinja
@@ -54,12 +54,12 @@ BINARY_PATHS = model_parse(BinaryPaths, {{ binary_paths.dict(by_alias=True) }})
 
 class Prisma:
     {% for model in dmmf.datamodel.models %}
-    {{ model.name.lower() }}: 'actions.{{ model.name }}Actions[models.{{ model.name }}]'
+    {{ model.instance_name }}: 'actions.{{ model.name }}Actions[models.{{ model.name }}]'
     {% endfor %}
 
     __slots__ = (
         {% for model in dmmf.datamodel.models %}
-        '{{ model.name.lower() }}',
+        '{{ model.instance_name }}',
         {% endfor %}
         '__engine',
         '__copied',
@@ -82,7 +82,7 @@ class Prisma:
         http: HttpConfig | None = None,
     ) -> None:
         {% for model in dmmf.datamodel.models %}
-        self.{{ model.name.lower() }} = actions.{{ model.name }}Actions[models.{{ model.name }}](self, models.{{ model.name }})
+        self.{{ model.instance_name }} = actions.{{ model.name }}Actions[models.{{ model.name }}](self, models.{{ model.name }})
         {% endfor %}
 
         # NOTE: if you add any more properties here then you may also need to forward
@@ -602,7 +602,7 @@ class TransactionManager:
 # TODO: don't require copy-pasting arguments between actions and batch actions
 class Batch:
     {% for model in dmmf.datamodel.models %}
-    {{ model.name.lower() }}: '{{ model.name }}BatchActions'
+    {{ model.instance_name }}: '{{ model.name }}BatchActions'
     {% endfor %}
 
     def __init__(self, client: Prisma) -> None:
@@ -610,7 +610,7 @@ class Batch:
         self.__queries: List[str] = []
         self._active_provider = client._active_provider
         {% for model in dmmf.datamodel.models %}
-        self.{{ model.name.lower() }} = {{ model.name }}BatchActions(self)
+        self.{{ model.instance_name }} = {{ model.name }}BatchActions(self)
         {% endfor %}
 
     def _add(self, **kwargs: Any) -> None:


### PR DESCRIPTION
Having a single source of truth for names makes them much more consistent and less error-prone.