### PR TITLE
fix(node): bump minimum node version to v16

### DIFF
--- a/src/prisma/cli/_node.py
+++ b/src/prisma/cli/_node.py
@@ -22,7 +22,7 @@ File = Union[int, IO[Any]]
 Target = Literal['node', 'npm']
 
 # taken from https://github.com/prisma/prisma/blob/main/package.json
-MIN_NODE_VERSION = (14, 17)
+MIN_NODE_VERSION = (16, 13)
 
 # mapped the node version above from https://nodejs.org/en/download/releases/
 MIN_NPM_VERSION = (6, 14)

--- a/tests/test_node/test_node.py
+++ b/tests/test_node/test_node.py
@@ -235,14 +235,9 @@ def test_node_version(target: Target, fake_process: FakeProcess) -> None:
     assert version == (16, 15)
     assert node._should_use_binary(target, path) is True
 
-    _register_process('v14.17.1')
+    _register_process('v16.13.1')
     version = node._get_binary_version(target, path)
-    assert version == (14, 17)
-    assert node._should_use_binary(target, path) is True
-
-    _register_process('14.17.1')
-    version = node._get_binary_version(target, path)
-    assert version == (14, 17)
+    assert version == (16, 13)
     assert node._should_use_binary(target, path) is True
 
 


### PR DESCRIPTION
Prisma bumped this so we need to as well: https://github.com/prisma/prisma/blob/main/package.json