### PR TITLE
fix(requirements): set minimum pydantic version to 1.10.0

### DIFF
--- a/databases/main.py
+++ b/databases/main.py
@@ -183,7 +183,7 @@ def _setup_test_env(session: nox.Session, *, pydantic_v2: bool, inplace: bool) -
     if pydantic_v2:
         session.install('-r', '../pipelines/requirements/deps/pydantic.txt')
     else:
-        session.install('pydantic<2')
+        session.install('pydantic==1.10.0')
 
     session.install('-r', 'requirements.txt')
     maybe_install_nodejs_bin(session)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 httpx>=0.19.0
 jinja2>=2.11.2
-pydantic>=1.8.0, < 3
+pydantic>=1.10.13, < 3
 click>=7.1.2
 python-dotenv>=0.12.0
 typing-extensions>=4.5.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 httpx>=0.19.0
 jinja2>=2.11.2
-pydantic>=1.10.13, < 3
+pydantic>=1.10.0, < 3
 click>=7.1.2
 python-dotenv>=0.12.0
 typing-extensions>=4.5.0


### PR DESCRIPTION
## Change Summary

Updated the minimum version of pydantic to `1.10.0`. Current version is set to `1.8.0` but it lacks some required typing extensions.

## Reproduce

Run:
```
pip3 install pydantic==1.8.0 prisma
python3 -c 'import prisma'
```

Output:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/ezorita/tmp/prisma-pydantic/lib/python3.8/site-packages/prisma/__init__.py", line 11, in <module>
    from ._config import config as config
  File "/home/ezorita/tmp/prisma-pydantic/lib/python3.8/site-packages/prisma/_config.py", line 12, in <module>
    from ._compat import (
  File "/home/ezorita/tmp/prisma-pydantic/lib/python3.8/site-packages/prisma/_compat.py", line 162, in <module>
    from pydantic.typing import is_union as is_union
ImportError: cannot import name 'is_union' from 'pydantic.typing' (/home/ezorita/tmp/prisma-pydantic/lib/python3.8/site-packages/pydantic/typing.cpython-38-x86_64-linux-gnu.so)
```

## Checklist

Should not a a
- [x] Unit tests for the changes exist
- [x] Tests pass without significant drop in coverage
- [x] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
