### PR TITLE
fix(raw queries): correct None handling for all fields

### DIFF
--- a/databases/sync_tests/types/raw_queries/test_bigint.py
+++ b/databases/sync_tests/types/raw_queries/test_bigint.py
@@ -9,14 +9,17 @@ from ...._compat import LiteralString
 
 class Queries(BaseModel):
     select: LiteralString
+    select_null: LiteralString
 
 
 _mysql_queries = Queries(
     select='SELECT * FROM Types WHERE `bigint` = ?',
+    select_null='SELECT * FROM Types WHERE `optional_bigint` IS NULL',
 )
 
 _postgresql_queries = Queries(
     select='SELECT * FROM "Types" WHERE bigint = $1',
+    select_null='SELECT * FROM "Types" WHERE optional_bigint IS NULL',
 )
 
 RAW_QUERIES: DatabaseMapping[Queries] = {
@@ -24,6 +27,7 @@ RAW_QUERIES: DatabaseMapping[Queries] = {
     'mariadb': _mysql_queries,
     'sqlite': Queries(
         select='SELECT * FROM Types WHERE bigint = ?',
+        select_null='SELECT * FROM Types WHERE optional_bigint IS NULL',
     ),
     'postgresql': _postgresql_queries,
     'cockroachdb': _postgresql_queries,
@@ -47,3 +51,22 @@ def test_query_first(
     assert model is not None
     assert model.id == record.id
     assert model.bigint == 12522
+
+
+def test_query_first_optional(
+    client: Prisma,
+    database: SupportedDatabase,
+) -> None:
+    """Use of BigInt in raw SELECT queries with optional/nullable results"""
+    queries = RAW_QUERIES[database]
+
+    record = client.types.create({'optional_bigint': None})
+
+    found = client.query_first(queries.select_null)
+    assert found['id'] == record.id
+    assert found['optional_bigint'] is None
+
+    model = client.query_first(queries.select_null, model=Types)
+    assert model is not None
+    assert model.id == record.id
+    assert model.optional_bigint is None

--- a/databases/sync_tests/types/raw_queries/test_decimal.py
+++ b/databases/sync_tests/types/raw_queries/test_decimal.py
@@ -11,14 +11,17 @@ from ...._compat import LiteralString
 
 class Queries(BaseModel):
     select: LiteralString
+    select_null: LiteralString
 
 
 _mysql_queries = Queries(
     select='SELECT * FROM Types WHERE decimal_ = ?',
+    select_null='SELECT * FROM Types WHERE optional_decimal IS NULL',
 )
 
 _postgresql_queries = Queries(
     select='SELECT * FROM "Types" WHERE decimal_ = $1::numeric',
+    select_null='SELECT * FROM "Types" WHERE optional_decimal IS NULL',
 )
 
 RAW_QUERIES: DatabaseMapping[Queries] = {
@@ -26,6 +29,7 @@ RAW_QUERIES: DatabaseMapping[Queries] = {
     'mariadb': _mysql_queries,
     'sqlite': Queries(
         select='SELECT * FROM Types WHERE decimal_ = ?',
+        select_null='SELECT * FROM Types WHERE optional_decimal IS NULL',
     ),
     'postgresql': _postgresql_queries,
     'cockroachdb': _postgresql_queries,
@@ -55,3 +59,22 @@ def test_query_first(
     assert model is not None
     assert model.id == record2.id
     assert model.decimal_ == Decimal('1.24343336464224')
+
+
+def test_query_first_optional(
+    client: Prisma,
+    database: SupportedDatabase,
+) -> None:
+    """Use of decimal in raw SELECT queries with optional/nullable results"""
+    queries = RAW_QUERIES[database]
+
+    record = client.types.create({'optional_decimal': None})
+
+    found = client.query_first(queries.select_null)
+    assert found['id'] == record.id
+    assert found['optional_decimal'] is None
+
+    model = client.query_first(queries.select_null, model=Types)
+    assert model is not None
+    assert model.id == record.id
+    assert model.optional_decimal is None

--- a/databases/tests/types/raw_queries/test_decimal.py
+++ b/databases/tests/types/raw_queries/test_decimal.py
@@ -12,14 +12,17 @@ from ...._compat import LiteralString
 
 class Queries(BaseModel):
     select: LiteralString
+    select_null: LiteralString
 
 
 _mysql_queries = Queries(
     select='SELECT * FROM Types WHERE decimal_ = ?',
+    select_null='SELECT * FROM Types WHERE optional_decimal IS NULL',
 )
 
 _postgresql_queries = Queries(
     select='SELECT * FROM "Types" WHERE decimal_ = $1::numeric',
+    select_null='SELECT * FROM "Types" WHERE optional_decimal IS NULL',
 )
 
 RAW_QUERIES: DatabaseMapping[Queries] = {
@@ -27,6 +30,7 @@ RAW_QUERIES: DatabaseMapping[Queries] = {
     'mariadb': _mysql_queries,
     'sqlite': Queries(
         select='SELECT * FROM Types WHERE decimal_ = ?',
+        select_null='SELECT * FROM Types WHERE optional_decimal IS NULL',
     ),
     'postgresql': _postgresql_queries,
     'cockroachdb': _postgresql_queries,
@@ -57,3 +61,23 @@ async def test_query_first(
     assert model is not None
     assert model.id == record2.id
     assert model.decimal_ == Decimal('1.24343336464224')
+
+
+@pytest.mark.asyncio
+async def test_query_first_optional(
+    client: Prisma,
+    database: SupportedDatabase,
+) -> None:
+    """Use of decimal in raw SELECT queries with optional/nullable results"""
+    queries = RAW_QUERIES[database]
+
+    record = await client.types.create({'optional_decimal': None})
+
+    found = await client.query_first(queries.select_null)
+    assert found['id'] == record.id
+    assert found['optional_decimal'] is None
+
+    model = await client.query_first(queries.select_null, model=Types)
+    assert model is not None
+    assert model.id == record.id
+    assert model.optional_decimal is None

--- a/src/prisma/_raw_query.py
+++ b/src/prisma/_raw_query.py
@@ -135,12 +135,11 @@ def _deserialize_prisma_object(
         key = result.columns[i]
         prisma_type = result.types[i]
 
-        if prisma_type.endswith('-array'):
-            if field is None:
-                # array fields can stil be `None`
-                new_obj[key] = None
-                continue
+        if field is None:
+            new_obj[key] = None
+            continue
 
+        if prisma_type.endswith('-array'):
             if not isinstance(field, list):
                 raise TypeError(
                     f'Expected array data for {key} column with internal type {prisma_type}',


### PR DESCRIPTION
## Change Summary

See https://github.com/RobertCraigie/prisma-client-py/issues/998 for the most part.

This PR goes in and makes the check mentioned in the above issue happen earlier.

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Note
Adding tests for JSON was not done due to technical difficulties I had when testing. Apparently, optional JSON fields can't accept a `None` value when being created, according to Prisma, despite the fact that I see it as [optional in the schema used](https://github.com/RobertCraigie/prisma-client-py/blob/f1ab3b183cbfaf2d0c7c0c9bce0aeec346236841/databases/templates/schema.prisma.jinja2#L87). I'll leave what errors I got below, though it may be just a me thing.

```python
record = await client.types.create({'json_obj': None})
```

```
prisma.errors.MissingRequiredValueError: Unable to match input value to any allowed input type for the field. Parse errors: [Unable to match input value to any allowed input type for the field. Parse errors: [`data.json_obj`: A value is required but not set, `data.json_obj`: A value is required but not set], Unable to match input value to any allowed input type for the field. Parse errors: [`data.json_obj`: A value is required but not set, `data.json_obj`: A value is required but not set]]
```

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
