### PR TITLE
fix(generator): write using utf-8

### DIFF
--- a/src/prisma/generator/generator.py
+++ b/src/prisma/generator/generator.py
@@ -238,7 +238,7 @@ class Generator(GenericGenerator[PythonData]):
         # package so we can use it to instantiate the query engine
         packaged_schema = rootdir / 'schema.prisma'
         if not is_same_path(data.schema_path, packaged_schema):
-            packaged_schema.write_text(data.datamodel)
+            packaged_schema.write_text(data.datamodel, encoding='utf-8')
 
         params = data.to_params()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,6 +40,22 @@ def test_no_file(testdir: Testdir) -> None:
     config = Config.load(path)
     assert isinstance(config.prisma_version, str)
 
+def test_with_file(testdir: Testdir) -> None:
+    """Can works config from pyproject.toml successfully"""
+    path = Path('pyproject.toml')
+    testdir.makefile(
+        '.toml',
+        pyproject=dedent(
+            """
+            [tool.prisma]
+            prisma_version = '~'
+            """
+        ),
+    )
+    
+    assert path.exists()
+    config = Config.load(path)
+    assert config.home_dir == '~'
 
 def test_loading(testdir: Testdir) -> None:
     """Config loading overrides defaults"""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,22 +40,6 @@ def test_no_file(testdir: Testdir) -> None:
     config = Config.load(path)
     assert isinstance(config.prisma_version, str)
 
-def test_with_file(testdir: Testdir) -> None:
-    """Can works config from pyproject.toml successfully"""
-    path = Path('pyproject.toml')
-    testdir.makefile(
-        '.toml',
-        pyproject=dedent(
-            """
-            [tool.prisma]
-            prisma_version = '~'
-            """
-        ),
-    )
-    
-    assert path.exists()
-    config = Config.load(path)
-    assert config.home_dir == '~'
 
 def test_loading(testdir: Testdir) -> None:
     """Config loading overrides defaults"""


### PR DESCRIPTION
## Change Summary
Changed to explicitly use utf-8 in `packaged_schema.write_text` to avoid `UnicodeEncodeError` that cp932 may cause in Japanese Windows environment.

Unit Test is currently under construction :)
## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
