### PR TITLE
chore(internal): restructure PrismaUnion representation

### DIFF
--- a/src/prisma/generator/templates/types.py.jinja
+++ b/src/prisma/generator/templates/types.py.jinja
@@ -49,8 +49,8 @@ from .utils import _NoneType
 {{ type.name }} = {{ type.to }}
 {% elif type.kind == 'union' %}
 {{ type.name }} = Union[
-    {% for subtype in type.subtypes %}
-    '{{ subtype.name }}',
+    {% for variant in type.variants %}
+    '{{ variant.name }}',
     {% endfor %}
 ]
 {% elif type.kind == 'typeddict' %}


### PR DESCRIPTION
We shouldn't be overloading `subtypes` for unions as we may need to distinguish between `subtypes` and `variants`, e.g. each variant has the same shared parent class