### PR TITLE
Add warning when running prisma with an outdated client

### DIFF
--- a/src/prisma/generator/models.py
+++ b/src/prisma/generator/models.py
@@ -32,7 +32,7 @@ import click
 import pydantic
 from pydantic.fields import PrivateAttr
 
-from .. import config
+from .. import config, __version__
 from .utils import Faker, Sampler, clean_multiline
 from ..utils import DEBUG_GENERATOR, assert_never
 from ..errors import UnsupportedListTypeError
@@ -354,6 +354,7 @@ class GenericData(GenericModel, Generic[ConfigT]):
         params = vars(self)
         params['type_schema'] = Schema.from_data(self)
         params['client_types'] = ClientTypes.from_data(self)
+        params['pkg_version'] = __version__
 
         # add utility functions
         for func in [

--- a/src/prisma/generator/templates/client.py.jinja
+++ b/src/prisma/generator/templates/client.py.jinja
@@ -11,18 +11,19 @@ from typing_extensions import override
 
 from pydantic import BaseModel
 
-from . import types, models, errors, actions
+from . import types, models, errors, actions, __version__
 from ._base_client import BasePrisma, UseClientDefault, USE_CLIENT_DEFAULT
 from .types import DatasourceOverride, HttpConfig, MetricsFormat
 from ._types import BaseModelT, PrismaMethod, TransactionId, Datasource
 from .bases import _PrismaModel
 from ._builder import QueryBuilder, dumps
 from .generator.models import EngineType, OptionalValueFromEnvVar, BinaryPaths
+from .generator.utils import is_outdated
 from ._compat import removeprefix, model_parse
 from ._constants import CREATE_MANY_SKIP_DUPLICATES_UNSUPPORTED, DEFAULT_CONNECT_TIMEOUT, DEFAULT_TX_MAX_WAIT, DEFAULT_TX_TIMEOUT
 from ._raw_query import deserialize_raw_results
 from ._metrics import Metrics
-from .metadata import PRISMA_MODELS, RELATIONAL_FIELD_MAPPINGS
+from .metadata import PRISMA_MODELS, PKG_VERSION, RELATIONAL_FIELD_MAPPINGS
 from ._transactions import AsyncTransactionManager, SyncTransactionManager
 
 # re-exports
@@ -77,6 +78,10 @@ class Prisma({% if is_async %}AsyncBasePrisma{% else %}SyncBasePrisma{% endif %}
         connect_timeout: int | timedelta = DEFAULT_CONNECT_TIMEOUT,
         http: HttpConfig | None = None,
     ) -> None:
+        if is_outdated(__version__, PKG_VERSION):
+            # https://github.com/RobertCraigie/prisma-client-py/issues/1008
+            warnings.warn("Generated client is outdated. You should regenerate it.", UserWarning)
+
         super().__init__(
             http=http,
             use_dotenv=use_dotenv,

--- a/src/prisma/generator/templates/metadata.py.jinja
+++ b/src/prisma/generator/templates/metadata.py.jinja
@@ -10,6 +10,8 @@ PRISMA_MODELS: set[str] = {
     {% endfor %}
 }
 
+PKG_VERSION: str = '{{ pkg_version }}'
+
 RELATIONAL_FIELD_MAPPINGS: dict[str, dict[str, str]] = {
     {% for model in dmmf.datamodel.models %}
     '{{ model.name }}': {

--- a/src/prisma/generator/utils.py
+++ b/src/prisma/generator/utils.py
@@ -168,3 +168,16 @@ def to_constant_case(input_str: str) -> str:
     fooBar -> FOO_BAR
     """
     return to_snake_case(input_str).upper()
+
+
+def is_outdated(latest_version: str, current_version: str) -> bool:
+    l_major, l_minor, l_patch = [int(x) for x in latest_version.split('.')]
+    c_major, c_minor, c_patch = [int(x) for x in current_version.split('.')]
+
+    if l_major != c_major:
+        return l_major > c_major
+
+    if l_minor != c_minor:
+        return l_minor > c_minor
+
+    return l_patch > c_patch

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -255,3 +255,15 @@ def test_is_registered(client: Prisma) -> None:
     with reset_client():
         assert not client.is_registered()
         assert not other_client.is_registered()
+
+
+def test_warn_if_generated_client_is_outdated(mocker: MockerFixture) -> None:
+    """Tests a warning if the generated client is outdated
+
+    https://github.com/RobertCraigie/prisma-client-py/issues/1008
+    """
+    mocker.patch('prisma.__version__', '0.15.1')
+    mocker.patch('prisma.metadata.PKG_VERSION', '0.15.0')
+
+    with pytest.warns(UserWarning, match='Generated client is outdated. You should regenerate it.'):
+        _ = Prisma()

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[client.py].raw
@@ -49,18 +49,19 @@ from typing_extensions import override
 
 from pydantic import BaseModel
 
-from . import types, models, errors, actions
+from . import types, models, errors, actions, __version__
 from ._base_client import BasePrisma, UseClientDefault, USE_CLIENT_DEFAULT
 from .types import DatasourceOverride, HttpConfig, MetricsFormat
 from ._types import BaseModelT, PrismaMethod, TransactionId, Datasource
 from .bases import _PrismaModel
 from ._builder import QueryBuilder, dumps
 from .generator.models import EngineType, OptionalValueFromEnvVar, BinaryPaths
+from .generator.utils import is_outdated
 from ._compat import removeprefix, model_parse
 from ._constants import CREATE_MANY_SKIP_DUPLICATES_UNSUPPORTED, DEFAULT_CONNECT_TIMEOUT, DEFAULT_TX_MAX_WAIT, DEFAULT_TX_TIMEOUT
 from ._raw_query import deserialize_raw_results
 from ._metrics import Metrics
-from .metadata import PRISMA_MODELS, RELATIONAL_FIELD_MAPPINGS
+from .metadata import PRISMA_MODELS, PKG_VERSION, RELATIONAL_FIELD_MAPPINGS
 from ._transactions import AsyncTransactionManager, SyncTransactionManager
 
 # re-exports
@@ -133,6 +134,10 @@ class Prisma(AsyncBasePrisma):
         connect_timeout: int | timedelta = DEFAULT_CONNECT_TIMEOUT,
         http: HttpConfig | None = None,
     ) -> None:
+        if is_outdated(__version__, PKG_VERSION):
+            # https://github.com/RobertCraigie/prisma-client-py/issues/1008
+            warnings.warn("Generated client is outdated. You should regenerate it.", UserWarning)
+
         super().__init__(
             http=http,
             use_dotenv=use_dotenv,

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[metadata.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_async[metadata.py].raw
@@ -21,6 +21,8 @@ PRISMA_MODELS: set[str] = {
     'E',
 }
 
+PKG_VERSION: str = '0.15.0'
+
 RELATIONAL_FIELD_MAPPINGS: dict[str, dict[str, str]] = {
     'Post': {
         'author': 'User',

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[client.py].raw
@@ -49,18 +49,19 @@ from typing_extensions import override
 
 from pydantic import BaseModel
 
-from . import types, models, errors, actions
+from . import types, models, errors, actions, __version__
 from ._base_client import BasePrisma, UseClientDefault, USE_CLIENT_DEFAULT
 from .types import DatasourceOverride, HttpConfig, MetricsFormat
 from ._types import BaseModelT, PrismaMethod, TransactionId, Datasource
 from .bases import _PrismaModel
 from ._builder import QueryBuilder, dumps
 from .generator.models import EngineType, OptionalValueFromEnvVar, BinaryPaths
+from .generator.utils import is_outdated
 from ._compat import removeprefix, model_parse
 from ._constants import CREATE_MANY_SKIP_DUPLICATES_UNSUPPORTED, DEFAULT_CONNECT_TIMEOUT, DEFAULT_TX_MAX_WAIT, DEFAULT_TX_TIMEOUT
 from ._raw_query import deserialize_raw_results
 from ._metrics import Metrics
-from .metadata import PRISMA_MODELS, RELATIONAL_FIELD_MAPPINGS
+from .metadata import PRISMA_MODELS, PKG_VERSION, RELATIONAL_FIELD_MAPPINGS
 from ._transactions import AsyncTransactionManager, SyncTransactionManager
 
 # re-exports
@@ -133,6 +134,10 @@ class Prisma(SyncBasePrisma):
         connect_timeout: int | timedelta = DEFAULT_CONNECT_TIMEOUT,
         http: HttpConfig | None = None,
     ) -> None:
+        if is_outdated(__version__, PKG_VERSION):
+            # https://github.com/RobertCraigie/prisma-client-py/issues/1008
+            warnings.warn("Generated client is outdated. You should regenerate it.", UserWarning)
+
         super().__init__(
             http=http,
             use_dotenv=use_dotenv,

--- a/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[metadata.py].raw
+++ b/tests/test_generation/exhaustive/__snapshots__/test_exhaustive/test_sync[metadata.py].raw
@@ -21,6 +21,8 @@ PRISMA_MODELS: set[str] = {
     'E',
 }
 
+PKG_VERSION: str = '0.15.0'
+
 RELATIONAL_FIELD_MAPPINGS: dict[str, dict[str, str]] = {
     'Post': {
         'author': 'User',

--- a/tests/test_generation/test_utils.py
+++ b/tests/test_generation/test_utils.py
@@ -2,6 +2,7 @@ import pytest
 
 from prisma.generator.utils import (
     copy_tree,
+    is_outdated,
     to_camel_case,
     to_snake_case,
     to_pascal_case,
@@ -86,3 +87,18 @@ def test_to_camel_case(input_str: str, expected: str) -> None:
 )
 def test_to_constant_case(input_str: str, expected: str) -> None:
     assert to_constant_case(input_str) == expected
+
+
+@pytest.mark.parametrize(
+    'latest_version,current_version,expected',
+    [
+        ('0.0.9', '1.0.0', False),
+        ('0.9.0', '1.0.0', False),
+        ('1.0.0', '1.0.0', False),
+        ('1.0.1', '1.0.0', True),
+        ('1.1.0', '1.0.0', True),
+        ('2.0.0', '1.0.0', True),
+    ],
+)
+def test_is_outdated(latest_version: str, current_version: str, expected: bool) -> None:
+    assert is_outdated(latest_version, current_version) == expected


### PR DESCRIPTION
## Change Summary

Related to https://github.com/RobertCraigie/prisma-client-py/issues/1008.

I added `PKG_VERSION` variable in `prisma.generator.templates.metadata.py.jinja` and warning message (**not error**) if `prisma.__version__` (latest client version) is greater than `PKG_VERSION` (generated client version).

The only concern is that when releasing, we'll have to update `test_sync[metadata.py].raw` and `test_async[metadata.py].raw`.

@RobertCraigie If you know a better solution, let me know.

## Checklist

- [x] Unit tests for the changes exist
- [ ] Tests pass without significant drop in coverage
- [ ] Documentation reflects changes where applicable
- [x] Test snapshots have been [updated](https://prisma-client-py.readthedocs.io/en/latest/contributing/contributing/#snapshot-tests) if applicable

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy and redistribute this contribution, under the terms of your choice.
