### PR TITLE
Explicitly use utf-8 in path.read_text

### DIFF
--- a/src/prisma/_config.py
+++ b/src/prisma/_config.py
@@ -108,7 +108,7 @@ class Config(DefaultConfig):
             path = Path('pyproject.toml')
 
         if path.exists():
-            config = tomlkit.loads(path.read_text()).get('tool', {}).get('prisma', {})
+            config = tomlkit.loads(path.read_text(encoding='utf-8')).get('tool', {}).get('prisma', {})
         else:
             config = {}
 


### PR DESCRIPTION
## Change Summary
Changed `path.read_text` to explicitly use utf-8 to avoid `UnicodeEncodeError` that may be caused by cp932 in Japanese Windows environments.

Only src/prisma/_config.py was changed.

(This is my first time contributing to another repository, so there may be some clumsiness, but I'd appreciate it if you could let me know if that's the case.)
## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
