### PR TITLE
feat(client): Add support for full text search

### DIFF
--- a/databases/constants.py
+++ b/databases/constants.py
@@ -38,6 +38,7 @@ CONFIG_MAPPING: DatabaseMapping[DatabaseConfig] = {
             'json_arrays',
             'array_push',
             'transactions',
+            'full_text_search',
         },
     ),
     'sqlite': DatabaseConfig(
@@ -54,6 +55,7 @@ CONFIG_MAPPING: DatabaseMapping[DatabaseConfig] = {
             'arrays',
             'create_many_skip_duplicates',
             'case_sensitivity',
+            'full_text_search',
         },
     ),
     'mysql': DatabaseConfig(
@@ -78,6 +80,7 @@ CONFIG_MAPPING: DatabaseMapping[DatabaseConfig] = {
         unsupported_features={
             'arrays',
             'case_sensitivity',
+            'full_text_search',
         },
     ),
 }
@@ -106,6 +109,7 @@ FEATURES_MAPPING: dict[DatabaseFeature, list[str]] = {
     'create_many_skip_duplicates': ['test_create_many_skip_duplicates.py'],
     'raw_queries': ['test_raw_queries.py', *_fromdir('types/raw_queries')],
     'case_sensitivity': ['test_case_sensitivity.py'],
+    'full_text_search': ['test_full_text_search.py'],
 }
 
 # config files

--- a/databases/sync_tests/test_full_text_search.py
+++ b/databases/sync_tests/test_full_text_search.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Optional, cast
 
 import pytest
 from pydantic import BaseModel
@@ -30,7 +30,7 @@ _postgresql_syntax = FullTextSearchSyntax(
 )
 
 # Map the syntax to the corresponding database
