### PR TITLE
feat(generator): initial support for typing of Composite Types

### DIFF
--- a/src/prisma/generator/templates/types.py.jinja
+++ b/src/prisma/generator/templates/types.py.jinja
@@ -440,6 +440,16 @@ class _{{ type }}ListUpdatePush(TypedDict):
 
 {% endfor %}
 
+{% for composite_type in dmmf.datamodel.types %}
+# {{ composite_type.name }} types
+
+class {{ composite_type.name }}(TypedDict, total=False):
+    {% for field in composite_type.fields %}
+    {{ field.name }}: {{ field.maybe_optional(field.create_input_type) }}
+    {% endfor %}
+{% endfor %}
+
+
 {% for model in dmmf.datamodel.models %}
 {% set model_schema = type_schema.get_model(model.name) %}
 # {{ model.name }} types

--- a/tests/test_generation/test_composite_type.py
+++ b/tests/test_generation/test_composite_type.py
@@ -1,0 +1,40 @@
+from textwrap import dedent
+
+from ..utils import Testdir
+
+
+def test_composite_type_not_supported(testdir: Testdir) -> None:
+    """Composite types are now supported"""
+    schema = (
+        testdir.default_generator
+        + """
+        datasource db {{
+            provider = "mongodb"
+            url      = env("foo")
+        }}
+
+        model User {{
+            id       String @id @map("_id")
+            prouuuut String
+            settings UserSettings
+        }}
+
+        type UserSettings {{
+            theme String
+        }}
+    """
+    )
+    testdir.generate(schema=schema)
+
+    client_types_path = testdir.path / "prisma" / "types.py"
+    client_types = client_types_path.read_text()
+
+    assert dedent("""
+        class UserSettings(TypedDict, total=False):
+            theme: _str
+    """).strip() in client_types
+
+    for line in client_types.splitlines():
+        line = line.strip()
+        if line.startswith("settings:"):
+            assert line == "settings: 'UserSettings'"

--- a/tests/test_generation/test_validation.py
+++ b/tests/test_generation/test_validation.py
@@ -225,31 +225,3 @@ def test_decimal_type_experimental(testdir: Testdir) -> None:
     output = str(exc.value.output, 'utf-8')
     assert 'Support for the Decimal type is experimental' in output
     assert 'set the `enable_experimental_decimal` config flag to true' in output
-
-
-def test_composite_type_not_supported(testdir: Testdir) -> None:
-    """Composite types are not supported yet"""
-    schema = (
-        testdir.default_generator
-        + """
-        datasource db {{
-            provider = "mongodb"
-            url      = env("foo")
-        }}
-
-        model User {{
-            id       String @id @map("_id")
-            // settings UserSettings
-        }}
-
-        type UserSettings {{
-            points Decimal
-        }}
-    """
-    )
-    with pytest.raises(subprocess.CalledProcessError) as exc:
-        testdir.generate(schema=schema)
-
-    output = str(exc.value.output, 'utf-8')
-    assert 'Composite types are not supported yet.' in output
-    assert 'https://github.com/RobertCraigie/prisma-client-py/issues/314' in output


### PR DESCRIPTION
## Change Summary

This is a draft PR that aims to bring support for [composite types](https://www.prisma.io/docs/orm/prisma-client/special-fields-and-types/composite-types) (#314).

As I don't know the project well, I am open to receive reviews and guidance on this.

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
