### PR TITLE
fix(types): remove definition of StrEnum as Enum

### DIFF
--- a/pipelines/requirements/dev.txt
+++ b/pipelines/requirements/dev.txt
@@ -9,3 +9,4 @@ typer==0.9.0
 rtoml==0.9.0
 GitPython
 distro
+StrEnum

--- a/pipelines/requirements/dev.txt
+++ b/pipelines/requirements/dev.txt
@@ -9,4 +9,3 @@ typer==0.9.0
 rtoml==0.9.0
 GitPython
 distro
-StrEnum

--- a/src/prisma/_compat.py
+++ b/src/prisma/_compat.py
@@ -338,16 +338,10 @@ else:
     except ImportError:
         nodejs = None
 
-
-if TYPE_CHECKING:
-    from enum import Enum
-
-    StrEnum = Enum
-else:
-    try:
-        from enum import StrEnum as StrEnum
-    except ImportError:
-        from strenum import StrEnum as StrEnum
+try:
+    from enum import StrEnum as StrEnum
+except ImportError:
+    from strenum import StrEnum as StrEnum
 
 
 def removeprefix(string: str, prefix: str) -> str:

--- a/src/prisma/_compat.py
+++ b/src/prisma/_compat.py
@@ -338,10 +338,17 @@ else:
     except ImportError:
         nodejs = None
 
-try:
-    from enum import StrEnum as StrEnum
-except ImportError:
-    from strenum import StrEnum as StrEnum
+
+if TYPE_CHECKING:
+    if sys.version_info < (3, 11):
+        from strenum import StrEnum as StrEnum
+    else:
+        from enum import StrEnum as StrEnum
+else:
+    try:
+        from enum import StrEnum as StrEnum
+    except ImportError:
+        from strenum import StrEnum as StrEnum
 
 
 def removeprefix(string: str, prefix: str) -> str:

--- a/src/prisma/_compat.py
+++ b/src/prisma/_compat.py
@@ -338,10 +338,18 @@ else:
     except ImportError:
         nodejs = None
 
+
+# Note: this shim is due to an inconsistency with string enums
+# that was fixed in Python3.11, for reference see:
+# - https://blog.pecar.me/python-enum#there-be-dragons
+# - https://github.com/python/cpython/issues/100458
 if TYPE_CHECKING:
     if sys.version_info >= (3, 11):
         from enum import StrEnum as StrEnum
     else:
+        # Note: we have to define our own `StrEnum`
+        # class as the backport we're using doesn't
+        # define good types.
         from enum import Enum
 
         class StrEnum(str, Enum):

--- a/src/prisma/_compat.py
+++ b/src/prisma/_compat.py
@@ -339,16 +339,10 @@ else:
         nodejs = None
 
 
-if TYPE_CHECKING:
-    if sys.version_info < (3, 11):
-        from strenum import StrEnum as StrEnum
-    else:
-        from enum import StrEnum as StrEnum
+if sys.version_info < (3, 11):
+    from strenum import StrEnum
 else:
-    try:
-        from enum import StrEnum as StrEnum
-    except ImportError:
-        from strenum import StrEnum as StrEnum
+    from enum import StrEnum
 
 
 def removeprefix(string: str, prefix: str) -> str:

--- a/src/prisma/_compat.py
+++ b/src/prisma/_compat.py
@@ -340,9 +340,9 @@ else:
 
 
 if sys.version_info < (3, 11):
-    from strenum import StrEnum
+    from strenum import StrEnum as StrEnum
 else:
-    from enum import StrEnum
+    from enum import StrEnum as StrEnum
 
 
 def removeprefix(string: str, prefix: str) -> str:

--- a/src/prisma/_compat.py
+++ b/src/prisma/_compat.py
@@ -353,7 +353,6 @@ else:
         from strenum import StrEnum as StrEnum
 
 
-
 def removeprefix(string: str, prefix: str) -> str:
     if string.startswith(prefix):
         return string[len(prefix) :]

--- a/src/prisma/_compat.py
+++ b/src/prisma/_compat.py
@@ -338,11 +338,20 @@ else:
     except ImportError:
         nodejs = None
 
+if TYPE_CHECKING:
+    if sys.version_info >= (3, 11):
+        from enum import StrEnum as StrEnum
+    else:
+        from enum import Enum
 
-if sys.version_info < (3, 11):
-    from strenum import StrEnum as StrEnum
+        class StrEnum(str, Enum):
+            ...
 else:
-    from enum import StrEnum as StrEnum
+    if sys.version_info >= (3, 11):
+        from enum import StrEnum as StrEnum
+    else:
+        from strenum import StrEnum as StrEnum
+
 
 
 def removeprefix(string: str, prefix: str) -> str:

--- a/typesafety/pyright/schema.prisma
+++ b/typesafety/pyright/schema.prisma
@@ -59,6 +59,7 @@ model Types {
   json_obj Json     @default("{}")
   datetime DateTime @default(now())
   decimal  Decimal  @default(22.99)
+  role     Role     @default(USER)
 }
 
 model Lists {

--- a/typesafety/pyright/types/enum.py
+++ b/typesafety/pyright/types/enum.py
@@ -1,0 +1,20 @@
+from prisma import Prisma
+from prisma.enums import Role
+
+
+async def filtering(client: Prisma) -> None:
+    # case: all valid filter fields
+    await client.types.find_first(
+        where={
+            'role': Role.USER,
+        },
+    )
+
+
+def use_str_enum_as_str():
+    # case: StrEnum is compatible with str typing
+    _test_string: str = Role.USER
+
+
+def raise_error_on_invalid_type():
+    _test_int: int = Role.USER  # E: Expression of type "Literal[Role.USER]" cannot be assigned to declared type "int"


### PR DESCRIPTION
This addresses an issue with typing where string enums generated by prisma are not compatible with str typing. This specifically fixes an issue where Pyright checks would fail since prisma StrEnum has type Enum, which is not valid as a str.

## Change Summary

Please summarise the changes this pull request is making here.

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass without significant drop in coverage
- [x] Documentation reflects changes where applicable
- [x] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
