### PR TITLE
Fix platform check

### DIFF
--- a/src/prisma/binaries/platform.py
+++ b/src/prisma/binaries/platform.py
@@ -32,15 +32,12 @@ def linux_distro() -> str:
 
 
 def _get_linux_distro_details() -> Tuple[str, str]:
-    process = subprocess.run(['cat', '/etc/os-release'], stdout=subprocess.PIPE, check=True)
-    output = str(process.stdout, sys.getdefaultencoding())
-
-    match = re.search(r'ID="?([^"\n]*)"?', output)
-    distro_id = match.group(1) if match else ''
-
-    match = re.search(r'ID_LIKE="?([^"\n]*)"?', output)
-    distro_id_like = match.group(1) if match else ''
-    return distro_id, distro_id_like
+    if hasattr(platform, 'freedesktop_os_release'):
+        # For python >= 3.10
+        distro = platform.freedesktop_os_release()
+    else:
+        distro = platform.linux_distribution()
+    return distro.get('ID', ''), distro.get('ID_LIKE', '')
 
 
 @lru_cache(maxsize=None)


### PR DESCRIPTION
`cat /etc/os-release` is not always available, the prisma client broke when trying to deploy in an Ubuntu 22.04 VM. This uses the standard library's `platform` instead.

## Change Summary

Please summarise the changes this pull request is making here.

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [ ] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
