### PR TITLE
Add `pydantic_disable_protected_namespaces` config setting

### DIFF
--- a/src/prisma/generator/models.py
+++ b/src/prisma/generator/models.py
@@ -506,6 +506,8 @@ class Config(BaseSettings):
     # https://github.com/prisma/prisma/issues/12442
     enable_experimental_decimal: bool = FieldInfo(default=False, env='PRISMA_PY_CONFIG_ENABLE_EXPERIMENTAL_DECIMAL')
 
+    pydantic_disable_protected_namespaces: bool = False
+
     # this seems to be the only good method for setting the contextvar as
     # we don't control the actual construction of the object like we do for
     # the Data model.

--- a/src/prisma/generator/templates/bases.py.jinja
+++ b/src/prisma/generator/templates/bases.py.jinja
@@ -21,6 +21,9 @@ class _PrismaModel(BaseModel):
             use_enum_values=True,
             arbitrary_types_allowed=True,
             populate_by_name=True,
+{% if generator.config.pydantic_disable_protected_namespaces %}
+            protected_namespaces=(),
+{% endif %}
         )
     elif not TYPE_CHECKING:
         from ._compat import BaseConfig


### PR DESCRIPTION
Fixes: GH-982

## Change Summary

Adds a `pydantic_disable_protected_namespaces` config setting. When this is true, it  adds:
```python
protected_namespaces=()
```

to the Pydantic `model_config`.

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