-FULL_TEXT_SEARCH_SYNTAX: DatabaseMapping[FullTextSearchSyntax | None] = {
+FULL_TEXT_SEARCH_SYNTAX: DatabaseMapping[Optional[FullTextSearchSyntax]] = {
     'mysql': _mysql_syntax,
     'postgresql': _postgresql_syntax,
     'cockroachdb': None,

--- a/databases/sync_tests/test_full_text_search.py
+++ b/databases/sync_tests/test_full_text_search.py
@@ -30,9 +30,12 @@ _postgresql_syntax = FullTextSearchSyntax(
 )
 
 # Map the syntax to the corresponding database
-FULL_TEXT_SEARCH_SYNTAX: DatabaseMapping[FullTextSearchSyntax] = {
+FULL_TEXT_SEARCH_SYNTAX: DatabaseMapping[FullTextSearchSyntax | None] = {
     'mysql': _mysql_syntax,
     'postgresql': _postgresql_syntax,
+    'cockroachdb': None,
+    'mariadb': None,
+    'sqlite': None,
 }
 
 
@@ -42,6 +45,9 @@ def test_full_text_search(client: Prisma) -> None:
     # Determine the correct syntax based on the database
     db_type = cast(SupportedDatabase, client._active_provider)
     syntax = FULL_TEXT_SEARCH_SYNTAX[db_type]
+
+    if syntax is None:
+        pytest.skip(f'Skipping test for {db_type}')
 
     # Create some posts with varied content
     await client.post.create_many(

--- a/databases/sync_tests/test_full_text_search.py
+++ b/databases/sync_tests/test_full_text_search.py
@@ -12,21 +12,18 @@ from .._types import DatabaseMapping, SupportedDatabase
 class FullTextSearchSyntax(BaseModel):
     search_or: str
     search_and: str
-    search_not: str
 
 
 # Define the queries for MySQL
 _mysql_syntax = FullTextSearchSyntax(
     search_or='cats dogs',
     search_and='+cats +dogs',
-    search_not='-dogs',
 )
 
 # Define the queries for PostgreSQL
 _postgresql_syntax = FullTextSearchSyntax(
     search_or='cats | dogs',
     search_and='cats & dogs',
-    search_not='!dogs',
 )
 
 # Map the syntax to the corresponding database
@@ -90,14 +87,3 @@ def test_full_text_search(client: Prisma) -> None:
     assert len(posts) == 1
     assert 'cats' in posts[0].title
     assert 'dogs' in posts[0].title
-
-    # Test: Search for posts that contain 'cats' but not 'dogs'
-    posts = client.post.find_many(
-        where={
-            'title': {
-                'search': syntax.search_not,
-            },
-        }
-    )
-    assert len(posts) == 2
-    assert 'dogs' not in posts[0].title

--- a/databases/sync_tests/test_full_text_search.py
+++ b/databases/sync_tests/test_full_text_search.py
@@ -46,7 +46,7 @@ async def test_full_text_search(client: Prisma) -> None:
     syntax = FULL_TEXT_SEARCH_SYNTAX[db_type]
 
     # Create some posts with varied content
-    await client.post.create_many(
+    client.post.create_many(
         data=[
             {
                 'title': 'Post about cats and dogs',
@@ -67,7 +67,7 @@ async def test_full_text_search(client: Prisma) -> None:
     )
 
     # Test: Search for posts that contain 'cats' or 'dogs'
-    posts = await client.post.find_many(
+    posts = client.post.find_many(
         where={
             'body': {
                 'search': syntax.search_or,
@@ -79,7 +79,7 @@ async def test_full_text_search(client: Prisma) -> None:
     assert any('dogs' in post.body for post in posts)
 
     # Test: Search for posts that contain both 'cats' and 'dogs'
-    posts = await client.post.find_many(
+    posts = client.post.find_many(
         where={
             'body': {
                 'search': syntax.search_and,
@@ -91,7 +91,7 @@ async def test_full_text_search(client: Prisma) -> None:
     assert 'dogs' in posts[0].body
 
     # Test: Search for posts that contain 'cats' but not 'dogs'
-    posts = await client.post.find_many(
+    posts = client.post.find_many(
         where={
             'body': {
                 'search': syntax.search_not,
@@ -103,7 +103,7 @@ async def test_full_text_search(client: Prisma) -> None:
     assert 'dogs' not in posts[0].body
 
     # Test: Search for posts that contain the phrase 'small and cute'
-    posts = await client.post.find_many(
+    posts = client.post.find_many(
         where={
             'body': {
                 'search': syntax.search_phrase,

--- a/databases/sync_tests/test_full_text_search.py
+++ b/databases/sync_tests/test_full_text_search.py
@@ -50,7 +50,7 @@ def test_full_text_search(client: Prisma) -> None:
         pytest.skip(f'Skipping test for {db_type}')
 
     # Create some posts with varied content
-    await client.post.create_many(
+    client.post.create_many(
         data=[
             {
                 'title': 'cats are great pets. dogs are loyal companions.',
@@ -68,7 +68,7 @@ def test_full_text_search(client: Prisma) -> None:
     )
 
     # Test: Search for posts that contain 'cats' or 'dogs'
-    posts = await client.post.find_many(
+    posts = client.post.find_many(
         where={
             'title': {
                 'search': syntax.search_or,
@@ -80,7 +80,7 @@ def test_full_text_search(client: Prisma) -> None:
     assert any('dogs' in post.title for post in posts)
 
     # Test: Search for posts that contain both 'cats' and 'dogs'
-    posts = await client.post.find_many(
+    posts = client.post.find_many(
         where={
             'title': {
                 'search': syntax.search_and,
@@ -92,7 +92,7 @@ def test_full_text_search(client: Prisma) -> None:
     assert 'dogs' in posts[0].title
 
     # Test: Search for posts that contain 'cats' but not 'dogs'
-    posts = await client.post.find_many(
+    posts = client.post.find_many(
         where={
             'title': {
                 'search': syntax.search_not,

--- a/databases/sync_tests/test_full_text_search.py
+++ b/databases/sync_tests/test_full_text_search.py
@@ -49,18 +49,15 @@ async def test_full_text_search(client: Prisma) -> None:
     client.post.create_many(
         data=[
             {
-                'title': 'Post about cats and dogs',
-                'body': 'Cats are great pets. Dogs are loyal companions.',
+                'title': 'Cats are great pets. Dogs are loyal companions.',
                 'published': True,
             },
             {
-                'title': 'Post about only cats',
-                'body': 'Cats are independent and mysterious animals.',
+                'title': 'Cats are independent and mysterious animals.',
                 'published': True,
             },
             {
-                'title': 'Post about other animals',
-                'body': 'Rabbits and hamsters are small and cute pets.',
+                'title': 'Rabbits and hamsters are small and cute pets.',
                 'published': True,
             },
         ]
@@ -69,46 +66,46 @@ async def test_full_text_search(client: Prisma) -> None:
     # Test: Search for posts that contain 'cats' or 'dogs'
     posts = client.post.find_many(
         where={
-            'body': {
+            'title': {
                 'search': syntax.search_or,
             },
         }
     )
     assert len(posts) == 2
-    assert any('cats' in post.body for post in posts)
-    assert any('dogs' in post.body for post in posts)
+    assert any('cats' in post.title for post in posts)
+    assert any('dogs' in post.title for post in posts)
 
     # Test: Search for posts that contain both 'cats' and 'dogs'
     posts = client.post.find_many(
         where={
-            'body': {
+            'title': {
                 'search': syntax.search_and,
             },
         }
     )
     assert len(posts) == 1
-    assert 'cats' in posts[0].body
-    assert 'dogs' in posts[0].body
+    assert 'cats' in posts[0].title
+    assert 'dogs' in posts[0].title
 
     # Test: Search for posts that contain 'cats' but not 'dogs'
     posts = client.post.find_many(
         where={
-            'body': {
+            'title': {
                 'search': syntax.search_not,
             },
         }
     )
     assert len(posts) == 1
-    assert 'cats' in posts[0].body
-    assert 'dogs' not in posts[0].body
+    assert 'cats' in posts[0].title
+    assert 'dogs' not in posts[0].title
 
     # Test: Search for posts that contain the phrase 'small and cute'
     posts = client.post.find_many(
         where={
-            'body': {
+            'title': {
                 'search': syntax.search_phrase,
             },
         }
     )
     assert len(posts) == 1
-    assert 'small and cute' in posts[0].body
+    assert 'small and cute' in posts[0].title

--- a/databases/sync_tests/test_full_text_search.py
+++ b/databases/sync_tests/test_full_text_search.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 import pytest
 from pydantic import BaseModel
 
@@ -34,12 +36,11 @@ FULL_TEXT_SEARCH_SYNTAX: DatabaseMapping[FullTextSearchSyntax] = {
 }
 
 
-@pytest.mark.asyncio
 def test_full_text_search(client: Prisma) -> None:
     """Ensure that full-text search works correctly on both PostgreSQL and MySQL"""
 
     # Determine the correct syntax based on the database
-    db_type: SupportedDatabase = client._active_provider
+    db_type = cast(SupportedDatabase, client._active_provider)
     syntax = FULL_TEXT_SEARCH_SYNTAX[db_type]
 
     # Create some posts with varied content

--- a/databases/sync_tests/test_full_text_search.py
+++ b/databases/sync_tests/test_full_text_search.py
@@ -73,8 +73,8 @@ def test_full_text_search(client: Prisma) -> None:
         }
     )
     assert len(posts) == 2
-    assert any('cats' in post.title for post in posts)
-    assert any('dogs' in post.title for post in posts)
+    for post in posts:
+        assert 'cats' in post.title or 'dogs' in post.title
 
     # Test: Search for posts that contain both 'cats' and 'dogs'
     posts = client.post.find_many(
@@ -118,7 +118,7 @@ def test_order_by_relevance(client: Prisma) -> None:
     )
 
     # Test: Order posts by relevance descending
-    posts = client.post.find_first(
+    post = client.post.find_first(
         order={
             '_relevance': {
                 'fields': ['title'],
@@ -127,12 +127,12 @@ def test_order_by_relevance(client: Prisma) -> None:
             },
         }
     )
-    assert posts is not None
-    assert 'cats' in posts.title
-    assert 'dogs' in posts.title
+    assert post is not None
+    assert 'cats' in post.title
+    assert 'dogs' in post.title
 
     # Test: Order posts by relevance ascending
-    posts = client.post.find_first(
+    post = client.post.find_first(
         order={
             '_relevance': {
                 'fields': ['title'],
@@ -141,5 +141,5 @@ def test_order_by_relevance(client: Prisma) -> None:
             },
         }
     )
-    assert posts is not None
-    assert 'rabbits' in posts.title
+    assert post is not None
+    assert 'rabbits' in post.title

--- a/databases/templates/schema.prisma.jinja2
+++ b/databases/templates/schema.prisma.jinja2
@@ -14,6 +14,9 @@ generator client {
   engineType                  = "binary"
   enable_experimental_decimal = true
   partial_type_generator      = "{{ partial_generator }}"
+  {% if config.supports_feature('full_text_search') %}
+  previewFeatures = ["fullTextSearch"]
+  {% endif %}
 }
 
 model User {

--- a/databases/templates/schema.prisma.jinja2
+++ b/databases/templates/schema.prisma.jinja2
@@ -14,8 +14,10 @@ generator client {
   engineType                  = "binary"
   enable_experimental_decimal = true
   partial_type_generator      = "{{ partial_generator }}"
-  {% if config.supports_feature('full_text_search') %}
+  {% if config.id == "postgresql" %}
   previewFeatures = ["fullTextSearch"]
+  {% elif config.id == "mysql" %}
+  previewFeatures = ["fullTextSearch", "fullTextIndex"]
   {% endif %}
 }
 

--- a/databases/templates/schema.prisma.jinja2
+++ b/databases/templates/schema.prisma.jinja2
@@ -54,6 +54,9 @@ model Post {
   author      User?      @relation(fields: [author_id], references: [id])
   author_id   String?
   categories  Category[]
+  {% if config.id == "mysql" %}
+  @@fulltext([title])
+  {% endif %}
 }
 
 /// @Python(instance_name: "custom_category")

--- a/databases/tests/test_full_text_search.py
+++ b/databases/tests/test_full_text_search.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Optional, cast
 
 import pytest
 from pydantic import BaseModel
@@ -30,7 +30,7 @@ _postgresql_syntax = FullTextSearchSyntax(
 )
 
 # Map the syntax to the corresponding database
-FULL_TEXT_SEARCH_SYNTAX: DatabaseMapping[FullTextSearchSyntax | None] = {
+FULL_TEXT_SEARCH_SYNTAX: DatabaseMapping[Optional[FullTextSearchSyntax]] = {
     'mysql': _mysql_syntax,
     'postgresql': _postgresql_syntax,
     'cockroachdb': None,

--- a/databases/tests/test_full_text_search.py
+++ b/databases/tests/test_full_text_search.py
@@ -49,18 +49,15 @@ async def test_full_text_search(client: Prisma) -> None:
     await client.post.create_many(
         data=[
             {
-                'title': 'Post about cats and dogs',
-                'body': 'Cats are great pets. Dogs are loyal companions.',
+                'title': 'Cats are great pets. Dogs are loyal companions.',
                 'published': True,
             },
             {
-                'title': 'Post about only cats',
-                'body': 'Cats are independent and mysterious animals.',
+                'title': 'Cats are independent and mysterious animals.',
                 'published': True,
             },
             {
-                'title': 'Post about other animals',
-                'body': 'Rabbits and hamsters are small and cute pets.',
+                'title': 'Rabbits and hamsters are small and cute pets.',
                 'published': True,
             },
         ]
@@ -69,46 +66,46 @@ async def test_full_text_search(client: Prisma) -> None:
     # Test: Search for posts that contain 'cats' or 'dogs'
     posts = await client.post.find_many(
         where={
-            'body': {
+            'title': {
                 'search': syntax.search_or,
             },
         }
     )
     assert len(posts) == 2
-    assert any('cats' in post.body for post in posts)
-    assert any('dogs' in post.body for post in posts)
+    assert any('cats' in post.title for post in posts)
+    assert any('dogs' in post.title for post in posts)
 
     # Test: Search for posts that contain both 'cats' and 'dogs'
     posts = await client.post.find_many(
         where={
-            'body': {
+            'title': {
                 'search': syntax.search_and,
             },
         }
     )
     assert len(posts) == 1
-    assert 'cats' in posts[0].body
-    assert 'dogs' in posts[0].body
+    assert 'cats' in posts[0].title
+    assert 'dogs' in posts[0].title
 
     # Test: Search for posts that contain 'cats' but not 'dogs'
     posts = await client.post.find_many(
         where={
-            'body': {
+            'title': {
                 'search': syntax.search_not,
             },
         }
     )
     assert len(posts) == 1
-    assert 'cats' in posts[0].body
-    assert 'dogs' not in posts[0].body
+    assert 'cats' in posts[0].title
+    assert 'dogs' not in posts[0].title
 
     # Test: Search for posts that contain the phrase 'small and cute'
     posts = await client.post.find_many(
         where={
-            'body': {
+            'title': {
                 'search': syntax.search_phrase,
             },
         }
     )
     assert len(posts) == 1
-    assert 'small and cute' in posts[0].body
+    assert 'small and cute' in posts[0].title

--- a/databases/tests/test_full_text_search.py
+++ b/databases/tests/test_full_text_search.py
@@ -11,23 +11,20 @@ class FullTextSearchSyntax(BaseModel):
     search_or: str
     search_and: str
     search_not: str
-    search_phrase: str
 
 
 # Define the queries for MySQL
 _mysql_syntax = FullTextSearchSyntax(
     search_or='cats dogs',
     search_and='+cats +dogs',
-    search_not='+cats -dogs',
-    search_phrase='"small and cute"',
+    search_not='-dogs',
 )
 
 # Define the queries for PostgreSQL
 _postgresql_syntax = FullTextSearchSyntax(
     search_or='cats | dogs',
     search_and='cats & dogs',
-    search_not='cats & !dogs',
-    search_phrase='small <-> cute',
+    search_not='!dogs',
 )
 
 # Map the syntax to the corresponding database
@@ -49,15 +46,15 @@ async def test_full_text_search(client: Prisma) -> None:
     await client.post.create_many(
         data=[
             {
-                'title': 'Cats are great pets. Dogs are loyal companions.',
+                'title': 'cats are great pets. dogs are loyal companions.',
                 'published': True,
             },
             {
-                'title': 'Cats are independent and mysterious animals.',
+                'title': 'cats are independent and mysterious animals.',
                 'published': True,
             },
             {
-                'title': 'Rabbits and hamsters are small and cute pets.',
+                'title': 'rabbits and hamsters are small and cute pets.',
                 'published': True,
             },
         ]
@@ -95,17 +92,5 @@ async def test_full_text_search(client: Prisma) -> None:
             },
         }
     )
-    assert len(posts) == 1
-    assert 'cats' in posts[0].title
+    assert len(posts) == 2
     assert 'dogs' not in posts[0].title
-
-    # Test: Search for posts that contain the phrase 'small and cute'
-    posts = await client.post.find_many(
-        where={
-            'title': {
-                'search': syntax.search_phrase,
-            },
-        }
-    )
-    assert len(posts) == 1
-    assert 'small and cute' in posts[0].title

--- a/databases/tests/test_full_text_search.py
+++ b/databases/tests/test_full_text_search.py
@@ -30,9 +30,12 @@ _postgresql_syntax = FullTextSearchSyntax(
 )
 
 # Map the syntax to the corresponding database
-FULL_TEXT_SEARCH_SYNTAX: DatabaseMapping[FullTextSearchSyntax] = {
+FULL_TEXT_SEARCH_SYNTAX: DatabaseMapping[FullTextSearchSyntax | None] = {
     'mysql': _mysql_syntax,
     'postgresql': _postgresql_syntax,
+    'cockroachdb': None,
+    'mariadb': None,
+    'sqlite': None,
 }
 
 
@@ -43,6 +46,9 @@ async def test_full_text_search(client: Prisma) -> None:
     # Determine the correct syntax based on the database
     db_type = cast(SupportedDatabase, client._active_provider)
     syntax = FULL_TEXT_SEARCH_SYNTAX[db_type]
+
+    if syntax is None:
+        pytest.skip(f'Skipping test for {db_type}')
 
     # Create some posts with varied content
     await client.post.create_many(

--- a/databases/tests/test_full_text_search.py
+++ b/databases/tests/test_full_text_search.py
@@ -19,14 +19,12 @@ class FullTextSearchSyntax(BaseModel):
 _mysql_syntax = FullTextSearchSyntax(
     search_or='cats dogs',
     search_and='+cats +dogs',
-    search_not='-dogs',
 )
 
 # Define the queries for PostgreSQL
 _postgresql_syntax = FullTextSearchSyntax(
     search_or='cats | dogs',
     search_and='cats & dogs',
-    search_not='!dogs',
 )
 
 # Map the syntax to the corresponding database
@@ -91,14 +89,3 @@ async def test_full_text_search(client: Prisma) -> None:
     assert len(posts) == 1
     assert 'cats' in posts[0].title
     assert 'dogs' in posts[0].title
-
-    # Test: Search for posts that contain 'cats' but not 'dogs'
-    posts = await client.post.find_many(
-        where={
-            'title': {
-                'search': syntax.search_not,
-            },
-        }
-    )
-    assert len(posts) == 2
-    assert 'dogs' not in posts[0].title

--- a/databases/tests/test_full_text_search.py
+++ b/databases/tests/test_full_text_search.py
@@ -12,7 +12,6 @@ from .._types import DatabaseMapping, SupportedDatabase
 class FullTextSearchSyntax(BaseModel):
     search_or: str
     search_and: str
-    search_not: str
 
 
 # Define the queries for MySQL

--- a/databases/tests/test_full_text_search.py
+++ b/databases/tests/test_full_text_search.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 import pytest
 from pydantic import BaseModel
 
@@ -39,7 +41,7 @@ async def test_full_text_search(client: Prisma) -> None:
     """Ensure that full-text search works correctly on both PostgreSQL and MySQL"""
 
     # Determine the correct syntax based on the database
-    db_type: SupportedDatabase = client._active_provider
+    db_type = cast(SupportedDatabase, client._active_provider)
     syntax = FULL_TEXT_SEARCH_SYNTAX[db_type]
 
     # Create some posts with varied content

--- a/databases/tests/test_full_text_search.py
+++ b/databases/tests/test_full_text_search.py
@@ -74,8 +74,8 @@ async def test_full_text_search(client: Prisma) -> None:
         }
     )
     assert len(posts) == 2
-    assert any('cats' in post.title for post in posts)
-    assert any('dogs' in post.title for post in posts)
+    for post in posts:
+        assert 'cats' in post.title or 'dogs' in post.title
 
     # Test: Search for posts that contain both 'cats' and 'dogs'
     posts = await client.post.find_many(
@@ -120,7 +120,7 @@ async def test_order_by_relevance(client: Prisma) -> None:
     )
 
     # Test: Order posts by relevance descending
-    posts = await client.post.find_first(
+    post = await client.post.find_first(
         order={
             '_relevance': {
                 'fields': ['title'],
@@ -129,12 +129,12 @@ async def test_order_by_relevance(client: Prisma) -> None:
             },
         }
     )
-    assert posts is not None
-    assert 'cats' in posts.title
-    assert 'dogs' in posts.title
+    assert post is not None
+    assert 'cats' in post.title
+    assert 'dogs' in post.title
 
     # Test: Order posts by relevance ascending
-    posts = await client.post.find_first(
+    post = await client.post.find_first(
         order={
             '_relevance': {
                 'fields': ['title'],
@@ -143,5 +143,5 @@ async def test_order_by_relevance(client: Prisma) -> None:
             },
         }
     )
-    assert posts is not None
-    assert 'rabbits' in posts.title
+    assert post is not None
+    assert 'rabbits' in post.title

--- a/databases/tests/test_full_text_search.py
+++ b/databases/tests/test_full_text_search.py
@@ -88,3 +88,60 @@ async def test_full_text_search(client: Prisma) -> None:
     assert len(posts) == 1
     assert 'cats' in posts[0].title
     assert 'dogs' in posts[0].title
+
+
+@pytest.mark.asyncio
+async def test_order_by_relevance(client: Prisma) -> None:
+    """Ensure that ordering by relevance works correctly on both PostgreSQL and MySQL"""
+
+    # Determine the correct syntax based on the database
+    db_type = cast(SupportedDatabase, client._active_provider)
+    syntax = FULL_TEXT_SEARCH_SYNTAX[db_type]
+
+    if syntax is None:
+        pytest.skip(f'Skipping test for {db_type}')
+
+    # Create some posts with varied content
+    await client.post.create_many(
+        data=[
+            {
+                'title': 'cats are great pets. dogs are loyal companions.',
+                'published': True,
+            },
+            {
+                'title': 'cats are independent and mysterious animals.',
+                'published': True,
+            },
+            {
+                'title': 'rabbits and hamsters are small and cute pets.',
+                'published': True,
+            },
+        ]
+    )
+
+    # Test: Order posts by relevance descending
+    posts = await client.post.find_first(
+        order={
+            '_relevance': {
+                'fields': ['title'],
+                'search': syntax.search_or,
+                'sort': 'desc',
+            },
+        }
+    )
+    assert posts is not None
+    assert 'cats' in posts.title
+    assert 'dogs' in posts.title
+
+    # Test: Order posts by relevance ascending
+    posts = await client.post.find_first(
+        order={
+            '_relevance': {
+                'fields': ['title'],
+                'search': syntax.search_or,
+                'sort': 'asc',
+            },
+        }
+    )
+    assert posts is not None
+    assert 'rabbits' in posts.title

--- a/databases/tests/test_full_text_search.py
+++ b/databases/tests/test_full_text_search.py
@@ -1,0 +1,111 @@
+
+import pytest
+from pydantic import BaseModel
+
+from prisma import Prisma
+
+from .._types import DatabaseMapping, SupportedDatabase
+
+
+# Define a class to hold the search queries
+class FullTextSearchSyntax(BaseModel):
+    search_or: str
+    search_and: str
+    search_not: str
+    search_phrase: str
+
+# Define the queries for MySQL
+_mysql_syntax = FullTextSearchSyntax(
+    search_or="cats dogs",
+    search_and="+cats +dogs",
+    search_not="+cats -dogs",
+    search_phrase='"small and cute"',
+)
+
+# Define the queries for PostgreSQL
+_postgresql_syntax = FullTextSearchSyntax(
+    search_or="cats | dogs",
+    search_and="cats & dogs",
+    search_not="cats & !dogs",
+    search_phrase="small <-> cute",
+)
+
+# Map the syntax to the corresponding database
+FULL_TEXT_SEARCH_SYNTAX: DatabaseMapping[FullTextSearchSyntax] = {
+    'mysql': _mysql_syntax,
+    'postgresql': _postgresql_syntax,
+}
+
+@pytest.mark.asyncio
+async def test_full_text_search(client: Prisma) -> None:
+    """Ensure that full-text search works correctly on both PostgreSQL and MySQL"""
+
+    # Determine the correct syntax based on the database
+    db_type: SupportedDatabase = client._active_provider
+    syntax = FULL_TEXT_SEARCH_SYNTAX[db_type]
+
+    # Create some posts with varied content
+    await client.post.create_many(
+        data=[
+            {
+                'title': 'Post about cats and dogs',
+                'body': 'Cats are great pets. Dogs are loyal companions.',
+            },
+            {
+                'title': 'Post about only cats',
+                'body': 'Cats are independent and mysterious animals.',
+            },
+            {
+                'title': 'Post about other animals',
+                'body': 'Rabbits and hamsters are small and cute pets.',
+            },
+        ]
+    )
+
+
+    # Test: Search for posts that contain 'cats' or 'dogs'
+    posts = await client.post.find_many(
+        where={
+            'body': {
+                'search': syntax.search_or,
+            },
+        }
+    )
+    assert len(posts) == 2
+    assert any('cats' in post.body for post in posts)
+    assert any('dogs' in post.body for post in posts)
+
+    # Test: Search for posts that contain both 'cats' and 'dogs'
+    posts = await client.post.find_many(
+        where={
+            'body': {
+                'search': syntax.search_and,
+            },
+        }
+    )
+    assert len(posts) == 1
+    assert 'cats' in posts[0].body
+    assert 'dogs' in posts[0].body
+
+    # Test: Search for posts that contain 'cats' but not 'dogs'
+    posts = await client.post.find_many(
+        where={
+            'body': {
+                'search': syntax.search_not,
+            },
+        }
+    )
+    assert len(posts) == 1
+    assert 'cats' in posts[0].body
+    assert 'dogs' not in posts[0].body
+
+    # Test: Search for posts that contain the phrase 'small and cute'
+    posts = await client.post.find_many(
+        where={
+            'body': {
+                'search': syntax.search_phrase,
+            },
+        }
+    )
+    assert len(posts) == 1
+    assert 'small and cute' in posts[0].body

--- a/databases/utils.py
+++ b/databases/utils.py
@@ -23,6 +23,7 @@ DatabaseFeature = Literal[
     'create_many_skip_duplicates',
     'transactions',
     'case_sensitivity',
+    'full_text_search',
 ]
 
 

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -332,6 +332,8 @@ post = await db.post.find_first(
 )
 ```
 
+Please visit Prisma's [documentation](https://www.prisma.io/docs/orm/prisma-client/queries/full-text-search) for more information on full-text search.
+
 #### Integer Fields
 
 ```py

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -301,6 +301,7 @@ post = await db.post.find_first(
 
 !!! warning
     Case insensitive filtering is only available on PostgreSQL and MongoDB
+    Full-text search is only available on PostgreSQL and MySQL
 
 ```py
 post = await db.post.find_first(
@@ -319,6 +320,7 @@ post = await db.post.find_first(
             'endswith': 'must end with string',
             'in': ['find_string_1', 'find_string_2'],
             'mode': 'insensitive',
+            'search': 'full-text query',
             'not': {
                 # recursive type
                 'contains': 'string must not be present',

--- a/src/prisma/generator/schema.py
+++ b/src/prisma/generator/schema.py
@@ -158,6 +158,26 @@ class Model(BaseModel):
             )
             for field in self.info.scalar_fields
         ]
+        # Full-text search relevance sorting
+        relevance_type = PrismaDict(
+            name=f'_{model}_RelevanceOrderByInput',
+            total=True,
+            fields={
+                '_relevance': f'_{model}_RelevanceInner',
+            },
+            subtypes=[
+                PrismaDict(
+                    name=f'_{model}_RelevanceInner',
+                    total=True,
+                    fields={
+                        'fields': f'List[{model}ScalarFieldKeys]',
+                        'search': 'str',
+                        'sort': 'SortOrder',
+                    },
+                )
+            ],
+        )
+        variants.append(relevance_type)
         return PrismaType.from_variants(variants, name=f'{model}OrderByInput')
 
 

--- a/src/prisma/generator/templates/types.py.jinja
+++ b/src/prisma/generator/templates/types.py.jinja
@@ -138,6 +138,9 @@ Serializable = Union[
         {%+ if active_provider in ['postgresql', 'cockroachdb', 'mongodb'] -%}
             'mode': SortMode,
         {% endif %}
+        {%+ if active_provider in ['postgresql', 'mysql'] -%}
+            'search': str,
+        {% endif %}
     },
     total=False,
 )

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[types.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[types.py].raw
@@ -1128,6 +1128,24 @@ _Post_author_id_OrderByInput = TypedDict(
     total=True
 )
 
+_Post_RelevanceInner = TypedDict(
+    '_Post_RelevanceInner',
+    {
+        'fields': 'List[PostScalarFieldKeys]',
+        'search': 'str',
+        'sort': 'SortOrder',
+    },
+    total=True
+)
+
+_Post_RelevanceOrderByInput = TypedDict(
+    '_Post_RelevanceOrderByInput',
+    {
+        '_relevance': '_Post_RelevanceInner',
+    },
+    total=True
+)
+
 PostOrderByInput = Union[
     '_Post_id_OrderByInput',
     '_Post_created_at_OrderByInput',
@@ -1135,6 +1153,7 @@ PostOrderByInput = Union[
     '_Post_content_OrderByInput',
     '_Post_published_OrderByInput',
     '_Post_author_id_OrderByInput',
+    '_Post_RelevanceOrderByInput',
 ]
 
 
@@ -2375,6 +2394,24 @@ _User_optional_boolean_OrderByInput = TypedDict(
     total=True
 )
 
+_User_RelevanceInner = TypedDict(
+    '_User_RelevanceInner',
+    {
+        'fields': 'List[UserScalarFieldKeys]',
+        'search': 'str',
+        'sort': 'SortOrder',
+    },
+    total=True
+)
+
+_User_RelevanceOrderByInput = TypedDict(
+    '_User_RelevanceOrderByInput',
+    {
+        '_relevance': '_User_RelevanceInner',
+    },
+    total=True
+)
+
 UserOrderByInput = Union[
     '_User_id_OrderByInput',
     '_User_email_OrderByInput',
@@ -2388,6 +2425,7 @@ UserOrderByInput = Union[
     '_User_optional_enum_OrderByInput',
     '_User_boolean_OrderByInput',
     '_User_optional_boolean_OrderByInput',
+    '_User_RelevanceOrderByInput',
 ]
 
 
@@ -3698,6 +3736,24 @@ _M_optional_boolean_OrderByInput = TypedDict(
     total=True
 )
 
+_M_RelevanceInner = TypedDict(
+    '_M_RelevanceInner',
+    {
+        'fields': 'List[MScalarFieldKeys]',
+        'search': 'str',
+        'sort': 'SortOrder',
+    },
+    total=True
+)
+
+_M_RelevanceOrderByInput = TypedDict(
+    '_M_RelevanceOrderByInput',
+    {
+        '_relevance': '_M_RelevanceInner',
+    },
+    total=True
+)
+
 MOrderByInput = Union[
     '_M_id_OrderByInput',
     '_M_int_OrderByInput',
@@ -3710,6 +3766,7 @@ MOrderByInput = Union[
     '_M_optional_enum_OrderByInput',
     '_M_boolean_OrderByInput',
     '_M_optional_boolean_OrderByInput',
+    '_M_RelevanceOrderByInput',
 ]
 
 
@@ -5030,6 +5087,24 @@ _N_optional_boolean_OrderByInput = TypedDict(
     total=True
 )
 
+_N_RelevanceInner = TypedDict(
+    '_N_RelevanceInner',
+    {
+        'fields': 'List[NScalarFieldKeys]',
+        'search': 'str',
+        'sort': 'SortOrder',
+    },
+    total=True
+)
+
+_N_RelevanceOrderByInput = TypedDict(
+    '_N_RelevanceOrderByInput',
+    {
+        '_relevance': '_N_RelevanceInner',
+    },
+    total=True
+)
+
 NOrderByInput = Union[
     '_N_id_OrderByInput',
     '_N_int_OrderByInput',
@@ -5044,6 +5119,7 @@ NOrderByInput = Union[
     '_N_optional_enum_OrderByInput',
     '_N_boolean_OrderByInput',
     '_N_optional_boolean_OrderByInput',
+    '_N_RelevanceOrderByInput',
 ]
 
 
@@ -6368,6 +6444,24 @@ _OneOptional_optional_boolean_OrderByInput = TypedDict(
     total=True
 )
 
+_OneOptional_RelevanceInner = TypedDict(
+    '_OneOptional_RelevanceInner',
+    {
+        'fields': 'List[OneOptionalScalarFieldKeys]',
+        'search': 'str',
+        'sort': 'SortOrder',
+    },
+    total=True
+)
+
+_OneOptional_RelevanceOrderByInput = TypedDict(
+    '_OneOptional_RelevanceOrderByInput',
+    {
+        '_relevance': '_OneOptional_RelevanceInner',
+    },
+    total=True
+)
+
 OneOptionalOrderByInput = Union[
     '_OneOptional_id_OrderByInput',
     '_OneOptional_int_OrderByInput',
@@ -6380,6 +6474,7 @@ OneOptionalOrderByInput = Union[
     '_OneOptional_optional_enum_OrderByInput',
     '_OneOptional_boolean_OrderByInput',
     '_OneOptional_optional_boolean_OrderByInput',
+    '_OneOptional_RelevanceOrderByInput',
 ]
 
 
@@ -7686,6 +7781,24 @@ _ManyRequired_optional_boolean_OrderByInput = TypedDict(
     total=True
 )
 
+_ManyRequired_RelevanceInner = TypedDict(
+    '_ManyRequired_RelevanceInner',
+    {
+        'fields': 'List[ManyRequiredScalarFieldKeys]',
+        'search': 'str',
+        'sort': 'SortOrder',
+    },
+    total=True
+)
+
+_ManyRequired_RelevanceOrderByInput = TypedDict(
+    '_ManyRequired_RelevanceOrderByInput',
+    {
+        '_relevance': '_ManyRequired_RelevanceInner',
+    },
+    total=True
+)
+
 ManyRequiredOrderByInput = Union[
     '_ManyRequired_id_OrderByInput',
     '_ManyRequired_one_optional_id_OrderByInput',
@@ -7699,6 +7812,7 @@ ManyRequiredOrderByInput = Union[
     '_ManyRequired_optional_enum_OrderByInput',
     '_ManyRequired_boolean_OrderByInput',
     '_ManyRequired_optional_boolean_OrderByInput',
+    '_ManyRequired_RelevanceOrderByInput',
 ]
 
 
@@ -8998,6 +9112,24 @@ _Lists_decimals_OrderByInput = TypedDict(
     total=True
 )
 
+_Lists_RelevanceInner = TypedDict(
+    '_Lists_RelevanceInner',
+    {
+        'fields': 'List[ListsScalarFieldKeys]',
+        'search': 'str',
+        'sort': 'SortOrder',
+    },
+    total=True
+)
+
+_Lists_RelevanceOrderByInput = TypedDict(
+    '_Lists_RelevanceOrderByInput',
+    {
+        '_relevance': '_Lists_RelevanceInner',
+    },
+    total=True
+)
+
 ListsOrderByInput = Union[
     '_Lists_id_OrderByInput',
     '_Lists_strings_OrderByInput',
@@ -9009,6 +9141,7 @@ ListsOrderByInput = Union[
     '_Lists_bigints_OrderByInput',
     '_Lists_json_objects_OrderByInput',
     '_Lists_decimals_OrderByInput',
+    '_Lists_RelevanceOrderByInput',
 ]
 
 
@@ -10273,6 +10406,24 @@ _A_enum_OrderByInput = TypedDict(
     total=True
 )
 
+_A_RelevanceInner = TypedDict(
+    '_A_RelevanceInner',
+    {
+        'fields': 'List[AScalarFieldKeys]',
+        'search': 'str',
+        'sort': 'SortOrder',
+    },
+    total=True
+)
+
+_A_RelevanceOrderByInput = TypedDict(
+    '_A_RelevanceOrderByInput',
+    {
+        '_relevance': '_A_RelevanceInner',
+    },
+    total=True
+)
+
 AOrderByInput = Union[
     '_A_email_OrderByInput',
     '_A_name_OrderByInput',
@@ -10283,6 +10434,7 @@ AOrderByInput = Union[
     '_A_bInt_OrderByInput',
     '_A_inc_bInt_OrderByInput',
     '_A_enum_OrderByInput',
+    '_A_RelevanceOrderByInput',
 ]
 
 
@@ -11493,12 +11645,31 @@ _B_numFloat_OrderByInput = TypedDict(
     total=True
 )
 
+_B_RelevanceInner = TypedDict(
+    '_B_RelevanceInner',
+    {
+        'fields': 'List[BScalarFieldKeys]',
+        'search': 'str',
+        'sort': 'SortOrder',
+    },
+    total=True
+)
+
+_B_RelevanceOrderByInput = TypedDict(
+    '_B_RelevanceOrderByInput',
+    {
+        '_relevance': '_B_RelevanceInner',
+    },
+    total=True
+)
+
 BOrderByInput = Union[
     '_B_id_OrderByInput',
     '_B_float_OrderByInput',
     '_B_d_float_OrderByInput',
     '_B_decFloat_OrderByInput',
     '_B_numFloat_OrderByInput',
+    '_B_RelevanceOrderByInput',
 ]
 
 
@@ -12642,6 +12813,24 @@ _C_uuid_OrderByInput = TypedDict(
     total=True
 )
 
+_C_RelevanceInner = TypedDict(
+    '_C_RelevanceInner',
+    {
+        'fields': 'List[CScalarFieldKeys]',
+        'search': 'str',
+        'sort': 'SortOrder',
+    },
+    total=True
+)
+
+_C_RelevanceOrderByInput = TypedDict(
+    '_C_RelevanceOrderByInput',
+    {
+        '_relevance': '_C_RelevanceInner',
+    },
+    total=True
+)
+
 COrderByInput = Union[
     '_C_char_OrderByInput',
     '_C_v_char_OrderByInput',
@@ -12649,6 +12838,7 @@ COrderByInput = Union[
     '_C_bit_OrderByInput',
     '_C_v_bit_OrderByInput',
     '_C_uuid_OrderByInput',
+    '_C_RelevanceOrderByInput',
 ]
 
 
@@ -13791,6 +13981,24 @@ _D_binary_OrderByInput = TypedDict(
     total=True
 )
 
+_D_RelevanceInner = TypedDict(
+    '_D_RelevanceInner',
+    {
+        'fields': 'List[DScalarFieldKeys]',
+        'search': 'str',
+        'sort': 'SortOrder',
+    },
+    total=True
+)
+
+_D_RelevanceOrderByInput = TypedDict(
+    '_D_RelevanceOrderByInput',
+    {
+        '_relevance': '_D_RelevanceInner',
+    },
+    total=True
+)
+
 DOrderByInput = Union[
     '_D_id_OrderByInput',
     '_D_bool_OrderByInput',
@@ -13798,6 +14006,7 @@ DOrderByInput = Union[
     '_D_json__OrderByInput',
     '_D_jsonb_OrderByInput',
     '_D_binary_OrderByInput',
+    '_D_RelevanceOrderByInput',
 ]
 
 
@@ -14916,11 +15125,30 @@ _E_ts_OrderByInput = TypedDict(
     total=True
 )
 
+_E_RelevanceInner = TypedDict(
+    '_E_RelevanceInner',
+    {
+        'fields': 'List[EScalarFieldKeys]',
+        'search': 'str',
+        'sort': 'SortOrder',
+    },
+    total=True
+)
+
+_E_RelevanceOrderByInput = TypedDict(
+    '_E_RelevanceOrderByInput',
+    {
+        '_relevance': '_E_RelevanceInner',
+    },
+    total=True
+)
+
 EOrderByInput = Union[
     '_E_id_OrderByInput',
     '_E_date_OrderByInput',
     '_E_time_OrderByInput',
     '_E_ts_OrderByInput',
+    '_E_RelevanceOrderByInput',
 ]
 
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[types.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[types.py].raw
@@ -95,6 +95,7 @@ StringFilter = TypedDict(
         'in': List[str],
         'not': Union[str, 'StringFilterRecursive1'],
         'mode': SortMode,
+        'search': str,
     },
     total=False,
 )
@@ -115,6 +116,7 @@ StringFilterRecursive1 = TypedDict(
         'in': List[str],
         'not': Union[str, 'StringFilterRecursive2'],
         'mode': SortMode,
+        'search': str,
     },
     total=False,
 )
@@ -134,6 +136,7 @@ StringFilterRecursive2 = TypedDict(
         'endswith': str,
         'in': List[str],
                 'mode': SortMode,
+        'search': str,
     },
     total=False,
 )

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[types.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[types.py].raw
@@ -1128,6 +1128,24 @@ _Post_author_id_OrderByInput = TypedDict(
     total=True
 )
 
+_Post_RelevanceInner = TypedDict(
+    '_Post_RelevanceInner',
+    {
+        'fields': 'List[PostScalarFieldKeys]',
+        'search': 'str',
+        'sort': 'SortOrder',
+    },
+    total=True
+)
+
+_Post_RelevanceOrderByInput = TypedDict(
+    '_Post_RelevanceOrderByInput',
+    {
+        '_relevance': '_Post_RelevanceInner',
+    },
+    total=True
+)
+
 PostOrderByInput = Union[
     '_Post_id_OrderByInput',
     '_Post_created_at_OrderByInput',
@@ -1135,6 +1153,7 @@ PostOrderByInput = Union[
     '_Post_content_OrderByInput',
     '_Post_published_OrderByInput',
     '_Post_author_id_OrderByInput',
+    '_Post_RelevanceOrderByInput',
 ]
 
 
@@ -2375,6 +2394,24 @@ _User_optional_boolean_OrderByInput = TypedDict(
     total=True
 )
 
+_User_RelevanceInner = TypedDict(
+    '_User_RelevanceInner',
+    {
+        'fields': 'List[UserScalarFieldKeys]',
+        'search': 'str',
+        'sort': 'SortOrder',
+    },
+    total=True
+)
+
+_User_RelevanceOrderByInput = TypedDict(
+    '_User_RelevanceOrderByInput',
+    {
+        '_relevance': '_User_RelevanceInner',
+    },
+    total=True
+)
+
 UserOrderByInput = Union[
     '_User_id_OrderByInput',
     '_User_email_OrderByInput',
@@ -2388,6 +2425,7 @@ UserOrderByInput = Union[
     '_User_optional_enum_OrderByInput',
     '_User_boolean_OrderByInput',
     '_User_optional_boolean_OrderByInput',
+    '_User_RelevanceOrderByInput',
 ]
 
 
@@ -3698,6 +3736,24 @@ _M_optional_boolean_OrderByInput = TypedDict(
     total=True
 )
 
+_M_RelevanceInner = TypedDict(
+    '_M_RelevanceInner',
+    {
+        'fields': 'List[MScalarFieldKeys]',
+        'search': 'str',
+        'sort': 'SortOrder',
+    },
+    total=True
+)
+
+_M_RelevanceOrderByInput = TypedDict(
+    '_M_RelevanceOrderByInput',
+    {
+        '_relevance': '_M_RelevanceInner',
+    },
+    total=True
+)
+
 MOrderByInput = Union[
     '_M_id_OrderByInput',
     '_M_int_OrderByInput',
@@ -3710,6 +3766,7 @@ MOrderByInput = Union[
     '_M_optional_enum_OrderByInput',
     '_M_boolean_OrderByInput',
     '_M_optional_boolean_OrderByInput',
+    '_M_RelevanceOrderByInput',
 ]
 
 
@@ -5030,6 +5087,24 @@ _N_optional_boolean_OrderByInput = TypedDict(
     total=True
 )
 
+_N_RelevanceInner = TypedDict(
+    '_N_RelevanceInner',
+    {
+        'fields': 'List[NScalarFieldKeys]',
+        'search': 'str',
+        'sort': 'SortOrder',
+    },
+    total=True
+)
+
+_N_RelevanceOrderByInput = TypedDict(
+    '_N_RelevanceOrderByInput',
+    {
+        '_relevance': '_N_RelevanceInner',
+    },
+    total=True
+)
+
 NOrderByInput = Union[
     '_N_id_OrderByInput',
     '_N_int_OrderByInput',
@@ -5044,6 +5119,7 @@ NOrderByInput = Union[
     '_N_optional_enum_OrderByInput',
     '_N_boolean_OrderByInput',
     '_N_optional_boolean_OrderByInput',
+    '_N_RelevanceOrderByInput',
 ]
 
 
@@ -6368,6 +6444,24 @@ _OneOptional_optional_boolean_OrderByInput = TypedDict(
     total=True
 )
 
+_OneOptional_RelevanceInner = TypedDict(
+    '_OneOptional_RelevanceInner',
+    {
+        'fields': 'List[OneOptionalScalarFieldKeys]',
+        'search': 'str',
+        'sort': 'SortOrder',
+    },
+    total=True
+)
+
+_OneOptional_RelevanceOrderByInput = TypedDict(
+    '_OneOptional_RelevanceOrderByInput',
+    {
+        '_relevance': '_OneOptional_RelevanceInner',
+    },
+    total=True
+)
+
 OneOptionalOrderByInput = Union[
     '_OneOptional_id_OrderByInput',
     '_OneOptional_int_OrderByInput',
@@ -6380,6 +6474,7 @@ OneOptionalOrderByInput = Union[
     '_OneOptional_optional_enum_OrderByInput',
     '_OneOptional_boolean_OrderByInput',
     '_OneOptional_optional_boolean_OrderByInput',
+    '_OneOptional_RelevanceOrderByInput',
 ]
 
 
@@ -7686,6 +7781,24 @@ _ManyRequired_optional_boolean_OrderByInput = TypedDict(
     total=True
 )
 
+_ManyRequired_RelevanceInner = TypedDict(
+    '_ManyRequired_RelevanceInner',
+    {
+        'fields': 'List[ManyRequiredScalarFieldKeys]',
+        'search': 'str',
+        'sort': 'SortOrder',
+    },
+    total=True
+)
+
+_ManyRequired_RelevanceOrderByInput = TypedDict(
+    '_ManyRequired_RelevanceOrderByInput',
+    {
+        '_relevance': '_ManyRequired_RelevanceInner',
+    },
+    total=True
+)
+
 ManyRequiredOrderByInput = Union[
     '_ManyRequired_id_OrderByInput',
     '_ManyRequired_one_optional_id_OrderByInput',
@@ -7699,6 +7812,7 @@ ManyRequiredOrderByInput = Union[
     '_ManyRequired_optional_enum_OrderByInput',
     '_ManyRequired_boolean_OrderByInput',
     '_ManyRequired_optional_boolean_OrderByInput',
+    '_ManyRequired_RelevanceOrderByInput',
 ]
 
 
@@ -8998,6 +9112,24 @@ _Lists_decimals_OrderByInput = TypedDict(
     total=True
 )
 
+_Lists_RelevanceInner = TypedDict(
+    '_Lists_RelevanceInner',
+    {
+        'fields': 'List[ListsScalarFieldKeys]',
+        'search': 'str',
+        'sort': 'SortOrder',
+    },
+    total=True
+)
+
+_Lists_RelevanceOrderByInput = TypedDict(
+    '_Lists_RelevanceOrderByInput',
+    {
+        '_relevance': '_Lists_RelevanceInner',
+    },
+    total=True
+)
+
 ListsOrderByInput = Union[
     '_Lists_id_OrderByInput',
     '_Lists_strings_OrderByInput',
@@ -9009,6 +9141,7 @@ ListsOrderByInput = Union[
     '_Lists_bigints_OrderByInput',
     '_Lists_json_objects_OrderByInput',
     '_Lists_decimals_OrderByInput',
+    '_Lists_RelevanceOrderByInput',
 ]
 
 
@@ -10273,6 +10406,24 @@ _A_enum_OrderByInput = TypedDict(
     total=True
 )
 
+_A_RelevanceInner = TypedDict(
+    '_A_RelevanceInner',
+    {
+        'fields': 'List[AScalarFieldKeys]',
+        'search': 'str',
+        'sort': 'SortOrder',
+    },
+    total=True
+)
+
+_A_RelevanceOrderByInput = TypedDict(
+    '_A_RelevanceOrderByInput',
+    {
+        '_relevance': '_A_RelevanceInner',
+    },
+    total=True
+)
+
 AOrderByInput = Union[
     '_A_email_OrderByInput',
     '_A_name_OrderByInput',
@@ -10283,6 +10434,7 @@ AOrderByInput = Union[
     '_A_bInt_OrderByInput',
     '_A_inc_bInt_OrderByInput',
     '_A_enum_OrderByInput',
+    '_A_RelevanceOrderByInput',
 ]
 
 
@@ -11493,12 +11645,31 @@ _B_numFloat_OrderByInput = TypedDict(
     total=True
 )
 
+_B_RelevanceInner = TypedDict(
+    '_B_RelevanceInner',
+    {
+        'fields': 'List[BScalarFieldKeys]',
+        'search': 'str',
+        'sort': 'SortOrder',
+    },
+    total=True
+)
+
+_B_RelevanceOrderByInput = TypedDict(
+    '_B_RelevanceOrderByInput',
+    {
+        '_relevance': '_B_RelevanceInner',
+    },
+    total=True
+)
+
 BOrderByInput = Union[
     '_B_id_OrderByInput',
     '_B_float_OrderByInput',
     '_B_d_float_OrderByInput',
     '_B_decFloat_OrderByInput',
     '_B_numFloat_OrderByInput',
+    '_B_RelevanceOrderByInput',
 ]
 
 
@@ -12642,6 +12813,24 @@ _C_uuid_OrderByInput = TypedDict(
     total=True
 )
 
+_C_RelevanceInner = TypedDict(
+    '_C_RelevanceInner',
+    {
+        'fields': 'List[CScalarFieldKeys]',
+        'search': 'str',
+        'sort': 'SortOrder',
+    },
+    total=True
+)
+
+_C_RelevanceOrderByInput = TypedDict(
+    '_C_RelevanceOrderByInput',
+    {
+        '_relevance': '_C_RelevanceInner',
+    },
+    total=True
+)
+
 COrderByInput = Union[
     '_C_char_OrderByInput',
     '_C_v_char_OrderByInput',
@@ -12649,6 +12838,7 @@ COrderByInput = Union[
     '_C_bit_OrderByInput',
     '_C_v_bit_OrderByInput',
     '_C_uuid_OrderByInput',
+    '_C_RelevanceOrderByInput',
 ]
 
 
@@ -13791,6 +13981,24 @@ _D_binary_OrderByInput = TypedDict(
     total=True
 )
 
+_D_RelevanceInner = TypedDict(
+    '_D_RelevanceInner',
+    {
+        'fields': 'List[DScalarFieldKeys]',
+        'search': 'str',
+        'sort': 'SortOrder',
+    },
+    total=True
+)
+
+_D_RelevanceOrderByInput = TypedDict(
+    '_D_RelevanceOrderByInput',
+    {
+        '_relevance': '_D_RelevanceInner',
+    },
+    total=True
+)
+
 DOrderByInput = Union[
     '_D_id_OrderByInput',
     '_D_bool_OrderByInput',
@@ -13798,6 +14006,7 @@ DOrderByInput = Union[
     '_D_json__OrderByInput',
     '_D_jsonb_OrderByInput',
     '_D_binary_OrderByInput',
+    '_D_RelevanceOrderByInput',
 ]
 
 
@@ -14916,11 +15125,30 @@ _E_ts_OrderByInput = TypedDict(
     total=True
 )
 
+_E_RelevanceInner = TypedDict(
+    '_E_RelevanceInner',
+    {
+        'fields': 'List[EScalarFieldKeys]',
+        'search': 'str',
+        'sort': 'SortOrder',
+    },
+    total=True
+)
+
+_E_RelevanceOrderByInput = TypedDict(
+    '_E_RelevanceOrderByInput',
+    {
+        '_relevance': '_E_RelevanceInner',
+    },
+    total=True
+)
+
 EOrderByInput = Union[
     '_E_id_OrderByInput',
     '_E_date_OrderByInput',
     '_E_time_OrderByInput',
     '_E_ts_OrderByInput',
+    '_E_RelevanceOrderByInput',
 ]
 
 

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[types.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[types.py].raw
@@ -95,6 +95,7 @@ StringFilter = TypedDict(
         'in': List[str],
         'not': Union[str, 'StringFilterRecursive1'],
         'mode': SortMode,
+        'search': str,
     },
     total=False,
 )
@@ -115,6 +116,7 @@ StringFilterRecursive1 = TypedDict(
         'in': List[str],
         'not': Union[str, 'StringFilterRecursive2'],
         'mode': SortMode,
+        'search': str,
     },
     total=False,
 )
@@ -134,6 +136,7 @@ StringFilterRecursive2 = TypedDict(
         'endswith': str,
         'in': List[str],
                 'mode': SortMode,
+        'search': str,
     },
     total=False,
 )


### PR DESCRIPTION
## Change Summary

* #52
* Supports full text search in where clause for postgresql and mysql
* Supports relevance ordering - which requires tracking `active_provider` in `Model` context

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass without significant drop in coverage
- [x] Documentation reflects changes where applicable
- [x] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
